### PR TITLE
Render weapon stats as bar visualizations

### DIFF
--- a/src/hud/HUDController.js
+++ b/src/hud/HUDController.js
@@ -2,6 +2,7 @@ import { NavigationTabs } from './components/NavigationTabs.js';
 import { WeaponList } from './components/WeaponList.js';
 import { WeaponDetailPanel } from './components/WeaponDetailPanel.js';
 import { WEAPON_CATEGORIES } from '../data/weaponSchema.js';
+import { buildWeaponStatContext } from '../utils/weaponStatBars.js';
 
 const CATEGORY_LABELS = {
   primary: 'Primary',
@@ -34,6 +35,7 @@ export class HUDController {
 
     this.weaponsByCategory = {};
     this.weaponMap = new Map();
+    this.statContext = { profiles: new Map(), maxValues: {} };
 
     this.activeCategory = WEAPON_CATEGORIES[0];
     this.activeWeaponId = null;
@@ -68,7 +70,10 @@ export class HUDController {
       panelElement: this.detailPanelElement,
       rarityBadge: this.rarityBadge,
       footerElement: this.detailFooter,
+      statContext: this.statContext,
     });
+
+    this.weaponDetailPanel.setStatContext(this.statContext);
 
     this.refreshCategory(this.activeCategory, { announce: false });
     if (this.activeWeaponId) {
@@ -78,9 +83,20 @@ export class HUDController {
 
   buildWeaponIndex() {
     this.weaponMap.clear();
+    const allWeapons = [];
+
     Object.values(this.weaponsByCategory).forEach((list = []) => {
-      list.forEach((weapon) => this.weaponMap.set(weapon.id, weapon));
+      list.forEach((weapon) => {
+        this.weaponMap.set(weapon.id, weapon);
+        allWeapons.push(weapon);
+      });
     });
+
+    this.statContext = buildWeaponStatContext(allWeapons);
+
+    if (this.weaponDetailPanel) {
+      this.weaponDetailPanel.setStatContext(this.statContext);
+    }
   }
 
   handleCategoryChange(category) {

--- a/src/utils/weaponStatBars.js
+++ b/src/utils/weaponStatBars.js
@@ -1,0 +1,171 @@
+const ATTACK_SPEED_SCALE = {
+  'very slow': 1.6,
+  slow: 2.4,
+  medium: 3.4,
+  fast: 4.6,
+  'very fast': 5.6,
+};
+
+const AMMO_PREFERENCE_ORDER = [
+  'magazineSize',
+  'quiverCapacity',
+  'capacity',
+  'heatCapacity',
+  'carryLimit',
+  'ammoRestock',
+];
+
+const STAT_BAR_CONFIG = [
+  {
+    key: 'damage',
+    label: 'Damage',
+    resolve: (weapon) => weapon?.stats?.damage ?? null,
+  },
+  {
+    key: 'fireRate',
+    label: 'Fire Rate',
+    resolve: (weapon) => {
+      const stats = weapon?.stats ?? {};
+      if (hasValue(stats.fireRate)) {
+        return stats.fireRate;
+      }
+
+      if (hasValue(stats.attackSpeed)) {
+        const descriptor = String(stats.attackSpeed).trim();
+        const normalized = descriptor.toLowerCase();
+        const numericValue = ATTACK_SPEED_SCALE[normalized] ?? null;
+        return {
+          displayValue: descriptor,
+          numericValue,
+        };
+      }
+
+      return null;
+    },
+  },
+  {
+    key: 'ammo',
+    label: 'Ammo',
+    resolve: (weapon) => {
+      const stats = weapon?.stats ?? {};
+      for (const key of AMMO_PREFERENCE_ORDER) {
+        if (hasValue(stats[key])) {
+          return stats[key];
+        }
+      }
+      return null;
+    },
+  },
+  {
+    key: 'weight',
+    label: 'Weight',
+    resolve: (weapon) => weapon?.stats?.weight ?? null,
+  },
+];
+
+const hasValue = (value) => value !== null && value !== undefined && value !== '';
+
+const toNumber = (value) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const match = value.replace(/,/g, '').match(/-?\d+(\.\d+)?/);
+    return match ? Number.parseFloat(match[0]) : null;
+  }
+
+  return null;
+};
+
+const formatDisplayValue = (value) => {
+  if (value === null || value === undefined || value === '') {
+    return '—';
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : '—';
+  }
+
+  return String(value);
+};
+
+const normalizeStatEntry = (resolved) => {
+  if (resolved && typeof resolved === 'object' && !Array.isArray(resolved)) {
+    const numericValue =
+      typeof resolved.numericValue === 'number' && Number.isFinite(resolved.numericValue)
+        ? resolved.numericValue
+        : toNumber(resolved.value ?? resolved.displayValue ?? null);
+
+    const displayValue = formatDisplayValue(
+      resolved.displayValue ?? resolved.value ?? resolved.numericValue ?? null
+    );
+
+    return {
+      displayValue,
+      numericValue,
+      hasValue: hasValue(resolved.value ?? resolved.displayValue ?? resolved.numericValue),
+    };
+  }
+
+  const numericValue = toNumber(resolved);
+  return {
+    displayValue: formatDisplayValue(resolved),
+    numericValue,
+    hasValue: hasValue(resolved),
+  };
+};
+
+export const createWeaponStatProfile = (weapon) =>
+  STAT_BAR_CONFIG.map(({ key, label, resolve }) => {
+    const entry = normalizeStatEntry(resolve(weapon));
+    const hasNumeric = typeof entry.numericValue === 'number' && Number.isFinite(entry.numericValue);
+
+    return {
+      key,
+      label,
+      displayValue: entry.displayValue,
+      numericValue: hasNumeric ? entry.numericValue : null,
+      hasValue: entry.hasValue,
+    };
+  });
+
+export const buildWeaponStatContext = (weapons = []) => {
+  const profiles = new Map();
+  const maxValues = STAT_BAR_CONFIG.reduce((acc, { key }) => {
+    acc[key] = 0;
+    return acc;
+  }, {});
+
+  weapons.forEach((weapon) => {
+    const profile = createWeaponStatProfile(weapon);
+    profiles.set(weapon.id, profile);
+
+    profile.forEach(({ key, numericValue }) => {
+      if (typeof numericValue === 'number' && Number.isFinite(numericValue)) {
+        maxValues[key] = Math.max(maxValues[key], numericValue);
+      }
+    });
+  });
+
+  return { profiles, maxValues };
+};
+
+export const calculateStatPercent = (value, max) => {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < 0 ||
+    typeof max !== 'number' ||
+    !Number.isFinite(max) ||
+    max <= 0
+  ) {
+    return 0;
+  }
+
+  const ratio = value / max;
+  return Math.max(0, Math.min(100, ratio * 100));
+};
+
+export const STAT_BAR_KEYS = STAT_BAR_CONFIG.map(({ key }) => key);
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -356,30 +356,64 @@ dl dt {
   color: var(--color-text-secondary);
 }
 
-.stat-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.85rem 1.2rem;
-  font-size: 0.9rem;
-}
-
-.stat-grid .stat {
+.stat-bar-list {
+  margin-top: 1.2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 1rem;
+}
+
+.stat-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.stat-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
 .stat-label {
-  font-size: 0.75rem;
+  font-size: 0.74rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: rgba(243, 248, 240, 0.72);
 }
 
 .stat-value {
-  font-size: 1.08rem;
+  font-size: 0.95rem;
   color: var(--color-text-primary);
   font-weight: 600;
+}
+
+.stat-value.is-empty {
+  color: rgba(243, 248, 240, 0.45);
+  font-weight: 500;
+}
+
+.stat-bar-track {
+  position: relative;
+  height: 0.6rem;
+  border-radius: 999px;
+  background: rgba(243, 248, 240, 0.18);
+  overflow: hidden;
+}
+
+.stat-bar-track.is-empty {
+  opacity: 0.4;
+}
+
+.stat-bar-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(124, 200, 111, 0.9), rgba(211, 243, 107, 0.95));
+  box-shadow: 0 0 12px rgba(124, 200, 111, 0.35);
+  transition: width 0.3s ease;
 }
 
 .special-section {


### PR DESCRIPTION
## Summary
- replace the weapon detail stat grid with bar visualizations for damage, fire rate, ammo, and weight
- compute normalized stat profiles across the catalog so each bar shares a consistent scale
- add styling and utilities to support the new stat bars and highlight missing data

## Testing
- node --input-type=module <<'EOF' ... EOF

------
https://chatgpt.com/codex/tasks/task_e_68c8e72740248329a45e21587d650db7