### PR TITLE
Add critter selector and interactive viewport controls

### DIFF
--- a/src/data/critters.js
+++ b/src/data/critters.js
@@ -1,0 +1,84 @@
+const basePath = 'assets/models/Critters';
+
+export const critters = [
+  {
+    id: 'ember-lynx',
+    name: 'Ember Lynx',
+    modelPath: `${basePath}/ember-lynx.glb`,
+    preview: {
+      scale: 1.1,
+      rotation: { x: 0, y: Math.PI, z: 0 },
+      position: { x: 0, y: -0.95, z: 0 },
+      focus: { x: 0, y: 0.9, z: 0 },
+      spinSpeed: 0.25,
+      glowColor: 0xffb27b,
+    },
+  },
+  {
+    id: 'mossback-tortoise',
+    name: 'Mossback Tortoise',
+    modelPath: `${basePath}/mossback-tortoise.glb`,
+    preview: {
+      scale: 1.2,
+      rotation: { x: 0, y: Math.PI * 0.5, z: 0 },
+      position: { x: 0, y: -0.85, z: 0 },
+      focus: { x: 0, y: 0.6, z: 0 },
+      spinSpeed: 0.18,
+      glowColor: 0x7cc86f,
+    },
+  },
+  {
+    id: 'skywhisper-owl',
+    name: 'Skywhisper Owl',
+    modelPath: `${basePath}/skywhisper-owl.glb`,
+    preview: {
+      scale: 1.05,
+      rotation: { x: 0, y: -Math.PI * 0.2, z: 0 },
+      position: { x: 0, y: -0.6, z: 0 },
+      focus: { x: 0, y: 1.35, z: 0 },
+      spinSpeed: 0.32,
+      glowColor: 0x7df0ff,
+    },
+  },
+  {
+    id: 'thunderfen-toad',
+    name: 'Thunderfen Toad',
+    modelPath: `${basePath}/thunderfen-toad.glb`,
+    preview: {
+      scale: 1.15,
+      rotation: { x: 0, y: Math.PI * 0.35, z: 0 },
+      position: { x: 0, y: -0.78, z: 0 },
+      focus: { x: 0, y: 0.7, z: 0 },
+      spinSpeed: 0.22,
+      glowColor: 0xb58cff,
+    },
+  },
+  {
+    id: 'opal-ridge-ram',
+    name: 'Opal Ridge Ram',
+    modelPath: `${basePath}/opal-ridge-ram.glb`,
+    preview: {
+      scale: 1.08,
+      rotation: { x: 0, y: Math.PI * 0.75, z: 0 },
+      position: { x: 0, y: -0.92, z: 0 },
+      focus: { x: 0, y: 1.05, z: 0 },
+      spinSpeed: 0.28,
+      glowColor: 0xffe37d,
+    },
+  },
+  {
+    id: 'starlit-otter',
+    name: 'Starlit Otter',
+    modelPath: `${basePath}/starlit-otter.glb`,
+    preview: {
+      scale: 1.12,
+      rotation: { x: 0, y: Math.PI, z: 0 },
+      position: { x: 0, y: -0.88, z: 0 },
+      focus: { x: 0, y: 0.75, z: 0 },
+      spinSpeed: 0.3,
+      glowColor: 0x9cd5ff,
+    },
+  },
+];
+
+export const findCritterById = (id) => critters.find((critter) => critter.id === id) || null;

--- a/src/hud/components/CritterSelector.js
+++ b/src/hud/components/CritterSelector.js
@@ -1,0 +1,136 @@
+export class CritterSelector {
+  constructor({
+    container,
+    critters = [],
+    defaultCritterId = null,
+    autoSpinEnabled = true,
+    onSelect,
+    onSpinToggle,
+    onResetView,
+  }) {
+    this.container = container;
+    this.critters = critters;
+    this.selectedCritterId = defaultCritterId;
+    this.autoSpinEnabled = autoSpinEnabled;
+    this.onSelect = onSelect;
+    this.onSpinToggle = onSpinToggle;
+    this.onResetView = onResetView;
+
+    this.selectElement = null;
+    this.spinToggleElement = null;
+    this.selectId = `critter-select-${Math.random().toString(36).slice(2, 9)}`;
+  }
+
+  render() {
+    if (!this.container) return;
+
+    this.container.innerHTML = '';
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'critter-controls';
+
+    const heading = document.createElement('label');
+    heading.className = 'critter-controls__label';
+    heading.textContent = 'Critters';
+    heading.setAttribute('for', this.selectId);
+
+    const helper = document.createElement('p');
+    helper.className = 'critter-controls__helper';
+    helper.id = `${this.selectId}-helper`;
+    helper.textContent = 'Pick a character to preview them on the stage.';
+
+    const selectWrapper = document.createElement('div');
+    selectWrapper.className = 'critter-controls__select-wrapper';
+
+    this.selectElement = document.createElement('select');
+    this.selectElement.className = 'critter-controls__select';
+    this.selectElement.id = this.selectId;
+    this.selectElement.setAttribute('aria-describedby', helper.id);
+    this.selectElement.addEventListener('change', (event) => {
+      const value = event.target.value || null;
+      this.selectedCritterId = value;
+      this.onSelect?.(value);
+    });
+
+    const placeholderOption = document.createElement('option');
+    placeholderOption.value = '';
+    placeholderOption.textContent = 'Show weapons only';
+    this.selectElement.appendChild(placeholderOption);
+
+    this.critters.forEach((critter) => {
+      const option = document.createElement('option');
+      option.value = critter.id;
+      option.textContent = critter.name;
+      this.selectElement.appendChild(option);
+    });
+
+    if (this.selectedCritterId) {
+      this.selectElement.value = this.selectedCritterId;
+    }
+
+    if (this.critters.length === 0) {
+      this.selectElement.disabled = true;
+      helper.textContent = 'Critter roster is still loading. Weapons remain available in the meantime.';
+    } else {
+      this.selectElement.disabled = false;
+    }
+
+    selectWrapper.appendChild(this.selectElement);
+
+    const actions = document.createElement('div');
+    actions.className = 'critter-controls__actions';
+
+    const spinLabel = document.createElement('label');
+    spinLabel.className = 'critter-controls__spin-toggle';
+
+    this.spinToggleElement = document.createElement('input');
+    this.spinToggleElement.type = 'checkbox';
+    this.spinToggleElement.checked = this.autoSpinEnabled;
+    this.spinToggleElement.addEventListener('change', (event) => {
+      const checked = event.target.checked;
+      this.autoSpinEnabled = checked;
+      this.onSpinToggle?.(checked);
+    });
+
+    const spinText = document.createElement('span');
+    spinText.textContent = 'Spin model';
+
+    spinLabel.appendChild(this.spinToggleElement);
+    spinLabel.appendChild(spinText);
+
+    actions.appendChild(spinLabel);
+
+    const resetButton = document.createElement('button');
+    resetButton.type = 'button';
+    resetButton.className = 'critter-controls__reset';
+    resetButton.textContent = 'Reset view';
+    resetButton.addEventListener('click', () => this.onResetView?.());
+    actions.appendChild(resetButton);
+
+    wrapper.appendChild(heading);
+    wrapper.appendChild(helper);
+    wrapper.appendChild(selectWrapper);
+    wrapper.appendChild(actions);
+
+    this.container.appendChild(wrapper);
+  }
+
+  setSelectedCritter(critterId) {
+    this.selectedCritterId = critterId;
+    if (this.selectElement) {
+      this.selectElement.value = critterId ?? '';
+    }
+  }
+
+  setAutoSpinState(enabled) {
+    this.autoSpinEnabled = enabled;
+    if (this.spinToggleElement) {
+      this.spinToggleElement.checked = enabled;
+    }
+  }
+
+  setCritters(critters) {
+    this.critters = critters;
+    this.render();
+  }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -142,6 +142,149 @@ body::after {
   color: var(--color-highlight);
 }
 
+.critter-controls {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.1rem 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(124, 200, 111, 0.32);
+  background: linear-gradient(160deg, rgba(36, 74, 53, 0.6), rgba(24, 54, 42, 0.45));
+  box-shadow: inset 0 0 0 1px rgba(14, 38, 26, 0.4);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.critter-controls::before {
+  content: '';
+  position: absolute;
+  inset: -40% -20% 55% -35%;
+  background: radial-gradient(circle at 60% 40%, rgba(124, 200, 111, 0.35), transparent 65%);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.critter-controls__label {
+  margin: 0;
+  font-family: var(--font-display);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+  font-size: 0.92rem;
+}
+
+.critter-controls__helper {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(243, 248, 240, 0.78);
+  line-height: 1.4;
+}
+
+.critter-controls__select-wrapper {
+  position: relative;
+}
+
+.critter-controls__select-wrapper::after {
+  content: '▾';
+  position: absolute;
+  top: 50%;
+  right: 0.9rem;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: rgba(243, 248, 240, 0.72);
+  font-size: 0.85rem;
+}
+
+.critter-controls__select {
+  width: 100%;
+  padding: 0.75rem 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(124, 200, 111, 0.35);
+  background: rgba(37, 78, 56, 0.55);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  appearance: none;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.critter-controls__select:focus-visible {
+  outline: 2px solid rgba(211, 243, 107, 0.65);
+  outline-offset: 2px;
+}
+
+.critter-controls__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.critter-controls__spin-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  color: rgba(243, 248, 240, 0.78);
+  cursor: pointer;
+  user-select: none;
+}
+
+.critter-controls__spin-toggle input {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--color-accent);
+  cursor: pointer;
+}
+
+.critter-controls__reset {
+  padding: 0.45rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid rgba(124, 200, 111, 0.45);
+  background: rgba(124, 200, 111, 0.18);
+  color: var(--color-highlight);
+  font-family: var(--font-display);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.critter-controls__reset:hover,
+.critter-controls__reset:focus-visible {
+  background: rgba(124, 200, 111, 0.28);
+  border-color: rgba(211, 243, 107, 0.65);
+  color: var(--color-text-primary);
+  box-shadow: 0 12px 24px rgba(12, 40, 28, 0.35);
+  outline: none;
+}
+
+.critter-controls__reset:focus-visible {
+  outline: 2px solid rgba(211, 243, 107, 0.6);
+  outline-offset: 2px;
+}
+
+@media (max-width: 860px) {
+  .critter-controls__actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.65rem;
+  }
+
+  .critter-controls__spin-toggle {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .critter-controls__reset {
+    width: 100%;
+    text-align: center;
+  }
+}
+
 .nav-tabs {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- add a critter selector above the category list and wire it into the app state
- extend the scene manager with orbit controls, critter loading, and auto-spin management
- style the new critter controls and provide sample critter metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8e5c1888883298b0f83f33c9dd866