### PR TITLE
Add critter selection and viewport interactivity

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -1,6 +1,8 @@
 import { SceneManager } from '../core/SceneManager.js';
 import { HUDController } from '../hud/HUDController.js';
 import { sampleWeapons } from '../data/sampleWeapons.js';
+import { sampleCritters } from '../data/sampleCritters.js';
+import { CritterSelector } from '../hud/components/CritterSelector.js';
 import { createEventBus } from '../utils/eventBus.js';
 
 export class WeaponDisplayApp {
@@ -15,15 +17,35 @@ export class WeaponDisplayApp {
     this.categories = ['primary', 'secondary', 'melee', 'utility'];
     this.activeCategory = 'primary';
     this.activeWeapon = null;
+
+    this.critters = sampleCritters;
+    this.critterMap = new Map();
+    this.activeCritter = null;
+    this.critterSelector = null;
   }
 
   init() {
     const layout = this.buildLayout();
     this.indexWeapons();
+    this.indexCritters();
     this.registerEventHandlers();
 
     this.sceneManager = new SceneManager(layout.stageElement);
     this.sceneManager.init();
+
+    const defaultCritter = this.findDefaultCritter();
+
+    this.critterSelector = new CritterSelector({
+      element: layout.critterSelectorElement,
+      critters: this.critters,
+      defaultCritterId: defaultCritter ? defaultCritter.id : null,
+      autoSpinEnabled: true,
+      onSelect: (critterId) => this.handleCritterSelection(critterId),
+      onToggleSpin: (enabled) => this.sceneManager.setAutoSpin(enabled),
+      onResetCamera: () => this.sceneManager.resetView(),
+    });
+    this.critterSelector.render();
+    this.sceneManager.setAutoSpin(this.critterSelector.autoSpinEnabled);
 
     this.hudController = new HUDController({
       bus: this.eventBus,
@@ -49,6 +71,10 @@ export class WeaponDisplayApp {
       this.activeWeapon = defaultWeapon;
       this.sceneManager.loadWeapon(defaultWeapon);
     }
+
+    if (defaultCritter) {
+      this.handleCritterSelection(defaultCritter.id);
+    }
   }
 
   buildLayout() {
@@ -56,6 +82,7 @@ export class WeaponDisplayApp {
       <div class="app-shell">
         <div class="hud-brand">Crtiz Armory</div>
         <nav class="hud-nav" aria-label="Weapon categories">
+          <div class="critter-controls__mount" data-component="critter-selector"></div>
           <h2>Categories</h2>
           <ul class="nav-tabs" data-component="nav-tabs"></ul>
         </nav>
@@ -90,6 +117,7 @@ export class WeaponDisplayApp {
       listFooter: this.root.querySelector('[data-role="list-footer"]'),
       rarityBadge: this.root.querySelector('[data-role="rarity-badge"]'),
       detailFooter: this.root.querySelector('[data-role="detail-footer"]'),
+      critterSelectorElement: this.root.querySelector('[data-component="critter-selector"]'),
     };
   }
 
@@ -116,6 +144,13 @@ export class WeaponDisplayApp {
     });
   }
 
+  indexCritters() {
+    this.critterMap.clear();
+    this.critters.forEach((critter) => {
+      this.critterMap.set(critter.id, critter);
+    });
+  }
+
   groupWeaponsByCategory() {
     return this.weapons.reduce((acc, weapon) => {
       const bucket = acc[weapon.category] || [];
@@ -129,5 +164,45 @@ export class WeaponDisplayApp {
     const byCategory = this.groupWeaponsByCategory();
     const defaultList = byCategory[this.activeCategory];
     return defaultList && defaultList.length > 0 ? defaultList[0] : null;
+  }
+
+  findDefaultCritter() {
+    return this.critters.length > 0 ? this.critters[0] : null;
+  }
+
+  handleCritterSelection(critterId) {
+    if (!critterId) {
+      if (!this.activeCritter) {
+        this.critterSelector?.setCritter(null);
+        if (this.activeWeapon) {
+          this.sceneManager.loadWeapon(this.activeWeapon);
+        } else {
+          this.sceneManager.loadCritter(null);
+        }
+        return;
+      }
+
+      this.activeCritter = null;
+      this.sceneManager.loadCritter(null);
+      if (this.activeWeapon) {
+        this.sceneManager.loadWeapon(this.activeWeapon);
+      }
+      this.critterSelector?.setCritter(null);
+      return;
+    }
+
+    const critter = this.critterMap.get(critterId);
+    if (!critter) {
+      console.warn(`Critter with id "${critterId}" was not found.`);
+      return;
+    }
+
+    if (this.activeCritter?.id === critterId) {
+      return;
+    }
+
+    this.critterSelector?.setCritter(critterId);
+    this.activeCritter = critter;
+    this.sceneManager.loadCritter(critter);
   }
 }

--- a/src/data/sampleCritters.js
+++ b/src/data/sampleCritters.js
@@ -1,0 +1,52 @@
+const basePath = 'assets/models/critters';
+
+export const sampleCritters = [
+  {
+    id: 'grove-warden',
+    name: 'Grove Warden',
+    modelPath: `${basePath}/grove-warden.glb`,
+    description: 'Ancient guardian who patrols the glades with patient vigilance.',
+    preview: {
+      scale: 1.05,
+      position: { y: -0.78 },
+      rotation: { y: Math.PI },
+      camera: {
+        position: { x: 0.6, y: 1.4, z: 2.9 },
+        target: { x: 0, y: 1.1, z: 0 },
+      },
+      ringColor: 0x7cc86f,
+    },
+  },
+  {
+    id: 'ember-runner',
+    name: 'Ember Runner',
+    modelPath: `${basePath}/ember-runner.glb`,
+    description: 'Fleet messenger cloaked in embers who never scorches the forest floor.',
+    preview: {
+      scale: 1.02,
+      position: { y: -0.82 },
+      rotation: { y: Math.PI * 0.85 },
+      camera: {
+        position: { x: -0.4, y: 1.3, z: 3.1 },
+        target: { x: 0, y: 1, z: 0 },
+      },
+      ringColor: 0xffa45f,
+    },
+  },
+  {
+    id: 'tidal-mystic',
+    name: 'Tidal Mystic',
+    modelPath: `${basePath}/tidal-mystic.glb`,
+    description: 'Wavecalling healer who channels the tides into protective veils.',
+    preview: {
+      scale: 1,
+      position: { y: -0.8 },
+      rotation: { y: Math.PI * 1.1 },
+      camera: {
+        position: { x: 0.2, y: 1.5, z: 3.2 },
+        target: { x: 0, y: 1.15, z: 0 },
+      },
+      ringColor: 0x5aa9c9,
+    },
+  },
+];

--- a/src/hud/components/CritterSelector.js
+++ b/src/hud/components/CritterSelector.js
@@ -1,0 +1,128 @@
+export class CritterSelector {
+  constructor({
+    element,
+    critters = [],
+    defaultCritterId = null,
+    autoSpinEnabled = true,
+    onSelect,
+    onToggleSpin,
+    onResetCamera,
+  }) {
+    this.element = element;
+    this.critters = [...critters].sort((a, b) => a.name.localeCompare(b.name));
+    this.defaultCritterId = defaultCritterId;
+    this.autoSpinEnabled = Boolean(autoSpinEnabled);
+    this.onSelect = onSelect;
+    this.onToggleSpin = onToggleSpin;
+    this.onResetCamera = onResetCamera;
+
+    this.selectElement = null;
+    this.spinButton = null;
+    this.resetButton = null;
+    this.selectId = `critter-select-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  render() {
+    if (!this.element) return;
+
+    this.element.innerHTML = '';
+    this.element.classList.add('critter-controls');
+
+    const title = document.createElement('p');
+    title.className = 'critter-controls__title';
+    title.textContent = 'Characters';
+    this.element.appendChild(title);
+
+    const field = document.createElement('label');
+    field.className = 'critter-controls__field';
+
+    const fieldLabel = document.createElement('span');
+    fieldLabel.className = 'critter-controls__label';
+    fieldLabel.textContent = 'Roster';
+    field.appendChild(fieldLabel);
+
+    this.selectElement = document.createElement('select');
+    this.selectElement.id = this.selectId;
+    this.selectElement.className = 'critter-controls__select';
+    this.populateOptions();
+    this.selectElement.addEventListener('change', () => this.handleSelection());
+    field.appendChild(this.selectElement);
+    this.element.appendChild(field);
+
+    const actions = document.createElement('div');
+    actions.className = 'critter-controls__actions';
+
+    this.spinButton = document.createElement('button');
+    this.spinButton.type = 'button';
+    this.spinButton.className = 'critter-controls__toggle';
+    this.spinButton.setAttribute('aria-label', 'Toggle auto-spin');
+    this.spinButton.title = 'Toggle character preview auto-spin';
+    this.spinButton.addEventListener('click', () => this.toggleSpin());
+    actions.appendChild(this.spinButton);
+
+    this.resetButton = document.createElement('button');
+    this.resetButton.type = 'button';
+    this.resetButton.className = 'critter-controls__action';
+    this.resetButton.textContent = 'Reset view';
+    this.resetButton.title = 'Reset the camera to the default orbit position';
+    this.resetButton.addEventListener('click', () => this.onResetCamera?.());
+    actions.appendChild(this.resetButton);
+
+    this.element.appendChild(actions);
+
+    this.updateSpinButton();
+  }
+
+  populateOptions() {
+    if (!this.selectElement) return;
+    this.selectElement.innerHTML = '';
+
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'None';
+    this.selectElement.appendChild(placeholder);
+
+    this.critters.forEach((critter) => {
+      const option = document.createElement('option');
+      option.value = critter.id;
+      option.textContent = critter.name;
+      this.selectElement.appendChild(option);
+    });
+
+    if (this.defaultCritterId) {
+      const exists = this.critters.some((critter) => critter.id === this.defaultCritterId);
+      if (exists) {
+        this.selectElement.value = this.defaultCritterId;
+      }
+    }
+  }
+
+  handleSelection() {
+    const value = this.selectElement?.value || '';
+    const critterId = value === '' ? null : value;
+    this.onSelect?.(critterId);
+  }
+
+  toggleSpin() {
+    this.autoSpinEnabled = !this.autoSpinEnabled;
+    this.updateSpinButton();
+    this.onToggleSpin?.(this.autoSpinEnabled);
+  }
+
+  updateSpinButton() {
+    if (!this.spinButton) return;
+    const pressed = Boolean(this.autoSpinEnabled);
+    this.spinButton.setAttribute('aria-pressed', pressed.toString());
+    this.spinButton.textContent = pressed ? 'Auto-spin: On' : 'Auto-spin: Off';
+  }
+
+  setAutoSpin(enabled) {
+    this.autoSpinEnabled = Boolean(enabled);
+    this.updateSpinButton();
+  }
+
+  setCritter(critterId) {
+    if (!this.selectElement) return;
+    this.selectElement.value = critterId ?? '';
+  }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -142,6 +142,119 @@ body::after {
   color: var(--color-highlight);
 }
 
+.critter-controls {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(135deg, rgba(46, 88, 64, 0.65), rgba(20, 47, 57, 0.55));
+  box-shadow: 0 18px 32px rgba(11, 30, 22, 0.4);
+}
+
+.critter-controls__title {
+  margin: 0;
+  font-family: var(--font-display);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  color: var(--color-water);
+}
+
+.critter-controls__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  cursor: pointer;
+}
+
+.critter-controls__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.75);
+}
+
+.critter-controls__select {
+  width: 100%;
+  padding: 0.65rem 2.5rem 0.65rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(20, 47, 57, 0.9);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, rgba(243, 248, 240, 0.75) 50%),
+    linear-gradient(135deg, rgba(243, 248, 240, 0.75) 50%, transparent 50%);
+  background-position: calc(100% - 1.4rem) calc(50% - 0.35rem), calc(100% - 1rem) calc(50% - 0.35rem);
+  background-size: 0.45rem 0.45rem, 0.45rem 0.45rem;
+  background-repeat: no-repeat;
+}
+
+.critter-controls__select:focus-visible {
+  outline: none;
+  border-color: rgba(124, 200, 111, 0.6);
+  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.22);
+}
+
+.critter-controls__actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.critter-controls__toggle,
+.critter-controls__action {
+  flex: 1 1 48%;
+  padding: 0.55rem 0.65rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(24, 52, 36, 0.65);
+  color: var(--color-text-primary);
+  font-family: var(--font-display);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.critter-controls__toggle[aria-pressed='true'] {
+  border-color: rgba(124, 200, 111, 0.6);
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.35), rgba(90, 169, 201, 0.28));
+  color: var(--color-text-primary);
+  box-shadow: 0 12px 26px rgba(16, 42, 29, 0.35);
+}
+
+.critter-controls__toggle:hover,
+.critter-controls__toggle:focus-visible,
+.critter-controls__action:hover,
+.critter-controls__action:focus-visible {
+  border-color: rgba(124, 200, 111, 0.55);
+  color: var(--color-text-primary);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(16, 45, 31, 0.38);
+  outline: none;
+}
+
+.critter-controls__action {
+  background: rgba(20, 47, 57, 0.55);
+}
+
+@media (max-width: 520px) {
+  .critter-controls__toggle,
+  .critter-controls__action {
+    flex-basis: 100%;
+  }
+}
+
 .nav-tabs {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- add a critter selector above the weapon categories with auto-spin and reset view controls
- integrate a critter manifest so selected characters load into the Three.js stage
- enhance the scene manager with orbit controls and preview presets for weapons and critters
- style the HUD navigation area to host the new critter controls

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8e5c1888883298b0f83f33c9dd866