### PR TITLE
Add critter preview selection and viewer controls

### DIFF
--- a/src/data/sampleCritters.js
+++ b/src/data/sampleCritters.js
@@ -1,0 +1,41 @@
+export const sampleCritters = [
+  {
+    id: 'verdant-stag',
+    name: 'Verdant Stag',
+    faction: 'Sylvan Wardens',
+    summary: 'Ancient guardian of the grove clad in living armor.',
+    modelPath: 'assets/models/critters/verdant-stag.glb',
+    preview: {
+      scale: 1.1,
+      position: { y: -0.75 },
+      target: { x: 0, y: 1.2, z: 0 },
+      glowColor: 0x7cc86f,
+    },
+  },
+  {
+    id: 'ember-fox',
+    name: 'Ember Fox',
+    faction: 'Ashen Vanguard',
+    summary: 'Fleet-footed scout whose tails shimmer with embers.',
+    modelPath: 'assets/models/critters/ember-fox.glb',
+    preview: {
+      scale: 1.4,
+      position: { y: -0.45 },
+      target: { x: 0, y: 0.6, z: 0 },
+      glowColor: 0xff9f6c,
+    },
+  },
+  {
+    id: 'tidal-sentinel',
+    name: 'Tidal Sentinel',
+    faction: 'Mariner Keep',
+    summary: 'Tide-born construct that patrols the coral bastions.',
+    modelPath: 'assets/models/critters/tidal-sentinel.glb',
+    preview: {
+      scale: 1.25,
+      position: { y: -0.65 },
+      target: { x: 0, y: 1.1, z: 0 },
+      glowColor: 0x5aa9c9,
+    },
+  },
+];

--- a/src/data/weaponSchema.js
+++ b/src/data/weaponSchema.js
@@ -103,20 +103,35 @@ export const createEmptyWeapon = () => ({
   special: {},
 });
 
-export const normalizeWeapon = (weapon) => ({
-  ...createEmptyWeapon(),
-  ...weapon,
-  preview: {
-    ...createEmptyWeapon().preview,
-    ...(weapon.preview || {}),
-  },
-  stats: {
-    ...(weapon.stats || {}),
-  },
-  special: {
-    ...(weapon.special || {}),
-  },
-});
+export const normalizeWeapon = (weapon) => {
+  const base = createEmptyWeapon();
+  const originalPreview = weapon.preview || {};
+  const normalizedPreview = {
+    ...base.preview,
+    ...originalPreview,
+  };
+
+  if (originalPreview.rotation && typeof originalPreview.rotation === 'object') {
+    const axes = Object.keys(originalPreview.rotation).filter((axis) =>
+      Object.prototype.hasOwnProperty.call(originalPreview.rotation, axis)
+    );
+    if (axes.length > 0) {
+      normalizedPreview.__rotationProvidedAxes = axes;
+    }
+  }
+
+  return {
+    ...base,
+    ...weapon,
+    preview: normalizedPreview,
+    stats: {
+      ...(weapon.stats || {}),
+    },
+    special: {
+      ...(weapon.special || {}),
+    },
+  };
+};
 
 export const deriveStatsList = (weapon) => {
   const normalized = normalizeWeapon(weapon);

--- a/src/hud/components/CritterSelector.js
+++ b/src/hud/components/CritterSelector.js
@@ -1,0 +1,91 @@
+export class CritterSelector {
+  constructor({ element, critters = [], activeId = null, onSelect } = {}) {
+    this.element = element;
+    this.critters = critters;
+    this.activeId = activeId;
+    this.onSelect = onSelect;
+
+    this.selectElement = this.element?.querySelector('[data-role="critter-select"]') || null;
+    this.descriptionElement = this.element?.querySelector('[data-role="critter-description"]') || null;
+
+    this.handleChange = this.handleChange.bind(this);
+    this.attachEvents();
+    this.renderOptions();
+    this.setActive(this.activeId);
+  }
+
+  attachEvents() {
+    if (!this.selectElement) return;
+    this.selectElement.addEventListener('change', this.handleChange);
+  }
+
+  detachEvents() {
+    if (!this.selectElement) return;
+    this.selectElement.removeEventListener('change', this.handleChange);
+  }
+
+  handleChange(event) {
+    const value = event.target.value;
+    this.activeId = value || null;
+    this.updateDescription();
+    this.onSelect?.(this.activeId);
+  }
+
+  setCritters(critters = []) {
+    this.critters = Array.isArray(critters) ? critters : [];
+    this.renderOptions();
+    this.setActive(this.activeId);
+  }
+
+  renderOptions() {
+    if (!this.selectElement) return;
+    const previousValue = this.selectElement.value;
+    this.selectElement.innerHTML = '';
+
+    const placeholderOption = document.createElement('option');
+    placeholderOption.value = '';
+    placeholderOption.textContent = 'Weapons Only';
+    this.selectElement.appendChild(placeholderOption);
+
+    this.critters.forEach((critter) => {
+      const option = document.createElement('option');
+      option.value = critter.id;
+      option.textContent = critter.name;
+      option.dataset.faction = critter.faction || '';
+      this.selectElement.appendChild(option);
+    });
+
+    if (previousValue) {
+      this.selectElement.value = previousValue;
+    }
+  }
+
+  setActive(critterId = null) {
+    this.activeId = critterId || null;
+    if (this.selectElement) {
+      this.selectElement.value = this.activeId || '';
+    }
+    this.updateDescription();
+  }
+
+  updateDescription() {
+    if (!this.descriptionElement) return;
+    if (!this.activeId) {
+      this.descriptionElement.textContent = 'View weapons on the stage or pick a critter to preview.';
+      return;
+    }
+
+    const critter = this.critters.find((entry) => entry.id === this.activeId);
+    if (!critter) {
+      this.descriptionElement.textContent = 'Select a critter to preview it in the stage.';
+      return;
+    }
+
+    const faction = critter.faction ? `${critter.faction} • ` : '';
+    this.descriptionElement.textContent = `${faction}${critter.summary || 'Ready for inspection.'}`;
+  }
+
+  destroy() {
+    this.detachEvents();
+  }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -133,6 +133,69 @@ body::after {
   opacity: 0.4;
 }
 
+.critter-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(46, 88, 64, 0.4);
+  position: relative;
+  overflow: hidden;
+}
+
+.critter-selector::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.16), transparent 65%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.critter-selector label {
+  font-family: var(--font-display);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.82rem;
+  color: var(--color-highlight);
+  z-index: 1;
+}
+
+.critter-selector-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  z-index: 1;
+}
+
+.critter-selector select {
+  flex: 1;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(31, 61, 44, 0.85);
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.critter-selector select:focus-visible {
+  border-color: rgba(124, 200, 111, 0.75);
+  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.25);
+  outline: none;
+  color: var(--color-text-primary);
+}
+
+.critter-selector-description {
+  margin: 0;
+  font-size: 0.74rem;
+  line-height: 1.4;
+  color: rgba(243, 248, 240, 0.75);
+  z-index: 1;
+}
+
 .hud-nav h2 {
   margin: 0;
   font-family: var(--font-display);
@@ -525,6 +588,54 @@ dl dt {
   pointer-events: none;
 }
 
+.stage-overlay {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.2rem;
+  display: flex;
+  gap: 0.65rem;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.stage-overlay > * {
+  pointer-events: auto;
+}
+
+.stage-spin-toggle {
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(211, 243, 107, 0.6);
+  background: rgba(31, 61, 44, 0.75);
+  color: var(--color-highlight);
+  font-family: var(--font-display);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.stage-spin-toggle:hover,
+.stage-spin-toggle:focus-visible {
+  background: rgba(46, 88, 64, 0.85);
+  border-color: rgba(124, 200, 111, 0.75);
+  color: var(--color-text-primary);
+  box-shadow: 0 10px 22px rgba(16, 45, 31, 0.4);
+  outline: none;
+}
+
+.stage-spin-toggle[aria-pressed='false'] {
+  border-color: rgba(90, 169, 201, 0.65);
+  color: var(--color-water);
+}
+
+.stage-spin-toggle[aria-pressed='false']:hover,
+.stage-spin-toggle[aria-pressed='false']:focus-visible {
+  border-color: rgba(90, 169, 201, 0.85);
+  color: var(--color-text-primary);
+}
+
 .stage canvas {
   width: 100%;
   height: 100%;
@@ -586,6 +697,15 @@ dl dt {
     gap: 1.1rem;
   }
 
+  .critter-selector {
+    flex: 1 1 220px;
+    padding: 0.85rem 0.95rem;
+  }
+
+  .critter-selector select {
+    font-size: 0.85rem;
+  }
+
   .hud-nav h2 {
     margin-bottom: 0;
   }
@@ -602,6 +722,10 @@ dl dt {
   .nav-tabs button {
     font-size: 0.85rem;
     padding: 0.75rem 0.9rem;
+  }
+
+  .critter-selector-description {
+    font-size: 0.7rem;
   }
 
   .hud-list {
@@ -632,6 +756,10 @@ dl dt {
 
   .nav-tabs li {
     flex: 1 1 calc(50% - 0.5rem);
+  }
+
+  .critter-selector {
+    flex: 1 1 100%;
   }
 
   .stage {


### PR DESCRIPTION
## Summary
- add a critter selector above the navigation tabs and populate it with sample roster data
- hook the viewport up to load critter models, enable orbit controls, and expose an auto-rotate toggle
- style the new critter selector and stage overlay controls to match the existing HUD aesthetics

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8eaac5b7883298f1de92a8b5afc9e