### PR TITLE
Add critter selection and orbit viewer controls

### DIFF
--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -1,4 +1,5 @@
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
 import { createRenderer } from './RendererFactory.js';
 import { ResourceLoader } from './ResourceLoader.js';
 
@@ -19,12 +20,15 @@ export class SceneManager {
     this.clock = new THREE.Clock();
     this.resourceLoader = new ResourceLoader();
     this.animationFrame = null;
+    this.controls = null;
+    this.autoRotate = true;
+    this.pendingLoadToken = null;
+    this.cameraDirection = new THREE.Vector3(0, 0, 1);
 
     this.stageGroup = new THREE.Group();
     this.currentModel = null;
     this.platform = null;
     this.glowRing = null;
-    this.pendingWeaponId = null;
 
     this.handleResize = this.handleResize.bind(this);
     this.animate = this.animate.bind(this);
@@ -33,6 +37,7 @@ export class SceneManager {
   init() {
     this.renderer = createRenderer(this.container);
     this.camera = this.createCamera();
+    this.controls = this.createControls(this.camera, this.renderer.domElement);
     this.setupLights();
     this.setupEnvironment();
     this.scene.add(this.stageGroup);
@@ -54,8 +59,12 @@ export class SceneManager {
   }
 
   update(delta) {
+    this.controls?.update();
+
     if (this.currentModel) {
-      this.currentModel.rotation.y += delta * 0.4;
+      if (this.autoRotate) {
+        this.currentModel.rotation.y += delta * 0.4;
+      }
     }
 
     if (this.glowRing) {
@@ -69,6 +78,20 @@ export class SceneManager {
     camera.position.set(0, 1.1, 3.3);
     camera.lookAt(0, 0.4, 0);
     return camera;
+  }
+
+  createControls(camera, domElement) {
+    const controls = new OrbitControls(camera, domElement);
+    domElement.tabIndex = 0;
+    domElement.setAttribute('aria-label', '3D model viewer');
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.enablePan = false;
+    controls.minDistance = 1.2;
+    controls.maxDistance = 8;
+    controls.target.set(0, 0.9, 0);
+    controls.update();
+    return controls;
   }
 
   setupLights() {
@@ -113,34 +136,68 @@ export class SceneManager {
   }
 
   async loadWeapon(weapon) {
-    if (!weapon) return;
+    await this.loadEntry(weapon, {
+      fallbackType: 'weapon',
+      applyRarityGlow: true,
+      defaultRotation: [0, Math.PI / 4, 0],
+      defaultScale: 1.2,
+      autoCenter: weapon?.preview?.autoCenter ?? false,
+      updateCamera: weapon?.preview?.updateCamera ?? false,
+    });
+  }
 
-    const requestId = (this.pendingWeaponId = weapon.id);
+  async loadCritter(critter) {
+    await this.loadEntry(critter, {
+      fallbackType: 'critter',
+      applyRarityGlow: false,
+      defaultRotation: [0, Math.PI, 0],
+      defaultScale: 1,
+      autoCenter: critter?.preview?.autoCenter ?? true,
+      updateCamera: critter?.preview?.updateCamera ?? true,
+      cameraOffset: critter?.preview?.cameraOffset,
+    });
+  }
+
+  async loadEntry(entry, options = {}) {
+    if (!entry) return;
+
+    const requestToken = {};
+    this.pendingLoadToken = requestToken;
 
     let model = null;
-    if (weapon.modelPath) {
-      model = await this.resourceLoader.loadModel(weapon.modelPath);
+    if (entry.modelPath) {
+      model = await this.resourceLoader.loadModel(entry.modelPath);
     }
 
-    if (this.pendingWeaponId !== requestId) {
+    if (this.pendingLoadToken !== requestToken) {
       return;
     }
 
     if (!model) {
-      model = this.createPlaceholderModel();
+      model = this.createPlaceholderModel(options.fallbackType);
     }
 
-    model.position.set(0, 0, 0);
-    model.rotation.set(0, Math.PI / 4, 0);
-
-    const scale = weapon.preview?.scale ?? 1.2;
-    model.scale.setScalar(scale);
+    const settings = this.buildPreviewSettings(entry, options);
+    const metrics = this.prepareModel(model, settings);
+    settings.metrics = metrics;
 
     this.disposeCurrentModel();
     this.currentModel = model;
     this.stageGroup.add(model);
 
-    this.applyRarityGlow(weapon.rarity);
+    if (settings.updateCamera) {
+      this.focusModel(settings);
+    } else {
+      this.resetCameraTarget(settings);
+    }
+
+    if (options.applyRarityGlow) {
+      this.applyRarityGlow(entry.rarity);
+    } else {
+      this.applyRarityGlow('common');
+    }
+
+    this.pendingLoadToken = null;
   }
 
   disposeCurrentModel() {
@@ -168,7 +225,20 @@ export class SceneManager {
     }
   }
 
-  createPlaceholderModel() {
+  createPlaceholderModel(type = 'weapon') {
+    if (type === 'critter') {
+      const body = new THREE.CapsuleGeometry(0.4, 1.6, 12, 24);
+      const material = new THREE.MeshStandardMaterial({
+        color: 0x7cc86f,
+        emissive: 0x1a3a29,
+        metalness: 0.2,
+        roughness: 0.5,
+      });
+      const mesh = new THREE.Mesh(body, material);
+      mesh.position.y = 0.8;
+      return mesh;
+    }
+
     const geometry = new THREE.TorusKnotGeometry(0.65, 0.18, 128, 16);
     const material = new THREE.MeshStandardMaterial({
       color: 0xff9dce,
@@ -188,6 +258,157 @@ export class SceneManager {
     this.renderer.setSize(clientWidth, clientHeight, false);
     this.camera.aspect = clientWidth / Math.max(clientHeight, 1);
     this.camera.updateProjectionMatrix();
+    this.controls?.update();
+  }
+
+  setAutoRotate(enabled) {
+    this.autoRotate = Boolean(enabled);
+  }
+
+  buildPreviewSettings(entry, options = {}) {
+    const preview = entry?.preview ?? {};
+    return {
+      rotation: preview.rotation ?? options.defaultRotation ?? [0, 0, 0],
+      scale: preview.scale ?? options.defaultScale ?? 1,
+      position: preview.position ?? options.defaultPosition ?? [0, 0, 0],
+      offset: preview.offset ?? options.defaultOffset ?? [0, 0, 0],
+      autoCenter: preview.autoCenter ?? options.autoCenter ?? false,
+      focusTarget: preview.focusTarget ?? null,
+      cameraDistance: preview.cameraDistance ?? null,
+      cameraDistanceMultiplier:
+        preview.cameraDistanceMultiplier ?? options.cameraDistanceMultiplier ?? null,
+      cameraOffset: preview.cameraOffset ?? options.cameraOffset ?? [0, 0, 0],
+      minDistanceMultiplier: preview.minDistanceMultiplier ?? null,
+      maxDistanceMultiplier: preview.maxDistanceMultiplier ?? null,
+      updateCamera: preview.updateCamera ?? options.updateCamera ?? true,
+    };
+  }
+
+  prepareModel(model, settings) {
+    const rotation = Array.isArray(settings.rotation) ? settings.rotation : [0, 0, 0];
+    const scale = settings.scale;
+
+    if (Array.isArray(scale)) {
+      const [sx = 1, sy = 1, sz = 1] = scale;
+      model.scale.set(sx, sy, sz);
+    } else if (typeof scale === 'number') {
+      model.scale.setScalar(scale);
+    } else {
+      model.scale.setScalar(1);
+    }
+
+    const [rx = 0, ry = 0, rz = 0] = rotation;
+    model.rotation.set(rx, ry, rz);
+    model.position.set(0, 0, 0);
+
+    if (Array.isArray(settings.position)) {
+      const [px = 0, py = 0, pz = 0] = settings.position;
+      model.position.add(new THREE.Vector3(px, py, pz));
+    }
+
+    return this.centerModel(model, settings);
+  }
+
+  centerModel(model, settings) {
+    const initialBox = new THREE.Box3().setFromObject(model);
+    if (settings.autoCenter && !initialBox.isEmpty()) {
+      const center = initialBox.getCenter(new THREE.Vector3());
+      model.position.x -= center.x;
+      model.position.z -= center.z;
+      model.position.y -= initialBox.min.y;
+    }
+
+    if (Array.isArray(settings.offset)) {
+      const [ox = 0, oy = 0, oz = 0] = settings.offset;
+      model.position.add(new THREE.Vector3(ox, oy, oz));
+    }
+
+    const box = new THREE.Box3().setFromObject(model);
+    const size = box.getSize(new THREE.Vector3());
+    const center = box.getCenter(new THREE.Vector3());
+    const sphere = box.getBoundingSphere(new THREE.Sphere());
+    const radius = sphere?.radius && Number.isFinite(sphere.radius)
+      ? sphere.radius
+      : Math.max(size.x, size.y, size.z, 1) * 0.5;
+
+    return { box, size, center, radius };
+  }
+
+  focusModel(settings) {
+    if (!this.controls || !this.camera) return;
+
+    const { metrics } = settings;
+    const radius = Math.max(metrics?.radius ?? 1, 0.5);
+    const target = Array.isArray(settings.focusTarget) ? settings.focusTarget : null;
+
+    if (target) {
+      this.controls.target.set(target[0] ?? 0, target[1] ?? 0, target[2] ?? 0);
+    } else {
+      const targetY = Math.max(metrics.center?.y ?? 0, (metrics.size?.y ?? 1) * 0.5);
+      this.controls.target.set(0, targetY, 0);
+    }
+
+    const distance = this.getCameraDistance(radius, settings);
+    const direction = this.getCameraDirection();
+    const offset = this.arrayToVector(settings.cameraOffset, 0);
+
+    const targetPosition = new THREE.Vector3().copy(this.controls.target);
+    const cameraPosition = targetPosition.add(direction.multiplyScalar(distance)).add(offset);
+    this.camera.position.copy(cameraPosition);
+    this.camera.updateProjectionMatrix();
+
+    const minMultiplier = settings.minDistanceMultiplier ?? 0.65;
+    const maxMultiplier = settings.maxDistanceMultiplier ?? 4.5;
+    this.controls.minDistance = Math.max(radius * minMultiplier, 0.8);
+    this.controls.maxDistance = Math.max(radius * maxMultiplier, this.controls.minDistance + 0.5);
+    this.controls.update();
+  }
+
+  resetCameraTarget(settings = {}) {
+    if (!this.controls) return;
+
+    const target = Array.isArray(settings.focusTarget) ? settings.focusTarget : null;
+    if (target) {
+      this.controls.target.set(target[0] ?? 0, target[1] ?? 0, target[2] ?? 0);
+    } else {
+      this.controls.target.set(0, 0.9, 0);
+    }
+
+    this.controls.minDistance = 1.2;
+    this.controls.maxDistance = 8;
+    this.controls.update();
+  }
+
+  getCameraDistance(radius, settings) {
+    if (typeof settings.cameraDistance === 'number' && Number.isFinite(settings.cameraDistance)) {
+      return Math.max(settings.cameraDistance, 1.2);
+    }
+    const multiplier = settings.cameraDistanceMultiplier ?? 2.8;
+    return Math.max(radius * multiplier, 1.6);
+  }
+
+  getCameraDirection() {
+    if (!this.controls) {
+      return this.cameraDirection.clone();
+    }
+
+    this.cameraDirection
+      .copy(this.camera.position)
+      .sub(this.controls.target)
+      .normalize();
+
+    if (this.cameraDirection.lengthSq() === 0) {
+      this.cameraDirection.set(0, 0, 1);
+    }
+    return this.cameraDirection.clone();
+  }
+
+  arrayToVector(input, defaultValue = 0) {
+    if (!Array.isArray(input)) {
+      return new THREE.Vector3(defaultValue, defaultValue, defaultValue);
+    }
+    const [x = defaultValue, y = defaultValue, z = defaultValue] = input;
+    return new THREE.Vector3(x, y, z);
   }
 
   dispose() {
@@ -204,5 +425,6 @@ export class SceneManager {
       }
     });
     this.renderer?.dispose?.();
+    this.controls?.dispose?.();
   }
 }

--- a/src/data/sampleCritters.js
+++ b/src/data/sampleCritters.js
@@ -1,0 +1,64 @@
+const basePath = 'assets/models/critters';
+
+export const sampleCritters = [
+  {
+    id: 'critter-forest-guardian',
+    name: 'Forest Guardian',
+    modelPath: `${basePath}/forest-guardian.glb`,
+    tags: ['warden', 'druidic', 'ancient'],
+    preview: {
+      scale: 1.2,
+      rotation: [0, Math.PI, 0],
+      autoCenter: true,
+      cameraDistanceMultiplier: 2.4,
+    },
+  },
+  {
+    id: 'critter-ember-fawn',
+    name: 'Ember Fawn',
+    modelPath: `${basePath}/ember-fawn.glb`,
+    tags: ['quadruped', 'fire', 'swift'],
+    preview: {
+      scale: 1.4,
+      rotation: [0, Math.PI, 0],
+      autoCenter: true,
+      cameraDistanceMultiplier: 2.8,
+    },
+  },
+  {
+    id: 'critter-tide-sage',
+    name: 'Tide Sage',
+    modelPath: `${basePath}/tide-sage.glb`,
+    tags: ['mystic', 'water', 'sage'],
+    preview: {
+      scale: 1.1,
+      rotation: [0, Math.PI, 0],
+      autoCenter: true,
+      cameraDistanceMultiplier: 2.3,
+    },
+  },
+  {
+    id: 'critter-sky-runner',
+    name: 'Sky Runner',
+    modelPath: `${basePath}/sky-runner.glb`,
+    tags: ['aviator', 'agile', 'winged'],
+    preview: {
+      scale: 1.15,
+      rotation: [0, Math.PI, 0],
+      autoCenter: true,
+      cameraDistanceMultiplier: 2.6,
+    },
+  },
+  {
+    id: 'critter-cavern-brute',
+    name: 'Cavern Brute',
+    modelPath: `${basePath}/cavern-brute.glb`,
+    tags: ['tank', 'stone', 'bruiser'],
+    preview: {
+      scale: 1.05,
+      rotation: [0, Math.PI, 0],
+      autoCenter: true,
+      cameraDistanceMultiplier: 3.1,
+    },
+  },
+];

--- a/src/hud/CritterController.js
+++ b/src/hud/CritterController.js
@@ -1,0 +1,185 @@
+export class CritterController {
+  constructor({ bus, containerElement }) {
+    this.bus = bus;
+    this.container = containerElement;
+
+    this.searchInput = null;
+    this.selectElement = null;
+    this.spinToggle = null;
+
+    this.allCritters = [];
+    this.filteredCritters = [];
+    this.activeCritterId = null;
+    this.autoRotateEnabled = true;
+    this.suppressEmit = false;
+  }
+
+  init({ critters = [], defaultCritterId = null, autoRotateDefault = true } = {}) {
+    if (!this.container) {
+      console.warn('Critter selector container is missing.');
+      return;
+    }
+
+    this.setCritters(critters);
+    this.bindDomReferences();
+    if (!this.selectElement || !this.spinToggle) {
+      console.warn('Critter selector requires select and toggle elements.');
+      return;
+    }
+
+    this.autoRotateEnabled = Boolean(autoRotateDefault);
+    this.spinToggle.checked = this.autoRotateEnabled;
+
+    this.registerDomListeners();
+
+    this.suppressEmit = true;
+    this.activeCritterId = this.resolveInitialCritterId(defaultCritterId);
+    this.renderCritterOptions();
+    this.suppressEmit = false;
+
+    this.bus.emit('hud:auto-rotate-changed', this.autoRotateEnabled);
+  }
+
+  setCritters(critters = []) {
+    this.allCritters = [...critters]
+      .map((critter) => ({
+        ...critter,
+        _searchLabel: [
+          critter.name,
+          critter.subtitle || '',
+          ...(critter.tags || []),
+        ]
+          .join(' ')
+          .toLowerCase(),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    this.filteredCritters = [...this.allCritters];
+  }
+
+  bindDomReferences() {
+    this.searchInput = this.container.querySelector('[data-role="critter-search"]');
+    this.selectElement = this.container.querySelector('[data-role="critter-select"]');
+    this.spinToggle = this.container.querySelector('[data-role="critter-spin"]');
+  }
+
+  registerDomListeners() {
+    if (this.searchInput) {
+      this.searchInput.addEventListener('input', () => this.handleSearchInput());
+      this.searchInput.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          const firstId = this.filteredCritters[0]?.id;
+          if (firstId) {
+            this.setActiveCritter(firstId, { emit: true });
+          }
+        }
+      });
+    }
+
+    this.selectElement.addEventListener('change', () => this.handleSelectionChange());
+    this.selectElement.addEventListener('dblclick', () => this.handleSelectionChange());
+    this.selectElement.addEventListener('keyup', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        this.handleSelectionChange();
+      }
+    });
+
+    this.spinToggle.addEventListener('change', () => this.handleSpinToggle());
+  }
+
+  resolveInitialCritterId(defaultCritterId) {
+    if (defaultCritterId && this.allCritters.some((critter) => critter.id === defaultCritterId)) {
+      return defaultCritterId;
+    }
+    return this.filteredCritters[0]?.id ?? null;
+  }
+
+  handleSearchInput() {
+    const query = (this.searchInput?.value || '').trim().toLowerCase();
+    if (!query) {
+      this.filteredCritters = [...this.allCritters];
+    } else {
+      this.filteredCritters = this.allCritters.filter((critter) =>
+        critter._searchLabel.includes(query),
+      );
+    }
+    this.renderCritterOptions();
+  }
+
+  handleSelectionChange() {
+    const critterId = this.selectElement.value;
+    if (!critterId) return;
+    this.setActiveCritter(critterId, { emit: true });
+  }
+
+  handleSpinToggle() {
+    this.autoRotateEnabled = this.spinToggle.checked;
+    this.bus.emit('hud:auto-rotate-changed', this.autoRotateEnabled);
+  }
+
+  renderCritterOptions() {
+    if (!this.selectElement) return;
+
+    const previousId = this.activeCritterId;
+
+    this.selectElement.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+
+    if (this.filteredCritters.length === 0) {
+      const option = document.createElement('option');
+      option.textContent = 'No critters found';
+      option.disabled = true;
+      fragment.appendChild(option);
+      this.selectElement.appendChild(fragment);
+      this.selectElement.disabled = true;
+      this.selectElement.value = '';
+      return;
+    }
+
+    this.filteredCritters.forEach((critter) => {
+      const option = document.createElement('option');
+      option.value = critter.id;
+      option.textContent = critter.name;
+      option.dataset.critterId = critter.id;
+      fragment.appendChild(option);
+    });
+
+    this.selectElement.appendChild(fragment);
+    this.selectElement.disabled = false;
+
+    const hasPrevious = this.filteredCritters.some((critter) => critter.id === previousId);
+    if (hasPrevious) {
+      this.selectElement.value = previousId;
+    } else {
+      const nextId = this.filteredCritters[0]?.id ?? null;
+      if (nextId) {
+        this.selectElement.value = nextId;
+        this.setActiveCritter(nextId, { emit: true });
+      }
+    }
+  }
+
+  setActiveCritter(critterId, { emit = true } = {}) {
+    if (!critterId) {
+      this.activeCritterId = null;
+      if (emit && !this.suppressEmit) {
+        this.bus.emit('hud:critter-selected', null);
+      }
+      return;
+    }
+
+    if (critterId === this.activeCritterId) {
+      return;
+    }
+
+    this.activeCritterId = critterId;
+    if (this.selectElement && this.selectElement.value !== critterId) {
+      this.selectElement.value = critterId;
+    }
+
+    if (emit && !this.suppressEmit) {
+      this.bus.emit('hud:critter-selected', critterId);
+    }
+  }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -142,6 +142,147 @@ body::after {
   color: var(--color-highlight);
 }
 
+.critter-selector {
+  position: relative;
+  padding: 1rem 1.1rem 1.15rem;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(46, 88, 64, 0.38);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  overflow: hidden;
+}
+
+.critter-selector::before {
+  content: '';
+  position: absolute;
+  inset: -30% -20% 55% -25%;
+  background: radial-gradient(circle at 42% 32%, rgba(124, 200, 111, 0.35), transparent 65%);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.critter-selector > * {
+  position: relative;
+  z-index: 1;
+}
+
+.critter-selector .selector-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-family: var(--font-display);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-size: 0.88rem;
+  color: var(--color-highlight);
+}
+
+.critter-selector .selector-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.critter-selector input[type='search'] {
+  width: 100%;
+  padding: 0.6rem 0.85rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(32, 64, 48, 0.55);
+  color: var(--color-text-primary);
+  font-size: 0.9rem;
+  font-family: var(--font-body);
+  outline: none;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.critter-selector input[type='search']::placeholder {
+  color: rgba(243, 248, 240, 0.5);
+}
+
+.critter-selector input[type='search']:focus-visible {
+  border-color: rgba(124, 200, 111, 0.65);
+  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.22);
+}
+
+.critter-selector select {
+  width: 100%;
+  min-height: 160px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(28, 56, 40, 0.6);
+  color: var(--color-text-secondary);
+  font-family: var(--font-body);
+  font-size: 0.92rem;
+  padding: 0.45rem 0.35rem;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.critter-selector select:focus-visible {
+  border-color: rgba(124, 200, 111, 0.65);
+  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.22);
+}
+
+.critter-selector option {
+  padding: 0.4rem 0.5rem;
+  background: rgba(32, 62, 46, 0.75);
+}
+
+.critter-selector option:checked {
+  background: rgba(124, 200, 111, 0.35);
+  color: var(--color-text-primary);
+}
+
+.spin-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.72);
+  cursor: pointer;
+}
+
+.spin-toggle input[type='checkbox'] {
+  appearance: none;
+  width: 38px;
+  height: 20px;
+  border-radius: 999px;
+  background: rgba(124, 200, 111, 0.28);
+  border: 1px solid rgba(124, 200, 111, 0.3);
+  position: relative;
+  transition: background 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+}
+
+.spin-toggle input[type='checkbox']::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-text-primary);
+  transform: translate(0, -50%);
+  transition: transform 0.2s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.28);
+}
+
+.spin-toggle input[type='checkbox']:checked {
+  background: rgba(124, 200, 111, 0.6);
+  border-color: rgba(124, 200, 111, 0.75);
+}
+
+.spin-toggle input[type='checkbox']:checked::after {
+  transform: translate(16px, -50%);
+}
+
 .nav-tabs {
   list-style: none;
   margin: 0;
@@ -582,8 +723,9 @@ dl dt {
     grid-column: 1;
     grid-row: 2;
     flex-direction: row;
-    align-items: center;
+    align-items: stretch;
     gap: 1.1rem;
+    flex-wrap: wrap;
   }
 
   .hud-nav h2 {
@@ -602,6 +744,11 @@ dl dt {
   .nav-tabs button {
     font-size: 0.85rem;
     padding: 0.75rem 0.9rem;
+  }
+
+  .critter-selector {
+    flex: 1 1 240px;
+    min-width: 220px;
   }
 
   .hud-list {
@@ -632,6 +779,10 @@ dl dt {
 
   .nav-tabs li {
     flex: 1 1 calc(50% - 0.5rem);
+  }
+
+  .critter-selector {
+    width: 100%;
   }
 
   .stage {


### PR DESCRIPTION
## Summary
- add a critter selector with search and an auto-spin toggle above the category navigation
- extend the scene manager with orbit controls and critter loading support, plus sample critter data
- refresh styling to accommodate the new selector

## Testing
- no automated tests (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8eaac5b7883298f1de92a8b5afc9e