### PR TITLE
Display weapon stats as progress bars

### DIFF
--- a/src/hud/HUDController.js
+++ b/src/hud/HUDController.js
@@ -2,6 +2,7 @@ import { NavigationTabs } from './components/NavigationTabs.js';
 import { WeaponList } from './components/WeaponList.js';
 import { WeaponDetailPanel } from './components/WeaponDetailPanel.js';
 import { WEAPON_CATEGORIES } from '../data/weaponSchema.js';
+import { computeStatMeta } from '../utils/statBars.js';
 
 const CATEGORY_LABELS = {
   primary: 'Primary',
@@ -39,6 +40,7 @@ export class HUDController {
     this.activeWeaponId = null;
     this.rarityBadge = rarityBadge;
     this.detailFooter = detailFooter;
+    this.statMeta = {};
   }
 
   init({ categories, weaponsByCategory, defaultCategory, defaultWeaponId }) {
@@ -46,6 +48,7 @@ export class HUDController {
     this.activeCategory = defaultCategory || categories[0] || WEAPON_CATEGORIES[0];
     this.activeWeaponId = defaultWeaponId || null;
     this.buildWeaponIndex();
+    this.statMeta = computeStatMeta(Array.from(this.weaponMap.values()));
 
     this.navigationTabs = new NavigationTabs({
       element: this.navElement,
@@ -68,6 +71,7 @@ export class HUDController {
       panelElement: this.detailPanelElement,
       rarityBadge: this.rarityBadge,
       footerElement: this.detailFooter,
+      statMeta: this.statMeta,
     });
 
     this.refreshCategory(this.activeCategory, { announce: false });

--- a/src/utils/statBars.js
+++ b/src/utils/statBars.js
@@ -1,0 +1,164 @@
+const ATTACK_SPEED_MAP = new Map(
+  [
+    ['very slow', 2],
+    ['slow', 4],
+    ['medium', 6],
+    ['fast', 9],
+    ['very fast', 12],
+  ]
+);
+
+const clamp = (value, min = 0, max = 1) => {
+  if (Number.isNaN(value) || !Number.isFinite(value)) return min;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+};
+
+const parseNumericValue = (input) => {
+  if (typeof input === 'number') {
+    return Number.isFinite(input) ? input : null;
+  }
+
+  if (typeof input !== 'string') {
+    return null;
+  }
+
+  const sanitized = input.replace(/,/g, '');
+  const match = sanitized.match(/-?\d*\.?\d+/);
+  if (!match) {
+    return null;
+  }
+
+  const parsed = parseFloat(match[0]);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseFireRateValue = (raw, { keyUsed }) => {
+  if (raw === null || raw === undefined || raw === '') {
+    return null;
+  }
+
+  if (keyUsed === 'attackSpeed') {
+    const mapped = ATTACK_SPEED_MAP.get(String(raw).trim().toLowerCase());
+    return mapped ?? null;
+  }
+
+  return parseNumericValue(raw);
+};
+
+const formatDisplayValue = (raw) => {
+  if (raw === null || raw === undefined || raw === '') {
+    return '—';
+  }
+
+  if (typeof raw === 'number') {
+    return Number.isFinite(raw) ? String(raw) : '—';
+  }
+
+  return String(raw);
+};
+
+const pickStatSource = (weapon, keys) => {
+  if (!weapon || !weapon.stats) {
+    return { raw: null, keyUsed: null };
+  }
+
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(weapon.stats, key)) continue;
+    const value = weapon.stats[key];
+    if (value !== null && value !== undefined && value !== '') {
+      return { raw: value, keyUsed: key };
+    }
+  }
+
+  return { raw: null, keyUsed: null };
+};
+
+const STAT_CONFIG = [
+  {
+    key: 'damage',
+    label: 'Damage',
+    pick: (weapon) => pickStatSource(weapon, ['damage']),
+    parse: (raw) => parseNumericValue(raw),
+  },
+  {
+    key: 'fireRate',
+    label: 'Fire Rate',
+    pick: (weapon) => pickStatSource(weapon, ['fireRate', 'attackSpeed']),
+    parse: (raw, context) => parseFireRateValue(raw, context),
+  },
+  {
+    key: 'ammo',
+    label: 'Ammo',
+    pick: (weapon) =>
+      pickStatSource(weapon, [
+        'magazineSize',
+        'capacity',
+        'quiverCapacity',
+        'carryLimit',
+        'heatCapacity',
+      ]),
+    parse: (raw) => parseNumericValue(raw),
+  },
+  {
+    key: 'weight',
+    label: 'Weight',
+    pick: (weapon) => pickStatSource(weapon, ['weight']),
+    parse: (raw) => parseNumericValue(raw),
+  },
+];
+
+export const computeStatMeta = (weapons = []) => {
+  const meta = {};
+
+  if (!Array.isArray(weapons)) {
+    return meta;
+  }
+
+  weapons.forEach((weapon) => {
+    STAT_CONFIG.forEach((config) => {
+      const { raw, keyUsed } = config.pick(weapon);
+      if (raw === null || raw === undefined || raw === '') {
+        return;
+      }
+
+      const numericValue = config.parse(raw, { weapon, keyUsed });
+      if (numericValue === null || Number.isNaN(numericValue)) {
+        return;
+      }
+
+      const currentMax = meta[config.key]?.max ?? 0;
+      const nextMax = numericValue > currentMax ? numericValue : currentMax;
+      meta[config.key] = { max: nextMax };
+    });
+  });
+
+  return meta;
+};
+
+export const deriveWeaponStatBars = (weapon, meta = {}) =>
+  STAT_CONFIG.map((config) => {
+    const { raw, keyUsed } = config.pick(weapon);
+    const hasValue = raw !== null && raw !== undefined && raw !== '';
+    const numericValue = hasValue ? config.parse(raw, { weapon, keyUsed }) : null;
+
+    const max = meta[config.key]?.max ?? null;
+    const ratio =
+      numericValue !== null && Number.isFinite(numericValue) && max && max > 0
+        ? clamp(numericValue / max)
+        : 0;
+    const percentage = Math.round(ratio * 100);
+
+    return {
+      key: config.key,
+      label: config.label,
+      value: hasValue ? formatDisplayValue(raw) : '—',
+      numericValue,
+      ratio,
+      percentage,
+      hasValue,
+    };
+  });
+
+export const STAT_BAR_KEYS = STAT_CONFIG.map((config) => config.key);

--- a/styles/main.css
+++ b/styles/main.css
@@ -356,17 +356,51 @@ dl dt {
   color: var(--color-text-secondary);
 }
 
-.stat-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.85rem 1.2rem;
-  font-size: 0.9rem;
-}
-
-.stat-grid .stat {
+.stat-bars {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.85rem;
+}
+
+.stat-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.stat-bar-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.stat-bar-track {
+  position: relative;
+  width: 100%;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: rgba(243, 248, 240, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(243, 248, 240, 0.12);
+  overflow: hidden;
+}
+
+.stat-bar-fill {
+  --stat-bar-fill: 0%;
+  width: var(--stat-bar-fill);
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(124, 200, 111, 0.88), rgba(211, 243, 107, 0.95));
+  box-shadow: 0 0 18px rgba(124, 200, 111, 0.45);
+  transition: width 0.35s ease;
+}
+
+.stat-bar--empty .stat-bar-fill {
+  background: rgba(243, 248, 240, 0.22);
+  box-shadow: none;
+}
+
+.stat-bar--empty .stat-value {
+  opacity: 0.6;
 }
 
 .stat-label {
@@ -380,6 +414,7 @@ dl dt {
   font-size: 1.08rem;
   color: var(--color-text-primary);
   font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .special-section {


### PR DESCRIPTION
## Summary
- add stat bar utilities that normalize weapon damage, fire rate, ammo, and weight values for visualization
- compute shared stat metadata in the HUD controller and render detail-panel stats as progress bars instead of plain numbers
- refresh HUD styling to support the new stat bar layout and accent colors

## Testing
- not run (project has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68c8e72740248329a45e21587d650db7