### PR TITLE
Revamp armory layout with nature-inspired UI

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -53,36 +53,28 @@ export class WeaponDisplayApp {
   buildLayout() {
     this.root.innerHTML = `
       <div class="app-shell">
-        <div class="hud-brand">Crtiz</div>
-        <nav class="hud-nav" aria-label="Weapon categories">
-          <h2>Arsenal</h2>
+        <nav class="category-panel" aria-label="Weapon categories">
+          <h1 class="app-title">Loadout</h1>
           <ul class="nav-tabs" data-component="nav-tabs"></ul>
         </nav>
+        <section class="panel arsenal-panel" data-component="weapon-list">
+          <div class="panel-header">
+            <h2>Arsenal</h2>
+            <span data-role="list-context"></span>
+          </div>
+          <div class="weapon-cards" data-role="weapon-cards"></div>
+        </section>
+        <section class="panel detail-panel" data-component="weapon-detail">
+          <div class="panel-header">
+            <h2>Details</h2>
+            <span data-role="rarity-badge"></span>
+          </div>
+          <div class="detail-content" data-role="detail-content">
+            <p class="description">Choose a weapon to view its details.</p>
+          </div>
+          <div class="panel-footer" data-role="detail-footer">No selection</div>
+        </section>
         <section class="stage" data-component="stage"></section>
-        <aside class="hud-info">
-          <section class="panel" data-component="weapon-list">
-            <div class="panel-header">
-              <span>Arsenal Roster</span>
-              <span data-role="list-context">Primary Wing</span>
-            </div>
-            <div class="weapon-cards" data-role="weapon-cards"></div>
-            <div class="panel-footer">No friendly mischief, only radiant firepower.</div>
-          </section>
-          <section class="panel" data-component="weapon-detail">
-            <div class="panel-header">
-              <span>Arcane Briefing</span>
-              <span data-role="rarity-badge"></span>
-            </div>
-            <div class="detail-content" data-role="detail-content">
-              <p class="description">Select an armament to reveal its spark.</p>
-            </div>
-            <div class="panel-footer" data-role="detail-footer">Awaiting attunement</div>
-          </section>
-        </aside>
-        <footer class="hud-footer">
-          <span>Arcane Carousel Online</span>
-          <span>Version 0.2.0 • Prototype HUD</span>
-        </footer>
       </div>
     `;
 

--- a/src/hud/HUDController.js
+++ b/src/hud/HUDController.js
@@ -90,7 +90,7 @@ export class HUDController {
     const weapons = this.weaponsByCategory[category] || [];
     const label = CATEGORY_LABELS[category] || this.prettify(category);
     if (this.listContextLabel) {
-      this.listContextLabel.textContent = `${label} Wing`;
+      this.listContextLabel.textContent = label;
     }
     this.navigationTabs.setActive(category);
     const defaultWeaponId = weapons[0]?.id ?? null;

--- a/src/hud/components/WeaponDetailPanel.js
+++ b/src/hud/components/WeaponDetailPanel.js
@@ -78,14 +78,14 @@ export class WeaponDetailPanel {
     `;
 
     if (this.footerElement) {
-      this.footerElement.textContent = `Manifest node: ${weapon.id}`;
+      this.footerElement.textContent = `ID: ${weapon.id}`;
     }
   }
 
   renderEmpty() {
     if (this.contentElement) {
       this.contentElement.innerHTML =
-        '<p class="description">Select an armament to reveal its statistics and lore.</p>';
+        '<p class="description">Choose a weapon to see its story and stats.</p>';
     }
 
     if (this.rarityBadge) {
@@ -94,7 +94,7 @@ export class WeaponDetailPanel {
     }
 
     if (this.footerElement) {
-      this.footerElement.textContent = 'Awaiting attunement';
+      this.footerElement.textContent = 'No selection';
     }
 
     this.panelElement.classList.add('is-empty');

--- a/src/hud/components/WeaponList.js
+++ b/src/hud/components/WeaponList.js
@@ -25,7 +25,7 @@ export class WeaponList {
     if (!this.weapons || this.weapons.length === 0) {
       const emptyState = document.createElement('p');
       emptyState.className = 'description';
-      emptyState.textContent = 'No weapons have been catalogued for this division yet.';
+      emptyState.textContent = 'No items are available in this category yet.';
       this.cardsContainer.appendChild(emptyState);
       return;
     }

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,18 +1,19 @@
 :root {
-  --color-bg: #0a0618;
-  --color-bg-alt: #1c1140;
-  --color-panel: rgba(36, 24, 66, 0.82);
-  --color-panel-border: rgba(255, 179, 240, 0.35);
-  --color-panel-highlight: rgba(140, 245, 255, 0.28);
-  --color-accent: #ffa9f9;
-  --color-accent-soft: rgba(255, 169, 249, 0.28);
-  --color-highlight: #8cf5ff;
-  --color-text-primary: #fff3ff;
-  --color-text-secondary: rgba(255, 236, 255, 0.76);
+  --color-bg: #0b1b13;
+  --color-bg-alt: #122a1f;
+  --color-surface: rgba(20, 46, 33, 0.92);
+  --color-surface-strong: rgba(16, 38, 27, 0.96);
+  --color-border: rgba(92, 142, 112, 0.55);
+  --color-border-strong: rgba(120, 170, 142, 0.75);
+  --color-accent: #5f9fb8;
+  --color-accent-soft: rgba(95, 159, 184, 0.28);
+  --color-highlight: #d6b179;
+  --color-text-primary: #f2f6f0;
+  --color-text-secondary: rgba(240, 248, 238, 0.78);
   --font-display: 'Lilita One', cursive;
   --font-body: 'Nunito', sans-serif;
-  --shadow-glow: 0 0 28px rgba(148, 104, 255, 0.45);
-  --border-radius-lg: 22px;
+  --shadow-soft: 0 20px 38px rgba(5, 22, 13, 0.42);
+  --border-radius-lg: 20px;
 }
 
 * {
@@ -26,15 +27,12 @@ body {
 
 body {
   margin: 0;
-  background: radial-gradient(circle at 15% 20%, rgba(255, 160, 248, 0.28), transparent 55%),
-    radial-gradient(circle at 85% 18%, rgba(124, 220, 255, 0.25), transparent 50%),
-    radial-gradient(circle at 50% 95%, rgba(111, 76, 255, 0.45), rgba(10, 6, 24, 0.88) 70%),
-    var(--color-bg);
+  background: linear-gradient(135deg, #07130d 0%, #123222 48%, #1f4964 100%);
   color: var(--color-text-primary);
   font-family: var(--font-body);
   letter-spacing: 0.01em;
-  overflow: hidden;
-  position: relative;
+  min-height: 100vh;
+  display: flex;
 }
 
 body::before,
@@ -43,108 +41,59 @@ body::after {
   position: fixed;
   inset: 0;
   pointer-events: none;
+  mix-blend-mode: screen;
 }
 
 body::before {
-  background: radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.35), transparent 40%),
-    radial-gradient(circle at 72% 12%, rgba(138, 255, 251, 0.3), transparent 48%),
-    radial-gradient(circle at 86% 66%, rgba(255, 184, 248, 0.28), transparent 52%);
-  mix-blend-mode: screen;
-  opacity: 0.45;
+  background: radial-gradient(circle at 18% 22%, rgba(133, 201, 157, 0.35), transparent 55%),
+    radial-gradient(circle at 70% 18%, rgba(95, 159, 184, 0.3), transparent 52%);
+  opacity: 0.35;
 }
 
 body::after {
-  background: radial-gradient(circle at 30% 80%, rgba(255, 230, 255, 0.14), transparent 55%),
-    linear-gradient(120deg, rgba(148, 104, 255, 0.12), transparent 60%),
-    linear-gradient(300deg, rgba(140, 245, 255, 0.15), transparent 65%);
-  opacity: 0.55;
+  background: radial-gradient(circle at 32% 80%, rgba(214, 177, 121, 0.2), transparent 60%),
+    linear-gradient(115deg, rgba(16, 68, 50, 0.35), transparent 65%);
+  opacity: 0.45;
 }
 
 #app {
-  height: 100%;
-  width: 100%;
+  flex: 1;
+  min-height: 100vh;
   display: flex;
-  justify-content: center;
-  align-items: stretch;
-  position: relative;
-  z-index: 1;
 }
 
 .app-shell {
-  height: 100%;
-  width: 100%;
+  flex: 1;
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr) 360px;
-  grid-template-rows: minmax(88px, auto) minmax(0, 1fr) minmax(64px, auto);
-  gap: 1.5rem;
-  padding: 1.75rem 2rem;
-  position: relative;
-  max-width: 1420px;
-  margin: 0 auto;
+  grid-template-columns: 200px 320px minmax(320px, 1fr) minmax(260px, 24vw);
+  grid-template-rows: minmax(0, 1fr);
+  gap: 1.75rem;
+  padding: 2.25rem 3rem;
+  align-items: stretch;
 }
 
 .app-shell > * {
   min-height: 0;
 }
 
-.hud-brand {
-  position: absolute;
-  top: 1.25rem;
-  left: 2rem;
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.28em;
-  font-family: var(--font-display);
-  font-size: 1.5rem;
-  color: var(--color-highlight);
-  text-shadow: 0 0 22px rgba(140, 245, 255, 0.6);
-}
-
-.hud-brand::before {
-  content: '';
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 2px solid var(--color-highlight);
-  box-shadow: inset 0 0 18px rgba(140, 245, 255, 0.35), 0 0 22px rgba(140, 245, 255, 0.4);
-}
-
-.hud-nav {
-  grid-column: 1;
-  grid-row: 2;
-  background: linear-gradient(160deg, rgba(44, 30, 84, 0.86), rgba(61, 41, 101, 0.72));
-  border: 1px solid var(--color-panel-border);
+.category-panel {
+  background: linear-gradient(180deg, rgba(21, 48, 33, 0.95), rgba(12, 30, 21, 0.92));
+  border: 1px solid var(--color-border);
   border-radius: var(--border-radius-lg);
-  padding: 1.35rem 1.25rem;
+  padding: 1.75rem 1.4rem;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
-  backdrop-filter: blur(14px);
-  box-shadow: var(--shadow-glow);
-  position: relative;
-  overflow: hidden;
-  min-height: 0;
+  gap: 1.5rem;
+  box-shadow: var(--shadow-soft);
 }
 
-.hud-nav::before {
-  content: '';
-  position: absolute;
-  inset: -20% -30%;
-  background: radial-gradient(circle at 30% 35%, var(--color-panel-highlight), transparent 55%);
-  opacity: 0.4;
-  pointer-events: none;
-}
-
-.hud-nav h2 {
+.app-title {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 1.05rem;
-  letter-spacing: 0.2em;
+  font-size: 1.6rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-highlight);
-  text-shadow: 0 0 12px rgba(140, 245, 255, 0.45);
 }
 
 .nav-tabs {
@@ -153,18 +102,22 @@ body::after {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.8rem;
+}
+
+.nav-tabs li {
+  margin: 0;
 }
 
 .nav-tabs button {
   width: 100%;
   padding: 0.85rem 1rem;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.05);
   color: var(--color-text-secondary);
-  font-size: 0.92rem;
-  letter-spacing: 0.08em;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   font-family: var(--font-display);
   transition: all 0.24s ease;
@@ -173,87 +126,40 @@ body::after {
 
 .nav-tabs button:hover,
 .nav-tabs button:focus-visible {
-  border-color: var(--color-panel-highlight);
+  border-color: var(--color-border-strong);
   color: var(--color-text-primary);
   background: var(--color-accent-soft);
-  box-shadow: 0 0 18px rgba(140, 245, 255, 0.25);
+  box-shadow: 0 0 18px rgba(95, 159, 184, 0.28);
   outline: none;
 }
 
 .nav-tabs button.active {
   border-color: var(--color-accent);
-  background: linear-gradient(135deg, rgba(255, 169, 249, 0.55), rgba(140, 245, 255, 0.25));
+  background: linear-gradient(135deg, rgba(95, 159, 184, 0.55), rgba(133, 201, 157, 0.3));
   color: var(--color-text-primary);
-  box-shadow: 0 0 22px rgba(255, 169, 249, 0.35);
-}
-
-.stage {
-  grid-column: 2;
-  grid-row: 1 / span 2;
-  position: relative;
-  background: linear-gradient(180deg, rgba(38, 26, 74, 0.92), rgba(19, 12, 39, 0.92));
-  border: 1px solid rgba(255, 179, 240, 0.32);
-  border-radius: calc(var(--border-radius-lg) + 2px);
-  overflow: hidden;
-  box-shadow: 0 0 32px rgba(120, 82, 255, 0.28);
-  min-height: 0;
-}
-
-.stage::before {
-  content: '';
-  position: absolute;
-  inset: -10% -15% 55%;
-  background: radial-gradient(circle at 45% 35%, rgba(140, 245, 255, 0.32), transparent 65%);
-  opacity: 0.65;
-  pointer-events: none;
-}
-
-.stage::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 50% 35%, rgba(255, 169, 249, 0.2), transparent 60%),
-    radial-gradient(circle at 50% 70%, rgba(140, 245, 255, 0.1), transparent 65%);
-  pointer-events: none;
-}
-
-.stage canvas {
-  width: 100%;
-  height: 100%;
-  display: block;
-}
-
-.hud-info {
-  grid-column: 3;
-  grid-row: 1 / span 2;
-  display: grid;
-  grid-template-rows: repeat(2, minmax(0, 1fr));
-  gap: 1.1rem;
-  min-height: 0;
+  box-shadow: 0 0 22px rgba(95, 159, 184, 0.35);
 }
 
 .panel {
-  background: linear-gradient(165deg, rgba(43, 27, 81, 0.92), rgba(29, 20, 56, 0.88));
-  border: 1px solid rgba(255, 179, 240, 0.32);
+  background: linear-gradient(180deg, var(--color-surface), var(--color-surface-strong));
+  border: 1px solid var(--color-border);
   border-radius: var(--border-radius-lg);
-  padding: 1.35rem 1.6rem;
+  padding: 1.75rem 1.6rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  backdrop-filter: blur(16px);
-  box-shadow: 0 0 28px rgba(120, 82, 255, 0.22);
-  position: relative;
+  gap: 1.1rem;
+  box-shadow: var(--shadow-soft);
   overflow: hidden;
-  min-height: 0;
+  position: relative;
 }
 
 .panel::before {
   content: '';
   position: absolute;
-  inset: -15% -25% 65% -25%;
-  background: radial-gradient(circle at 30% 20%, rgba(255, 169, 249, 0.28), transparent 60%);
-  opacity: 0.6;
+  inset: -20% -30% 60% -30%;
+  background: radial-gradient(circle at 30% 25%, rgba(95, 159, 184, 0.2), transparent 65%);
   pointer-events: none;
+  opacity: 0.6;
 }
 
 .panel > * {
@@ -261,37 +167,33 @@ body::after {
   z-index: 1;
 }
 
-.panel::after {
-  content: '';
-  position: absolute;
-  inset: 55% -35% -20% -20%;
-  background: radial-gradient(circle at 70% 80%, rgba(140, 245, 255, 0.18), transparent 55%);
-  opacity: 0.4;
-  pointer-events: none;
-}
-
 .panel-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   font-family: var(--font-display);
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--color-highlight);
-  text-shadow: 0 0 12px rgba(140, 245, 255, 0.35);
+}
+
+.panel-header h2 {
+  margin: 0;
+  font: inherit;
+  color: var(--color-highlight);
 }
 
 .panel-header [data-role='list-context'] {
   font-size: 0.78rem;
-  letter-spacing: 0.14em;
-  color: rgba(255, 236, 255, 0.78);
+  letter-spacing: 0.16em;
+  color: var(--color-text-secondary);
 }
 
 .weapon-cards {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.95rem;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -299,9 +201,9 @@ body::after {
 }
 
 .weapon-card {
-  border: 1px solid rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 16px;
-  padding: 0.85rem 1.1rem;
+  padding: 0.95rem 1.1rem;
   background: rgba(255, 255, 255, 0.04);
   cursor: pointer;
   transition: all 0.2s ease;
@@ -309,19 +211,19 @@ body::after {
 
 .weapon-card:hover,
 .weapon-card:focus-visible {
-  border-color: var(--color-panel-highlight);
+  border-color: var(--color-border-strong);
   outline: none;
-  box-shadow: 0 0 16px rgba(140, 245, 255, 0.24);
+  box-shadow: 0 0 16px rgba(95, 159, 184, 0.24);
 }
 
 .weapon-card.active {
   border-color: var(--color-accent);
-  background: linear-gradient(135deg, rgba(255, 169, 249, 0.38), rgba(140, 245, 255, 0.18));
-  box-shadow: 0 0 20px rgba(255, 169, 249, 0.32);
+  background: linear-gradient(135deg, rgba(95, 159, 184, 0.35), rgba(133, 201, 157, 0.24));
+  box-shadow: 0 0 20px rgba(95, 159, 184, 0.3);
 }
 
 .weapon-card h3 {
-  margin: 0 0 0.35rem;
+  margin: 0 0 0.4rem;
   font-size: 1.1rem;
   color: var(--color-text-primary);
   font-family: var(--font-display);
@@ -331,7 +233,7 @@ body::after {
   margin: 0;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.25rem 0.55rem;
+  gap: 0.3rem 0.6rem;
   font-size: 0.78rem;
   color: var(--color-text-secondary);
 }
@@ -344,16 +246,88 @@ dl dt {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.2rem;
   min-height: 0;
   overflow-y: auto;
   padding-right: 0.4rem;
 }
 
+.detail-content h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-family: var(--font-display);
+  letter-spacing: 0.16em;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem 1.1rem;
+  font-size: 0.9rem;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stat-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(240, 248, 238, 0.7);
+}
+
+.stat-value {
+  font-size: 1.05rem;
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.description {
+  font-size: 0.92rem;
+  line-height: 1.68;
+  color: var(--color-text-secondary);
+}
+
+.panel-footer {
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(240, 248, 238, 0.62);
+}
+
+.stage {
+  background: linear-gradient(200deg, rgba(31, 73, 100, 0.92), rgba(12, 30, 22, 0.88));
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  position: relative;
+  box-shadow: var(--shadow-soft);
+  min-height: 0;
+}
+
+.stage::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 35% 35%, rgba(133, 201, 157, 0.22), transparent 60%),
+    radial-gradient(circle at 65% 65%, rgba(95, 159, 184, 0.18), transparent 65%);
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.stage canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .weapon-cards,
 .detail-content {
   scrollbar-width: thin;
-  scrollbar-color: rgba(255, 169, 249, 0.6) transparent;
+  scrollbar-color: rgba(95, 159, 184, 0.6) transparent;
 }
 
 .weapon-cards::-webkit-scrollbar,
@@ -368,186 +342,65 @@ dl dt {
 
 .weapon-cards::-webkit-scrollbar-thumb,
 .detail-content::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(255, 169, 249, 0.75), rgba(140, 245, 255, 0.65));
+  background: linear-gradient(180deg, rgba(95, 159, 184, 0.75), rgba(133, 201, 157, 0.65));
   border-radius: 6px;
-}
-
-.detail-content h3 {
-  margin: 0;
-  font-size: 1.35rem;
-  font-family: var(--font-display);
-  letter-spacing: 0.18em;
-}
-
-.stat-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem 1.1rem;
-  font-size: 0.88rem;
-}
-
-.stat-grid .stat {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.stat-label {
-  font-size: 0.72rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(255, 236, 255, 0.75);
-}
-
-.stat-value {
-  font-size: 1.05rem;
-  color: var(--color-text-primary);
-  font-weight: 600;
-}
-
-.description {
-  font-size: 0.9rem;
-  line-height: 1.65;
-  color: var(--color-text-secondary);
-}
-
-.panel-footer {
-  font-size: 0.78rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(255, 236, 255, 0.62);
-}
-
-.hud-footer {
-  grid-column: 1 / -1;
-  grid-row: 3;
-  border-top: 1px solid rgba(255, 179, 240, 0.24);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 2rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(255, 236, 255, 0.55);
-  font-size: 0.78rem;
-}
-
-@media (max-width: 1200px) {
-  body {
-    overflow: auto;
-  }
-
-  .app-shell {
-    grid-template-columns: 180px minmax(0, 1fr);
-    grid-template-rows: minmax(88px, auto) minmax(0, 1fr) auto minmax(64px, auto);
-    padding: 1.5rem;
-  }
-
-  .hud-info {
-    grid-column: 1 / -1;
-    grid-row: 3;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    grid-template-rows: minmax(0, 1fr);
-  }
-}
-
-@media (max-width: 900px) {
-  .app-shell {
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(88px, auto) auto auto auto;
-    padding: 1.5rem;
-  }
-
-  .hud-nav {
-    grid-column: 1;
-    grid-row: 2;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .nav-tabs {
-    flex-direction: row;
-  }
-
-  .nav-tabs button {
-    font-size: 0.75rem;
-    padding: 0.75rem;
-  }
-
-  .stage {
-    grid-column: 1;
-    grid-row: 3;
-    height: 360px;
-  }
-
-  .hud-info {
-    grid-column: 1;
-    grid-row: 4;
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(0, 1fr);
-  }
-
-  .hud-footer {
-    display: none;
-  }
 }
 
 .rarity-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.35rem 0.9rem;
+  padding: 0.4rem 0.95rem;
   border-radius: 999px;
   border: 1px solid var(--color-highlight);
   font-size: 0.72rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--color-highlight);
-  background: rgba(140, 245, 255, 0.18);
+  background: rgba(214, 177, 121, 0.18);
   min-width: 128px;
   text-align: center;
 }
 
 .rarity-badge.rarity-common {
-  border-color: rgba(206, 206, 255, 0.5);
-  color: rgba(238, 238, 255, 0.85);
-  background: rgba(206, 206, 255, 0.18);
+  border-color: rgba(206, 216, 200, 0.45);
+  color: rgba(233, 243, 229, 0.9);
+  background: rgba(206, 216, 200, 0.18);
 }
 
 .rarity-badge.rarity-uncommon {
-  border-color: rgba(173, 255, 214, 0.55);
-  color: rgba(214, 255, 236, 0.95);
-  background: rgba(173, 255, 214, 0.2);
+  border-color: rgba(133, 201, 157, 0.55);
+  color: rgba(197, 238, 212, 0.95);
+  background: rgba(133, 201, 157, 0.2);
 }
 
 .rarity-badge.rarity-rare {
-  border-color: rgba(140, 245, 255, 0.75);
-  color: rgba(204, 255, 255, 0.98);
-  background: rgba(140, 245, 255, 0.22);
+  border-color: rgba(95, 159, 184, 0.75);
+  color: rgba(203, 236, 248, 0.98);
+  background: rgba(95, 159, 184, 0.22);
 }
 
 .rarity-badge.rarity-epic {
-  border-color: rgba(255, 169, 249, 0.75);
-  color: rgba(255, 214, 252, 0.98);
-  background: rgba(255, 169, 249, 0.24);
+  border-color: rgba(129, 168, 200, 0.75);
+  color: rgba(218, 236, 245, 0.98);
+  background: rgba(129, 168, 200, 0.24);
 }
 
 .rarity-badge.rarity-legendary {
-  border-color: rgba(255, 210, 150, 0.85);
-  color: rgba(255, 239, 197, 0.98);
-  background: rgba(255, 210, 150, 0.26);
+  border-color: rgba(214, 177, 121, 0.85);
+  color: rgba(248, 232, 205, 0.98);
+  background: rgba(214, 177, 121, 0.26);
 }
 
 .rarity-badge.rarity-mythic {
-  border-color: rgba(255, 184, 255, 0.9);
-  color: rgba(255, 230, 255, 1);
-  background: rgba(255, 184, 255, 0.28);
+  border-color: rgba(184, 214, 166, 0.9);
+  color: rgba(235, 246, 226, 1);
+  background: rgba(184, 214, 166, 0.28);
 }
 
 .special-section {
-  border-top: 1px solid rgba(255, 179, 240, 0.24);
-  padding-top: 0.75rem;
+  border-top: 1px solid rgba(92, 142, 112, 0.35);
+  padding-top: 0.85rem;
 }
 
 .special-section h4 {
@@ -562,8 +415,8 @@ dl dt {
   margin: 0;
   padding-left: 1rem;
   list-style: square;
-  font-size: 0.88rem;
-  color: rgba(255, 236, 255, 0.82);
+  font-size: 0.9rem;
+  color: rgba(240, 248, 238, 0.82);
   line-height: 1.65;
 }
 
@@ -574,4 +427,55 @@ dl dt {
 .special-key {
   color: var(--color-text-primary);
   font-weight: 600;
+}
+
+@media (max-width: 1400px) {
+  .app-shell {
+    grid-template-columns: 180px 280px minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr) minmax(280px, 32vh);
+    padding: 2rem;
+  }
+
+  .stage {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+}
+
+@media (max-width: 960px) {
+  body {
+    display: block;
+  }
+
+  #app {
+    display: block;
+  }
+
+  .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto auto;
+    padding: 1.75rem 1.25rem 2.5rem;
+    gap: 1.5rem;
+  }
+
+  .category-panel {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .nav-tabs {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+  }
+
+  .nav-tabs button {
+    font-size: 0.78rem;
+    padding: 0.7rem 0.85rem;
+  }
+
+  .stage {
+    height: 320px;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the app layout to dedicate the left rail to categories, the center to arsenal and details, and move the 3D stage to a compact right-side column
- refresh HUD copy to keep labels minimal while keeping contextual updates for category, detail, and empty states consistent
- overhaul the styling with a forest green, earth brown, and natural blue palette plus responsive grid behavior for smaller screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8dfa715908329b04c1839ef167f7e