### PR TITLE
Revamp armory UI with nature themed layout

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -31,6 +31,7 @@ export class WeaponDisplayApp {
       listPanel: layout.weaponListPanel,
       detailPanel: layout.weaponDetailPanel,
       listContextLabel: layout.listContextLabel,
+      listFooter: layout.listFooter,
       rarityBadge: layout.rarityBadge,
       detailFooter: layout.detailFooter,
     });
@@ -53,36 +54,30 @@ export class WeaponDisplayApp {
   buildLayout() {
     this.root.innerHTML = `
       <div class="app-shell">
-        <div class="hud-brand">Crtiz</div>
+        <div class="hud-brand">Crtiz Armory</div>
         <nav class="hud-nav" aria-label="Weapon categories">
-          <h2>Arsenal</h2>
+          <h2>Categories</h2>
           <ul class="nav-tabs" data-component="nav-tabs"></ul>
         </nav>
+        <section class="panel hud-panel hud-list" data-component="weapon-list">
+          <div class="panel-header">
+            <span>Arsenal</span>
+            <span data-role="list-context"></span>
+          </div>
+          <div class="weapon-cards" data-role="weapon-cards"></div>
+          <div class="panel-footer" data-role="list-footer">Choose a category to see its gear.</div>
+        </section>
+        <section class="panel hud-panel hud-detail" data-component="weapon-detail">
+          <div class="panel-header">
+            <span>Equipment Info</span>
+            <span data-role="rarity-badge"></span>
+          </div>
+          <div class="detail-content" data-role="detail-content">
+            <p class="description">Pick a tool to see its details.</p>
+          </div>
+          <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
+        </section>
         <section class="stage" data-component="stage"></section>
-        <aside class="hud-info">
-          <section class="panel" data-component="weapon-list">
-            <div class="panel-header">
-              <span>Arsenal Roster</span>
-              <span data-role="list-context">Primary Wing</span>
-            </div>
-            <div class="weapon-cards" data-role="weapon-cards"></div>
-            <div class="panel-footer">No friendly mischief, only radiant firepower.</div>
-          </section>
-          <section class="panel" data-component="weapon-detail">
-            <div class="panel-header">
-              <span>Arcane Briefing</span>
-              <span data-role="rarity-badge"></span>
-            </div>
-            <div class="detail-content" data-role="detail-content">
-              <p class="description">Select an armament to reveal its spark.</p>
-            </div>
-            <div class="panel-footer" data-role="detail-footer">Awaiting attunement</div>
-          </section>
-        </aside>
-        <footer class="hud-footer">
-          <span>Arcane Carousel Online</span>
-          <span>Version 0.2.0 • Prototype HUD</span>
-        </footer>
       </div>
     `;
 
@@ -92,6 +87,7 @@ export class WeaponDisplayApp {
       weaponListPanel: this.root.querySelector('[data-component="weapon-list"]'),
       weaponDetailPanel: this.root.querySelector('[data-component="weapon-detail"]'),
       listContextLabel: this.root.querySelector('[data-role="list-context"]'),
+      listFooter: this.root.querySelector('[data-role="list-footer"]'),
       rarityBadge: this.root.querySelector('[data-role="rarity-badge"]'),
       detailFooter: this.root.querySelector('[data-role="detail-footer"]'),
     };

--- a/src/hud/HUDController.js
+++ b/src/hud/HUDController.js
@@ -17,6 +17,7 @@ export class HUDController {
     listPanel,
     detailPanel,
     listContextLabel,
+    listFooter,
     rarityBadge,
     detailFooter,
   }) {
@@ -25,6 +26,7 @@ export class HUDController {
     this.listPanel = listPanel;
     this.detailPanelElement = detailPanel;
     this.listContextLabel = listContextLabel;
+    this.listFooter = listFooter;
 
     this.navigationTabs = null;
     this.weaponList = null;
@@ -58,6 +60,7 @@ export class HUDController {
 
     this.weaponList = new WeaponList({
       panelElement: this.listPanel,
+      footerElement: this.listFooter,
       onSelect: (weaponId) => this.handleWeaponSelection(weaponId),
     });
 
@@ -90,7 +93,7 @@ export class HUDController {
     const weapons = this.weaponsByCategory[category] || [];
     const label = CATEGORY_LABELS[category] || this.prettify(category);
     if (this.listContextLabel) {
-      this.listContextLabel.textContent = `${label} Wing`;
+      this.listContextLabel.textContent = label;
     }
     this.navigationTabs.setActive(category);
     const defaultWeaponId = weapons[0]?.id ?? null;

--- a/src/hud/components/WeaponDetailPanel.js
+++ b/src/hud/components/WeaponDetailPanel.js
@@ -78,14 +78,14 @@ export class WeaponDetailPanel {
     `;
 
     if (this.footerElement) {
-      this.footerElement.textContent = `Manifest node: ${weapon.id}`;
+      this.footerElement.textContent = `Catalog ID: ${weapon.id}`;
     }
   }
 
   renderEmpty() {
     if (this.contentElement) {
       this.contentElement.innerHTML =
-        '<p class="description">Select an armament to reveal its statistics and lore.</p>';
+        '<p class="description">Pick a tool to see its story and statistics.</p>';
     }
 
     if (this.rarityBadge) {
@@ -94,7 +94,7 @@ export class WeaponDetailPanel {
     }
 
     if (this.footerElement) {
-      this.footerElement.textContent = 'Awaiting attunement';
+      this.footerElement.textContent = 'Awaiting selection';
     }
 
     this.panelElement.classList.add('is-empty');

--- a/src/hud/components/WeaponList.js
+++ b/src/hud/components/WeaponList.js
@@ -1,9 +1,10 @@
 import { deriveStatsList } from '../../data/weaponSchema.js';
 
 export class WeaponList {
-  constructor({ panelElement, onSelect }) {
+  constructor({ panelElement, footerElement, onSelect }) {
     this.panelElement = panelElement;
     this.cardsContainer = panelElement.querySelector('[data-role="weapon-cards"]');
+    this.footerElement = footerElement;
     this.onSelect = onSelect;
     this.cards = new Map();
     this.weapons = [];
@@ -13,6 +14,7 @@ export class WeaponList {
   setWeapons(weapons, defaultWeaponId = null) {
     this.weapons = weapons;
     this.render();
+    this.updateFooter();
     if (defaultWeaponId) {
       this.setActiveWeapon(defaultWeaponId);
     }
@@ -25,7 +27,7 @@ export class WeaponList {
     if (!this.weapons || this.weapons.length === 0) {
       const emptyState = document.createElement('p');
       emptyState.className = 'description';
-      emptyState.textContent = 'No weapons have been catalogued for this division yet.';
+      emptyState.textContent = 'Nothing is available in this category yet.';
       this.cardsContainer.appendChild(emptyState);
       return;
     }
@@ -35,6 +37,17 @@ export class WeaponList {
       this.cardsContainer.appendChild(card);
       this.cards.set(weapon.id, card);
     });
+  }
+
+  updateFooter() {
+    if (!this.footerElement) return;
+    const count = this.weapons?.length ?? 0;
+    if (count === 0) {
+      this.footerElement.textContent = 'No gear catalogued yet.';
+      return;
+    }
+    const label = count === 1 ? 'choice' : 'choices';
+    this.footerElement.textContent = `${count} ${label} available`;
   }
 
   createCard(weapon) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,18 +1,21 @@
 :root {
-  --color-bg: #0a0618;
-  --color-bg-alt: #1c1140;
-  --color-panel: rgba(36, 24, 66, 0.82);
-  --color-panel-border: rgba(255, 179, 240, 0.35);
-  --color-panel-highlight: rgba(140, 245, 255, 0.28);
-  --color-accent: #ffa9f9;
-  --color-accent-soft: rgba(255, 169, 249, 0.28);
-  --color-highlight: #8cf5ff;
-  --color-text-primary: #fff3ff;
-  --color-text-secondary: rgba(255, 236, 255, 0.76);
+  --color-bg: #0f1f17;
+  --color-bg-alt: #142e20;
+  --color-canopy: #1f3d2c;
+  --color-panel: rgba(26, 58, 41, 0.9);
+  --color-panel-border: rgba(169, 213, 179, 0.38);
+  --color-panel-highlight: rgba(116, 182, 139, 0.4);
+  --color-accent: #7cc86f;
+  --color-accent-soft: rgba(124, 200, 111, 0.2);
+  --color-earth: #b78044;
+  --color-water: #5aa9c9;
+  --color-highlight: #d3f36b;
+  --color-text-primary: #f3f8f0;
+  --color-text-secondary: rgba(243, 248, 240, 0.82);
   --font-display: 'Lilita One', cursive;
   --font-body: 'Nunito', sans-serif;
-  --shadow-glow: 0 0 28px rgba(148, 104, 255, 0.45);
-  --border-radius-lg: 22px;
+  --shadow-soft: 0 24px 60px rgba(8, 22, 16, 0.55);
+  --border-radius-lg: 20px;
 }
 
 * {
@@ -26,13 +29,10 @@ body {
 
 body {
   margin: 0;
-  background: radial-gradient(circle at 15% 20%, rgba(255, 160, 248, 0.28), transparent 55%),
-    radial-gradient(circle at 85% 18%, rgba(124, 220, 255, 0.25), transparent 50%),
-    radial-gradient(circle at 50% 95%, rgba(111, 76, 255, 0.45), rgba(10, 6, 24, 0.88) 70%),
-    var(--color-bg);
-  color: var(--color-text-primary);
   font-family: var(--font-body);
   letter-spacing: 0.01em;
+  color: var(--color-text-primary);
+  background: linear-gradient(135deg, #0d1f17 0%, #143524 55%, #102330 100%);
   overflow: hidden;
   position: relative;
 }
@@ -46,17 +46,17 @@ body::after {
 }
 
 body::before {
-  background: radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.35), transparent 40%),
-    radial-gradient(circle at 72% 12%, rgba(138, 255, 251, 0.3), transparent 48%),
-    radial-gradient(circle at 86% 66%, rgba(255, 184, 248, 0.28), transparent 52%);
+  background: radial-gradient(circle at 18% 26%, rgba(124, 200, 111, 0.16), transparent 55%),
+    radial-gradient(circle at 78% 18%, rgba(90, 169, 201, 0.18), transparent 60%),
+    radial-gradient(circle at 48% 78%, rgba(179, 128, 68, 0.12), transparent 62%);
   mix-blend-mode: screen;
-  opacity: 0.45;
+  opacity: 0.6;
 }
 
 body::after {
-  background: radial-gradient(circle at 30% 80%, rgba(255, 230, 255, 0.14), transparent 55%),
-    linear-gradient(120deg, rgba(148, 104, 255, 0.12), transparent 60%),
-    linear-gradient(300deg, rgba(140, 245, 255, 0.15), transparent 65%);
+  background: radial-gradient(circle at 14% 82%, rgba(16, 63, 42, 0.35), transparent 70%),
+    linear-gradient(120deg, rgba(12, 42, 31, 0.35), transparent 65%),
+    linear-gradient(300deg, rgba(21, 52, 67, 0.3), transparent 55%);
   opacity: 0.55;
 }
 
@@ -64,23 +64,21 @@ body::after {
   height: 100%;
   width: 100%;
   display: flex;
-  justify-content: center;
   align-items: stretch;
   position: relative;
   z-index: 1;
 }
 
 .app-shell {
-  height: 100%;
   width: 100%;
+  height: 100%;
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr) 360px;
-  grid-template-rows: minmax(88px, auto) minmax(0, 1fr) minmax(64px, auto);
+  grid-template-columns: 180px 320px minmax(320px, 1fr) minmax(240px, 28vw);
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 1.5rem;
-  padding: 1.75rem 2rem;
+  padding: 2.25rem 2.75rem;
   position: relative;
-  max-width: 1420px;
-  margin: 0 auto;
+  align-items: stretch;
 }
 
 .app-shell > * {
@@ -88,63 +86,60 @@ body::after {
 }
 
 .hud-brand {
-  position: absolute;
-  top: 1.25rem;
-  left: 2rem;
+  grid-column: 1 / span 3;
+  grid-row: 1;
+  align-self: end;
   display: flex;
   align-items: center;
-  gap: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.28em;
+  gap: 0.85rem;
   font-family: var(--font-display);
-  font-size: 1.5rem;
+  font-size: 1.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
   color: var(--color-highlight);
-  text-shadow: 0 0 22px rgba(140, 245, 255, 0.6);
+  text-shadow: 0 0 18px rgba(124, 200, 111, 0.45);
 }
 
 .hud-brand::before {
   content: '';
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  border: 2px solid var(--color-highlight);
-  box-shadow: inset 0 0 18px rgba(140, 245, 255, 0.35), 0 0 22px rgba(140, 245, 255, 0.4);
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  border: 2px solid rgba(211, 243, 107, 0.6);
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.25), rgba(90, 169, 201, 0.4));
+  box-shadow: 0 0 22px rgba(124, 200, 111, 0.35);
 }
 
 .hud-nav {
   grid-column: 1;
   grid-row: 2;
-  background: linear-gradient(160deg, rgba(44, 30, 84, 0.86), rgba(61, 41, 101, 0.72));
+  background: var(--color-panel);
   border: 1px solid var(--color-panel-border);
   border-radius: var(--border-radius-lg);
-  padding: 1.35rem 1.25rem;
+  padding: 1.6rem 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
-  backdrop-filter: blur(14px);
-  box-shadow: var(--shadow-glow);
+  gap: 1.35rem;
   position: relative;
   overflow: hidden;
-  min-height: 0;
+  box-shadow: var(--shadow-soft);
 }
 
 .hud-nav::before {
   content: '';
   position: absolute;
-  inset: -20% -30%;
-  background: radial-gradient(circle at 30% 35%, var(--color-panel-highlight), transparent 55%);
+  inset: -25% -40% 55% -40%;
+  background: radial-gradient(circle at 50% 38%, var(--color-panel-highlight), transparent 58%);
   opacity: 0.4;
-  pointer-events: none;
 }
 
 .hud-nav h2 {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 1.05rem;
-  letter-spacing: 0.2em;
+  font-size: 1rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--color-highlight);
-  text-shadow: 0 0 12px rgba(140, 245, 255, 0.45);
 }
 
 .nav-tabs {
@@ -153,106 +148,92 @@ body::after {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
+}
+
+.nav-tabs li {
+  margin: 0;
 }
 
 .nav-tabs button {
   width: 100%;
-  padding: 0.85rem 1rem;
+  padding: 0.9rem 1rem;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(61, 102, 76, 0.35);
   color: var(--color-text-secondary);
-  font-size: 0.92rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-size: 0.95rem;
   font-family: var(--font-display);
-  transition: all 0.24s ease;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
   cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.nav-tabs button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
 }
 
 .nav-tabs button:hover,
 .nav-tabs button:focus-visible {
-  border-color: var(--color-panel-highlight);
+  border-color: rgba(124, 200, 111, 0.6);
   color: var(--color-text-primary);
-  background: var(--color-accent-soft);
-  box-shadow: 0 0 18px rgba(140, 245, 255, 0.25);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
   outline: none;
 }
 
+.nav-tabs button:hover::after,
+.nav-tabs button:focus-visible::after {
+  opacity: 1;
+}
+
 .nav-tabs button.active {
-  border-color: var(--color-accent);
-  background: linear-gradient(135deg, rgba(255, 169, 249, 0.55), rgba(140, 245, 255, 0.25));
+  border-color: rgba(211, 243, 107, 0.75);
   color: var(--color-text-primary);
-  box-shadow: 0 0 22px rgba(255, 169, 249, 0.35);
+  box-shadow: 0 14px 32px rgba(20, 52, 36, 0.45);
 }
 
-.stage {
-  grid-column: 2;
-  grid-row: 1 / span 2;
-  position: relative;
-  background: linear-gradient(180deg, rgba(38, 26, 74, 0.92), rgba(19, 12, 39, 0.92));
-  border: 1px solid rgba(255, 179, 240, 0.32);
-  border-radius: calc(var(--border-radius-lg) + 2px);
-  overflow: hidden;
-  box-shadow: 0 0 32px rgba(120, 82, 255, 0.28);
-  min-height: 0;
-}
-
-.stage::before {
-  content: '';
-  position: absolute;
-  inset: -10% -15% 55%;
-  background: radial-gradient(circle at 45% 35%, rgba(140, 245, 255, 0.32), transparent 65%);
-  opacity: 0.65;
-  pointer-events: none;
-}
-
-.stage::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 50% 35%, rgba(255, 169, 249, 0.2), transparent 60%),
-    radial-gradient(circle at 50% 70%, rgba(140, 245, 255, 0.1), transparent 65%);
-  pointer-events: none;
-}
-
-.stage canvas {
-  width: 100%;
-  height: 100%;
-  display: block;
-}
-
-.hud-info {
-  grid-column: 3;
-  grid-row: 1 / span 2;
-  display: grid;
-  grid-template-rows: repeat(2, minmax(0, 1fr));
-  gap: 1.1rem;
-  min-height: 0;
+.nav-tabs button.active::after {
+  opacity: 1;
 }
 
 .panel {
-  background: linear-gradient(165deg, rgba(43, 27, 81, 0.92), rgba(29, 20, 56, 0.88));
-  border: 1px solid rgba(255, 179, 240, 0.32);
+  background: linear-gradient(165deg, rgba(33, 71, 51, 0.92), rgba(23, 50, 35, 0.92));
+  border: 1px solid var(--color-panel-border);
   border-radius: var(--border-radius-lg);
-  padding: 1.35rem 1.6rem;
+  padding: 1.6rem 1.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  backdrop-filter: blur(16px);
-  box-shadow: 0 0 28px rgba(120, 82, 255, 0.22);
+  gap: 1.1rem;
   position: relative;
   overflow: hidden;
   min-height: 0;
+  box-shadow: var(--shadow-soft);
 }
 
 .panel::before {
   content: '';
   position: absolute;
-  inset: -15% -25% 65% -25%;
-  background: radial-gradient(circle at 30% 20%, rgba(255, 169, 249, 0.28), transparent 60%);
-  opacity: 0.6;
+  inset: -20% -35% 65% -25%;
+  background: radial-gradient(circle at 32% 24%, rgba(124, 200, 111, 0.25), transparent 60%);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.panel::after {
+  content: '';
+  position: absolute;
+  inset: 60% -30% -25% -20%;
+  background: radial-gradient(circle at 70% 80%, rgba(90, 169, 201, 0.18), transparent 60%);
+  opacity: 0.4;
   pointer-events: none;
 }
 
@@ -261,37 +242,43 @@ body::after {
   z-index: 1;
 }
 
-.panel::after {
-  content: '';
-  position: absolute;
-  inset: 55% -35% -20% -20%;
-  background: radial-gradient(circle at 70% 80%, rgba(140, 245, 255, 0.18), transparent 55%);
-  opacity: 0.4;
-  pointer-events: none;
+.hud-panel {
+  min-height: 0;
+}
+
+.hud-list {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.hud-detail {
+  grid-column: 3;
+  grid-row: 2;
 }
 
 .panel-header {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
   font-family: var(--font-display);
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  font-size: 0.85rem;
+  font-size: 0.95rem;
   color: var(--color-highlight);
-  text-shadow: 0 0 12px rgba(140, 245, 255, 0.35);
+  gap: 1rem;
 }
 
 .panel-header [data-role='list-context'] {
-  font-size: 0.78rem;
-  letter-spacing: 0.14em;
-  color: rgba(255, 236, 255, 0.78);
+  font-size: 0.85rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-water);
 }
 
 .weapon-cards {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.9rem;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -299,41 +286,45 @@ body::after {
 }
 
 .weapon-card {
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  border-radius: 16px;
-  padding: 0.85rem 1.1rem;
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 18px;
+  padding: 1rem 1.2rem;
+  background: rgba(46, 88, 64, 0.4);
+  color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: all 0.18s ease;
 }
 
 .weapon-card:hover,
 .weapon-card:focus-visible {
-  border-color: var(--color-panel-highlight);
+  border-color: rgba(124, 200, 111, 0.55);
+  box-shadow: 0 12px 26px rgba(16, 45, 31, 0.35);
+  background: rgba(46, 88, 64, 0.55);
   outline: none;
-  box-shadow: 0 0 16px rgba(140, 245, 255, 0.24);
+  color: var(--color-text-primary);
 }
 
 .weapon-card.active {
-  border-color: var(--color-accent);
-  background: linear-gradient(135deg, rgba(255, 169, 249, 0.38), rgba(140, 245, 255, 0.18));
-  box-shadow: 0 0 20px rgba(255, 169, 249, 0.32);
+  border-color: rgba(211, 243, 107, 0.75);
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.38), rgba(90, 169, 201, 0.28));
+  color: var(--color-text-primary);
+  box-shadow: 0 14px 30px rgba(17, 46, 33, 0.45);
 }
 
 .weapon-card h3 {
-  margin: 0 0 0.35rem;
+  margin: 0 0 0.4rem;
   font-size: 1.1rem;
   color: var(--color-text-primary);
   font-family: var(--font-display);
+  letter-spacing: 0.08em;
 }
 
 .weapon-card dl {
   margin: 0;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.25rem 0.55rem;
-  font-size: 0.78rem;
-  color: var(--color-text-secondary);
+  gap: 0.3rem 0.6rem;
+  font-size: 0.8rem;
 }
 
 dl dt {
@@ -344,16 +335,95 @@ dl dt {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.1rem;
   min-height: 0;
   overflow-y: auto;
   padding-right: 0.4rem;
 }
 
+.detail-content h3 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-family: var(--font-display);
+  letter-spacing: 0.16em;
+  color: var(--color-text-primary);
+}
+
+.description {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.7;
+  color: var(--color-text-secondary);
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem 1.2rem;
+  font-size: 0.9rem;
+}
+
+.stat-grid .stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.72);
+}
+
+.stat-value {
+  font-size: 1.08rem;
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.special-section {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 0.9rem;
+}
+
+.special-section h4 {
+  margin: 0 0 0.6rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+}
+
+.special-list {
+  margin: 0;
+  padding-left: 1rem;
+  list-style: square;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  line-height: 1.65;
+}
+
+.special-list li + li {
+  margin-top: 0.5rem;
+}
+
+.special-key {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.panel-footer {
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.65);
+}
+
 .weapon-cards,
 .detail-content {
   scrollbar-width: thin;
-  scrollbar-color: rgba(255, 169, 249, 0.6) transparent;
+  scrollbar-color: rgba(90, 169, 201, 0.55) transparent;
 }
 
 .weapon-cards::-webkit-scrollbar,
@@ -368,94 +438,144 @@ dl dt {
 
 .weapon-cards::-webkit-scrollbar-thumb,
 .detail-content::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(255, 169, 249, 0.75), rgba(140, 245, 255, 0.65));
+  background: linear-gradient(180deg, rgba(90, 169, 201, 0.65), rgba(124, 200, 111, 0.55));
   border-radius: 6px;
 }
 
-.detail-content h3 {
-  margin: 0;
-  font-size: 1.35rem;
-  font-family: var(--font-display);
-  letter-spacing: 0.18em;
-}
-
-.stat-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem 1.1rem;
-  font-size: 0.88rem;
-}
-
-.stat-grid .stat {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.stat-label {
-  font-size: 0.72rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(255, 236, 255, 0.75);
-}
-
-.stat-value {
-  font-size: 1.05rem;
-  color: var(--color-text-primary);
-  font-weight: 600;
-}
-
-.description {
-  font-size: 0.9rem;
-  line-height: 1.65;
-  color: var(--color-text-secondary);
-}
-
-.panel-footer {
-  font-size: 0.78rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(255, 236, 255, 0.62);
-}
-
-.hud-footer {
-  grid-column: 1 / -1;
-  grid-row: 3;
-  border-top: 1px solid rgba(255, 179, 240, 0.24);
-  display: flex;
+.rarity-badge {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0 2rem;
-  letter-spacing: 0.18em;
+  justify-content: center;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(211, 243, 107, 0.6);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: rgba(255, 236, 255, 0.55);
-  font-size: 0.78rem;
+  color: var(--color-highlight);
+  background: rgba(90, 169, 201, 0.18);
+  min-width: 128px;
+  text-align: center;
 }
 
-@media (max-width: 1200px) {
+.rarity-badge.rarity-common {
+  border-color: rgba(118, 158, 125, 0.55);
+  color: rgba(236, 243, 230, 0.92);
+  background: rgba(118, 158, 125, 0.22);
+}
+
+.rarity-badge.rarity-uncommon {
+  border-color: rgba(124, 200, 111, 0.6);
+  color: rgba(232, 245, 225, 0.96);
+  background: rgba(124, 200, 111, 0.24);
+}
+
+.rarity-badge.rarity-rare {
+  border-color: rgba(90, 169, 201, 0.7);
+  color: rgba(228, 242, 248, 0.98);
+  background: rgba(90, 169, 201, 0.26);
+}
+
+.rarity-badge.rarity-epic {
+  border-color: rgba(101, 138, 201, 0.7);
+  color: rgba(228, 235, 248, 0.98);
+  background: rgba(101, 138, 201, 0.26);
+}
+
+.rarity-badge.rarity-legendary {
+  border-color: rgba(183, 128, 68, 0.75);
+  color: rgba(250, 239, 224, 0.98);
+  background: rgba(183, 128, 68, 0.24);
+}
+
+.rarity-badge.rarity-mythic {
+  border-color: rgba(211, 243, 107, 0.75);
+  color: rgba(246, 250, 231, 0.98);
+  background: rgba(211, 243, 107, 0.3);
+}
+
+.stage {
+  grid-column: 4;
+  grid-row: 1 / span 2;
+  position: relative;
+  background: linear-gradient(160deg, rgba(24, 52, 36, 0.95), rgba(20, 47, 57, 0.92));
+  border: 1px solid rgba(90, 169, 201, 0.35);
+  border-radius: calc(var(--border-radius-lg) + 4px);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+  min-height: 0;
+}
+
+.stage::before {
+  content: '';
+  position: absolute;
+  inset: -25% -18% 60% -18%;
+  background: radial-gradient(circle at 62% 35%, rgba(124, 200, 111, 0.28), transparent 62%);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.stage::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 38% 72%, rgba(90, 169, 201, 0.22), transparent 70%),
+    radial-gradient(circle at 18% 28%, rgba(183, 128, 68, 0.18), transparent 58%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.stage canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+@media (max-width: 1400px) {
   body {
     overflow: auto;
   }
 
   .app-shell {
-    grid-template-columns: 180px minmax(0, 1fr);
-    grid-template-rows: minmax(88px, auto) minmax(0, 1fr) auto minmax(64px, auto);
-    padding: 1.5rem;
+    grid-template-columns: 160px 320px minmax(280px, 1fr);
+    grid-template-rows: auto minmax(0, 1fr) minmax(280px, auto);
+    padding: 2rem;
   }
 
-  .hud-info {
+  .hud-brand {
+    grid-column: 1 / span 2;
+  }
+
+  .hud-list {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .hud-detail {
+    grid-column: 3;
+    grid-row: 2;
+  }
+
+  .stage {
     grid-column: 1 / -1;
     grid-row: 3;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    grid-template-rows: minmax(0, 1fr);
+    height: 320px;
+    border-radius: var(--border-radius-lg);
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1100px) {
   .app-shell {
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(88px, auto) auto auto auto;
-    padding: 1.5rem;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto auto auto auto auto;
+    padding: 1.9rem;
+    gap: 1.25rem;
+  }
+
+  .hud-brand {
+    grid-column: 1;
+    grid-row: 1;
+    align-self: center;
   }
 
   .hud-nav {
@@ -463,115 +583,58 @@ dl dt {
     grid-row: 2;
     flex-direction: row;
     align-items: center;
-    justify-content: space-between;
+    gap: 1.1rem;
+  }
+
+  .hud-nav h2 {
+    margin-bottom: 0;
   }
 
   .nav-tabs {
     flex-direction: row;
+    gap: 0.75rem;
+  }
+
+  .nav-tabs li {
+    flex: 1 1 0;
   }
 
   .nav-tabs button {
-    font-size: 0.75rem;
-    padding: 0.75rem;
+    font-size: 0.85rem;
+    padding: 0.75rem 0.9rem;
+  }
+
+  .hud-list {
+    grid-row: 3;
+    grid-column: 1;
+  }
+
+  .hud-detail {
+    grid-row: 4;
+    grid-column: 1;
   }
 
   .stage {
+    grid-row: 5;
     grid-column: 1;
-    grid-row: 3;
-    height: 360px;
-  }
-
-  .hud-info {
-    grid-column: 1;
-    grid-row: 4;
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(0, 1fr);
-  }
-
-  .hud-footer {
-    display: none;
+    height: 320px;
   }
 }
 
-.rarity-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid var(--color-highlight);
-  font-size: 0.72rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--color-highlight);
-  background: rgba(140, 245, 255, 0.18);
-  min-width: 128px;
-  text-align: center;
-}
+@media (max-width: 700px) {
+  .app-shell {
+    padding: 1.5rem;
+  }
 
-.rarity-badge.rarity-common {
-  border-color: rgba(206, 206, 255, 0.5);
-  color: rgba(238, 238, 255, 0.85);
-  background: rgba(206, 206, 255, 0.18);
-}
+  .nav-tabs {
+    flex-wrap: wrap;
+  }
 
-.rarity-badge.rarity-uncommon {
-  border-color: rgba(173, 255, 214, 0.55);
-  color: rgba(214, 255, 236, 0.95);
-  background: rgba(173, 255, 214, 0.2);
-}
+  .nav-tabs li {
+    flex: 1 1 calc(50% - 0.5rem);
+  }
 
-.rarity-badge.rarity-rare {
-  border-color: rgba(140, 245, 255, 0.75);
-  color: rgba(204, 255, 255, 0.98);
-  background: rgba(140, 245, 255, 0.22);
-}
-
-.rarity-badge.rarity-epic {
-  border-color: rgba(255, 169, 249, 0.75);
-  color: rgba(255, 214, 252, 0.98);
-  background: rgba(255, 169, 249, 0.24);
-}
-
-.rarity-badge.rarity-legendary {
-  border-color: rgba(255, 210, 150, 0.85);
-  color: rgba(255, 239, 197, 0.98);
-  background: rgba(255, 210, 150, 0.26);
-}
-
-.rarity-badge.rarity-mythic {
-  border-color: rgba(255, 184, 255, 0.9);
-  color: rgba(255, 230, 255, 1);
-  background: rgba(255, 184, 255, 0.28);
-}
-
-.special-section {
-  border-top: 1px solid rgba(255, 179, 240, 0.24);
-  padding-top: 0.75rem;
-}
-
-.special-section h4 {
-  margin: 0 0 0.6rem;
-  font-size: 0.78rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--color-highlight);
-}
-
-.special-list {
-  margin: 0;
-  padding-left: 1rem;
-  list-style: square;
-  font-size: 0.88rem;
-  color: rgba(255, 236, 255, 0.82);
-  line-height: 1.65;
-}
-
-.special-list li + li {
-  margin-top: 0.5rem;
-}
-
-.special-key {
-  color: var(--color-text-primary);
-  font-weight: 600;
+  .stage {
+    height: 260px;
+  }
 }


### PR DESCRIPTION
## Summary
- restructure the armory shell so category tabs sit on the left, the arsenal list and weapon details fill the center, and the 3D stage lives in a reduced panel on the right
- apply a forest green, earth brown, and natural blue palette with soft panel treatments and responsive tweaks to fill the desktop canvas
- simplify HUD copy while updating list and detail panels to show plain labels, availability counts, and friendlier guidance

## Testing
- no tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8dfa715908329b04c1839ef167f7e