### PR TITLE
Switch weapon detail stats to bar visualization

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -357,16 +357,23 @@ dl dt {
 }
 
 .stat-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.85rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   font-size: 0.9rem;
 }
 
 .stat-grid .stat {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.45rem;
+}
+
+.stat-bar-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
 }
 
 .stat-label {
@@ -376,10 +383,53 @@ dl dt {
   color: rgba(243, 248, 240, 0.72);
 }
 
-.stat-value {
-  font-size: 1.08rem;
-  color: var(--color-text-primary);
+.stat-bar-value {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
   font-weight: 600;
+  white-space: nowrap;
+}
+
+.stat-bar-value.is-missing {
+  color: rgba(243, 248, 240, 0.45);
+  font-style: italic;
+  font-weight: 500;
+}
+
+.stat-bar-track {
+  position: relative;
+  height: 0.75rem;
+  background: rgba(124, 200, 111, 0.15);
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid rgba(124, 200, 111, 0.35);
+  box-shadow: inset 0 0 18px rgba(6, 18, 12, 0.6);
+}
+
+.stat-bar-track::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 50%, rgba(243, 248, 240, 0.25), transparent 65%);
+  opacity: 0.45;
+}
+
+.stat-bar-fill {
+  --fill: 0;
+  position: absolute;
+  inset: 0;
+  width: calc(var(--fill, 0) * 1%);
+  background: linear-gradient(90deg, rgba(124, 200, 111, 0.85), rgba(211, 243, 107, 0.95));
+  box-shadow: 0 0 18px rgba(124, 200, 111, 0.55);
+  transition: width 220ms ease-out;
+}
+
+.stat-bar-track[data-empty='true'] {
+  opacity: 0.35;
+}
+
+.stat-bar-track[data-empty='true'] .stat-bar-fill {
+  display: none;
 }
 
 .special-section {


### PR DESCRIPTION
## Summary
- replace the weapon detail stat grid with a four-stat bar visualization for damage, fire rate, ammo, and weight
- derive normalized bar widths with fallbacks for different ammo fields and present "N/A" when values are missing
- refresh the HUD styles with progress-bar visuals and accessibility metadata for the meter elements

## Testing
- Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c8e72740248329a45e21587d650db7