### PR TITLE
Refresh UI with natural styling

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -54,7 +54,13 @@ export class WeaponDisplayApp {
   buildLayout() {
     this.root.innerHTML = `
       <div class="app-shell">
-        <div class="hud-brand">Crtiz Armory</div>
+        <div class="hud-brand">
+          <span class="hud-brand__icon" aria-hidden="true"></span>
+          <div class="hud-brand__text" aria-label="Crtiz Armory">
+            <span class="hud-brand__title">Crtiz Armory</span>
+            <span class="hud-brand__tagline">Fieldcrafted Arsenal</span>
+          </div>
+        </div>
         <nav class="hud-nav" aria-label="Weapon categories">
           <h2>Categories</h2>
           <ul class="nav-tabs" data-component="nav-tabs"></ul>

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -3,11 +3,11 @@ import { createRenderer } from './RendererFactory.js';
 import { ResourceLoader } from './ResourceLoader.js';
 
 const RARITY_GLOWS = {
-  common: 0x7c6cff,
-  rare: 0x7df0ff,
-  epic: 0xff9af5,
-  legendary: 0xffe37d,
-  mythic: 0xffb7ff,
+  common: 0x8ebd85,
+  rare: 0x6ed4d1,
+  epic: 0xb7a7f1,
+  legendary: 0xf3c978,
+  mythic: 0xe5f3b8,
 };
 
 export class SceneManager {
@@ -72,24 +72,25 @@ export class SceneManager {
   }
 
   setupLights() {
-    const ambient = new THREE.AmbientLight(0xffe6ff, 0.4);
-    const rimLight = new THREE.DirectionalLight(0xa7c9ff, 1.15);
-    rimLight.position.set(-3, 4, 2);
-    const fillLight = new THREE.SpotLight(0xffc3f7, 1.25, 20, Math.PI / 4, 0.85, 2);
-    fillLight.position.set(2.6, 3.8, 1.4);
-    const bounceLight = new THREE.PointLight(0x8cf5ff, 0.6, 6, 2);
-    bounceLight.position.set(0, 1.2, 0.8);
+    const ambient = new THREE.AmbientLight(0xe6f7e8, 0.55);
+    const rimLight = new THREE.DirectionalLight(0xf1d8aa, 0.68);
+    rimLight.position.set(-3.2, 4.4, 2.2);
+    const fillLight = new THREE.SpotLight(0x8ccfb6, 1.1, 20, Math.PI / 4, 0.85, 2);
+    fillLight.position.set(2.4, 3.6, 1.6);
+    const bounceLight = new THREE.PointLight(0xa9f2c3, 0.62, 7, 2);
+    bounceLight.position.set(0.1, 1.1, 1.1);
+    const canopyLight = new THREE.HemisphereLight(0xcfead9, 0x112218, 0.42);
 
-    this.scene.add(ambient, rimLight, fillLight, bounceLight);
+    this.scene.add(ambient, canopyLight, rimLight, fillLight, bounceLight);
   }
 
   setupEnvironment() {
     const platformGeometry = new THREE.CylinderGeometry(1.45, 1.45, 0.12, 48, 1, true);
     const platformMaterial = new THREE.MeshStandardMaterial({
-      color: 0x20153f,
-      emissive: 0x0c0620,
-      metalness: 0.28,
-      roughness: 0.62,
+      color: 0x2a3a2f,
+      emissive: 0x122217,
+      metalness: 0.18,
+      roughness: 0.64,
       transparent: true,
       opacity: 0.95,
     });
@@ -100,9 +101,9 @@ export class SceneManager {
 
     const ringGeometry = new THREE.TorusGeometry(1.55, 0.035, 16, 100);
     const ringMaterial = new THREE.MeshBasicMaterial({
-      color: 0xff9de6,
+      color: 0x9ad5b2,
       transparent: true,
-      opacity: 0.65,
+      opacity: 0.55,
     });
     this.glowRing = new THREE.Mesh(ringGeometry, ringMaterial);
     this.glowRing.rotation.x = Math.PI / 2;
@@ -171,11 +172,11 @@ export class SceneManager {
   createPlaceholderModel() {
     const geometry = new THREE.TorusKnotGeometry(0.65, 0.18, 128, 16);
     const material = new THREE.MeshStandardMaterial({
-      color: 0xff9dce,
-      emissive: 0x2b0f35,
-      metalness: 0.28,
-      roughness: 0.28,
-      emissiveIntensity: 0.6,
+      color: 0xa8e4c1,
+      emissive: 0x1f3a29,
+      metalness: 0.2,
+      roughness: 0.32,
+      emissiveIntensity: 0.55,
     });
     const mesh = new THREE.Mesh(geometry, material);
     mesh.castShadow = false;

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,21 +1,24 @@
 :root {
-  --color-bg: #0f1f17;
-  --color-bg-alt: #142e20;
-  --color-canopy: #1f3d2c;
-  --color-panel: rgba(26, 58, 41, 0.9);
-  --color-panel-border: rgba(169, 213, 179, 0.38);
-  --color-panel-highlight: rgba(116, 182, 139, 0.4);
-  --color-accent: #7cc86f;
-  --color-accent-soft: rgba(124, 200, 111, 0.2);
-  --color-earth: #b78044;
-  --color-water: #5aa9c9;
-  --color-highlight: #d3f36b;
+  --color-bg: #07140d;
+  --color-bg-alt: #102219;
+  --color-canopy: #1a3424;
+  --color-panel: rgba(18, 32, 25, 0.88);
+  --color-panel-border: rgba(152, 199, 167, 0.32);
+  --color-panel-highlight: rgba(143, 209, 138, 0.32);
+  --color-accent: #8fd18a;
+  --color-accent-soft: rgba(143, 209, 138, 0.2);
+  --color-earth: #d6a364;
+  --color-water: #7bb9c4;
+  --color-highlight: #e3f7b2;
   --color-text-primary: #f3f8f0;
-  --color-text-secondary: rgba(243, 248, 240, 0.82);
+  --color-text-secondary: rgba(237, 245, 236, 0.85);
   --font-display: 'Lilita One', cursive;
   --font-body: 'Nunito', sans-serif;
-  --shadow-soft: 0 24px 60px rgba(8, 22, 16, 0.55);
-  --border-radius-lg: 20px;
+  --shadow-soft: 0 32px 80px rgba(6, 18, 12, 0.6);
+  --shadow-lift: 0 16px 30px rgba(4, 12, 8, 0.45);
+  --border-radius-lg: 22px;
+  --border-radius-xl: 30px;
+  --transition-base: 200ms ease;
 }
 
 * {
@@ -32,7 +35,14 @@ body {
   font-family: var(--font-body);
   letter-spacing: 0.01em;
   color: var(--color-text-primary);
-  background: linear-gradient(135deg, #0d1f17 0%, #143524 55%, #102330 100%);
+  background:
+    radial-gradient(circle at 16% 18%, rgba(255, 211, 137, 0.16), transparent 60%),
+    radial-gradient(circle at 82% 12%, rgba(122, 184, 198, 0.16), transparent 62%),
+    linear-gradient(140deg, var(--color-bg) 0%, var(--color-canopy) 48%, #0b1a13 100%);
+  min-height: 100%;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
   overflow: hidden;
   position: relative;
 }
@@ -46,43 +56,83 @@ body::after {
 }
 
 body::before {
-  background: radial-gradient(circle at 18% 26%, rgba(124, 200, 111, 0.16), transparent 55%),
-    radial-gradient(circle at 78% 18%, rgba(90, 169, 201, 0.18), transparent 60%),
-    radial-gradient(circle at 48% 78%, rgba(179, 128, 68, 0.12), transparent 62%);
+  background:
+    radial-gradient(circle at 12% 24%, rgba(226, 244, 205, 0.2), transparent 56%),
+    radial-gradient(circle at 74% 24%, rgba(107, 183, 164, 0.18), transparent 60%);
   mix-blend-mode: screen;
-  opacity: 0.6;
+  opacity: 0.65;
 }
 
 body::after {
-  background: radial-gradient(circle at 14% 82%, rgba(16, 63, 42, 0.35), transparent 70%),
-    linear-gradient(120deg, rgba(12, 42, 31, 0.35), transparent 65%),
-    linear-gradient(300deg, rgba(21, 52, 67, 0.3), transparent 55%);
+  background:
+    radial-gradient(circle at 14% 82%, rgba(12, 32, 21, 0.45), transparent 70%),
+    linear-gradient(120deg, rgba(10, 30, 20, 0.4), transparent 65%),
+    linear-gradient(310deg, rgba(17, 38, 45, 0.35), transparent 55%);
   opacity: 0.55;
 }
 
 #app {
+  flex: 1;
   height: 100%;
-  width: 100%;
   display: flex;
   align-items: stretch;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
   position: relative;
   z-index: 1;
+  min-height: 0;
 }
 
 .app-shell {
-  width: 100%;
-  height: 100%;
+  width: min(1280px, 100%);
   display: grid;
   grid-template-columns: 180px 320px minmax(320px, 1fr) minmax(240px, 28vw);
   grid-template-rows: auto minmax(0, 1fr);
-  gap: 1.5rem;
-  padding: 2.25rem 2.75rem;
+  gap: 1.65rem;
+  padding: clamp(2rem, 3vw + 1rem, 3rem);
   position: relative;
   align-items: stretch;
+  border-radius: var(--border-radius-xl);
+  background: linear-gradient(160deg, rgba(16, 30, 23, 0.92), rgba(10, 23, 17, 0.85));
+  border: 1px solid rgba(150, 198, 164, 0.28);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(28px);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.app-shell::before,
+.app-shell::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.app-shell::before {
+  inset: -20% 48% 56% -18%;
+  background: radial-gradient(circle at 30% 32%, rgba(226, 244, 205, 0.35), transparent 70%);
+  opacity: 0.65;
+  filter: blur(0.4px);
+}
+
+.app-shell::after {
+  width: 360px;
+  height: 360px;
+  top: 16%;
+  right: -140px;
+  background:
+    radial-gradient(circle at 52% 25%, rgba(135, 198, 157, 0.28), transparent 70%),
+    radial-gradient(circle at 40% 72%, rgba(209, 176, 116, 0.22), transparent 74%);
+  transform: rotate(-14deg);
+  opacity: 0.4;
+  filter: blur(0.4px);
+  animation: canopySway 14s ease-in-out infinite;
 }
 
 .app-shell > * {
   min-height: 0;
+  position: relative;
+  z-index: 1;
 }
 
 .hud-brand {
@@ -91,55 +141,98 @@ body::after {
   align-self: end;
   display: flex;
   align-items: center;
-  gap: 0.85rem;
+  gap: 1.25rem;
   font-family: var(--font-display);
-  font-size: 1.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-highlight);
-  text-shadow: 0 0 18px rgba(124, 200, 111, 0.45);
 }
 
-.hud-brand::before {
+.hud-brand__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px 22px 18px 22px;
+  border: 2px solid rgba(227, 247, 178, 0.7);
+  background: linear-gradient(135deg, rgba(143, 209, 138, 0.32), rgba(122, 184, 198, 0.42));
+  box-shadow: 0 0 28px rgba(143, 209, 138, 0.5);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.hud-brand__icon::after {
   content: '';
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
-  border: 2px solid rgba(211, 243, 107, 0.6);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.25), rgba(90, 169, 201, 0.4));
-  box-shadow: 0 0 22px rgba(124, 200, 111, 0.35);
+  width: 72%;
+  height: 72%;
+  border-radius: 42% 58% 38% 62%;
+  background: radial-gradient(circle at 32% 32%, rgba(227, 247, 178, 0.9), rgba(143, 209, 138, 0.55));
+  filter: blur(0.3px);
+  transform: rotate(-14deg);
+}
+
+.hud-brand__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.hud-brand__title {
+  font-size: 1.85rem;
+  letter-spacing: 0.2em;
+  text-shadow: 0 0 20px rgba(143, 209, 138, 0.45);
+}
+
+.hud-brand__tagline {
+  font-family: var(--font-body);
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  color: rgba(226, 244, 205, 0.78);
+  margin-left: 0.08rem;
 }
 
 .hud-nav {
   grid-column: 1;
   grid-row: 2;
-  background: var(--color-panel);
-  border: 1px solid var(--color-panel-border);
+  background: linear-gradient(180deg, rgba(20, 38, 28, 0.92), rgba(14, 30, 22, 0.85));
+  border: 1px solid rgba(152, 199, 167, 0.32);
   border-radius: var(--border-radius-lg);
-  padding: 1.6rem 1.25rem;
+  padding: 1.8rem 1.35rem;
   display: flex;
   flex-direction: column;
-  gap: 1.35rem;
+  gap: 1.5rem;
   position: relative;
   overflow: hidden;
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-lift);
+  backdrop-filter: blur(18px);
 }
 
 .hud-nav::before {
   content: '';
   position: absolute;
-  inset: -25% -40% 55% -40%;
-  background: radial-gradient(circle at 50% 38%, var(--color-panel-highlight), transparent 58%);
-  opacity: 0.4;
+  inset: -30% -34% 52% -34%;
+  background: radial-gradient(circle at 50% 38%, rgba(143, 209, 138, 0.38), transparent 60%);
+  opacity: 0.45;
+}
+
+.hud-nav::after {
+  content: '';
+  position: absolute;
+  inset: 58% -40% -20% -40%;
+  background: radial-gradient(circle at 40% 70%, rgba(209, 176, 116, 0.22), transparent 70%);
+  opacity: 0.35;
 }
 
 .hud-nav h2 {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 1rem;
-  letter-spacing: 0.14em;
+  font-size: 0.96rem;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--color-highlight);
+  text-shadow: 0 0 14px rgba(143, 209, 138, 0.4);
 }
 
 .nav-tabs {
@@ -148,7 +241,7 @@ body::after {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 1rem;
 }
 
 .nav-tabs li {
@@ -157,36 +250,55 @@ body::after {
 
 .nav-tabs button {
   width: 100%;
-  padding: 0.9rem 1rem;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(61, 102, 76, 0.35);
+  padding: 0.95rem 1.1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(227, 247, 178, 0.12);
+  background: linear-gradient(155deg, rgba(34, 60, 44, 0.78), rgba(20, 42, 32, 0.75));
   color: var(--color-text-secondary);
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   font-family: var(--font-display);
-  letter-spacing: 0.1em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    border-color var(--transition-base), color var(--transition-base);
   position: relative;
   overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  text-shadow: 0 0 8px rgba(143, 209, 138, 0.28);
+  backdrop-filter: blur(6px);
+}
+
+.nav-tabs button::before {
+  content: '';
+  width: 0.55rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
+  border-radius: 55% 45% 60% 40%;
+  background: linear-gradient(120deg, rgba(227, 247, 178, 0.85), rgba(143, 209, 138, 0.65));
+  box-shadow: 0 0 10px rgba(143, 209, 138, 0.35);
+  transform: rotate(-16deg);
 }
 
 .nav-tabs button::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
+  background: linear-gradient(135deg, rgba(227, 247, 178, 0.2), transparent 65%);
   opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: opacity var(--transition-base);
+  pointer-events: none;
 }
 
 .nav-tabs button:hover,
 .nav-tabs button:focus-visible {
-  border-color: rgba(124, 200, 111, 0.6);
+  border-color: rgba(227, 247, 178, 0.55);
   color: var(--color-text-primary);
-  transform: translateY(-1px);
-  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(9, 26, 18, 0.45);
   outline: none;
 }
 
@@ -195,10 +307,19 @@ body::after {
   opacity: 1;
 }
 
+.nav-tabs button:focus-visible {
+  box-shadow: 0 0 0 2px rgba(227, 247, 178, 0.45), 0 16px 32px rgba(9, 26, 18, 0.45);
+}
+
 .nav-tabs button.active {
-  border-color: rgba(211, 243, 107, 0.75);
+  border-color: rgba(227, 247, 178, 0.75);
+  background: linear-gradient(150deg, rgba(143, 209, 138, 0.45), rgba(122, 184, 198, 0.32));
   color: var(--color-text-primary);
-  box-shadow: 0 14px 32px rgba(20, 52, 36, 0.45);
+  box-shadow: 0 18px 34px rgba(9, 26, 18, 0.5);
+}
+
+.nav-tabs button.active::before {
+  background: linear-gradient(120deg, rgba(227, 247, 178, 0.95), rgba(143, 209, 138, 0.75));
 }
 
 .nav-tabs button.active::after {
@@ -206,24 +327,25 @@ body::after {
 }
 
 .panel {
-  background: linear-gradient(165deg, rgba(33, 71, 51, 0.92), rgba(23, 50, 35, 0.92));
-  border: 1px solid var(--color-panel-border);
+  background: linear-gradient(170deg, rgba(20, 37, 29, 0.92), rgba(14, 28, 21, 0.88));
+  border: 1px solid rgba(152, 199, 167, 0.28);
   border-radius: var(--border-radius-lg);
-  padding: 1.6rem 1.75rem;
+  padding: 1.8rem 1.9rem;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
+  gap: 1.15rem;
   position: relative;
   overflow: hidden;
   min-height: 0;
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-lift);
+  backdrop-filter: blur(22px);
 }
 
 .panel::before {
   content: '';
   position: absolute;
-  inset: -20% -35% 65% -25%;
-  background: radial-gradient(circle at 32% 24%, rgba(124, 200, 111, 0.25), transparent 60%);
+  inset: -24% -36% 62% -28%;
+  background: radial-gradient(circle at 26% 30%, rgba(143, 209, 138, 0.35), transparent 65%);
   opacity: 0.55;
   pointer-events: none;
 }
@@ -231,8 +353,8 @@ body::after {
 .panel::after {
   content: '';
   position: absolute;
-  inset: 60% -30% -25% -20%;
-  background: radial-gradient(circle at 70% 80%, rgba(90, 169, 201, 0.18), transparent 60%);
+  inset: 58% -32% -24% -18%;
+  background: radial-gradient(circle at 72% 82%, rgba(209, 176, 116, 0.22), transparent 70%);
   opacity: 0.4;
   pointer-events: none;
 }
@@ -261,112 +383,165 @@ body::after {
   align-items: flex-end;
   justify-content: space-between;
   font-family: var(--font-display);
-  letter-spacing: 0.14em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  font-size: 0.95rem;
+  font-size: 0.96rem;
   color: var(--color-highlight);
   gap: 1rem;
+  position: relative;
+  padding-bottom: 0.35rem;
+}
+
+.panel-header::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -0.35rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(227, 247, 178, 0.45), transparent 85%);
+  opacity: 0.7;
 }
 
 .panel-header [data-role='list-context'] {
   font-size: 0.85rem;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--color-water);
+  color: rgba(122, 184, 198, 0.85);
 }
 
 .weapon-cards {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 1rem;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding-right: 0.35rem;
+  padding-right: 0.45rem;
 }
 
 .weapon-card {
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 18px;
-  padding: 1rem 1.2rem;
-  background: rgba(46, 88, 64, 0.4);
+  border: 1px solid rgba(152, 199, 167, 0.18);
+  border-radius: 20px;
+  padding: 1.1rem 1.25rem;
+  background: linear-gradient(160deg, rgba(32, 58, 44, 0.58), rgba(22, 42, 32, 0.72));
   color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all 0.18s ease;
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    border-color var(--transition-base), background var(--transition-base),
+    color var(--transition-base);
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow: inset 0 1px 0 rgba(227, 247, 178, 0.1), 0 20px 32px rgba(5, 15, 11, 0.45);
+}
+
+.weapon-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(130deg, rgba(227, 247, 178, 0.16), transparent 65%);
+  opacity: 0;
+  transition: opacity var(--transition-base);
+  pointer-events: none;
 }
 
 .weapon-card:hover,
 .weapon-card:focus-visible {
-  border-color: rgba(124, 200, 111, 0.55);
-  box-shadow: 0 12px 26px rgba(16, 45, 31, 0.35);
-  background: rgba(46, 88, 64, 0.55);
+  border-color: rgba(227, 247, 178, 0.55);
+  box-shadow: 0 22px 40px rgba(9, 26, 18, 0.48);
+  background: linear-gradient(155deg, rgba(44, 74, 56, 0.78), rgba(26, 48, 35, 0.82));
   outline: none;
   color: var(--color-text-primary);
+  transform: translateY(-2px);
+}
+
+.weapon-card:hover::after,
+.weapon-card:focus-visible::after {
+  opacity: 1;
 }
 
 .weapon-card.active {
-  border-color: rgba(211, 243, 107, 0.75);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.38), rgba(90, 169, 201, 0.28));
+  border-color: rgba(227, 247, 178, 0.75);
+  background: linear-gradient(150deg, rgba(143, 209, 138, 0.42), rgba(122, 184, 198, 0.28));
   color: var(--color-text-primary);
-  box-shadow: 0 14px 30px rgba(17, 46, 33, 0.45);
+  box-shadow: 0 26px 48px rgba(9, 26, 18, 0.5);
+}
+
+.weapon-card.active::after {
+  opacity: 1;
 }
 
 .weapon-card h3 {
-  margin: 0 0 0.4rem;
+  margin: 0 0 0.5rem;
   font-size: 1.1rem;
   color: var(--color-text-primary);
   font-family: var(--font-display);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
 }
 
 .weapon-card dl {
   margin: 0;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.3rem 0.6rem;
-  font-size: 0.8rem;
+  gap: 0.35rem 0.8rem;
+  font-size: 0.82rem;
+  color: rgba(231, 240, 232, 0.85);
 }
 
 dl dt {
-  opacity: 0.7;
+  opacity: 0.75;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+dl dd {
+  margin: 0;
+  color: var(--color-text-primary);
 }
 
 .detail-content {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
+  gap: 1.2rem;
   min-height: 0;
   overflow-y: auto;
-  padding-right: 0.4rem;
+  padding-right: 0.45rem;
 }
 
 .detail-content h3 {
   margin: 0;
-  font-size: 1.4rem;
+  font-size: 1.5rem;
   font-family: var(--font-display);
-  letter-spacing: 0.16em;
+  letter-spacing: 0.18em;
   color: var(--color-text-primary);
+  text-shadow: 0 0 18px rgba(143, 209, 138, 0.35);
 }
 
 .description {
   margin: 0;
-  font-size: 0.92rem;
-  line-height: 1.7;
+  font-size: 0.94rem;
+  line-height: 1.75;
   color: var(--color-text-secondary);
 }
 
 .stat-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.1rem 1.4rem;
   font-size: 0.9rem;
 }
 
 .stat-grid .stat {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem 1.05rem;
+  border-radius: 18px;
+  border: 1px solid rgba(152, 199, 167, 0.2);
+  background: linear-gradient(150deg, rgba(31, 56, 41, 0.65), rgba(20, 38, 30, 0.72));
+  box-shadow: inset 0 1px 0 rgba(227, 247, 178, 0.08), 0 18px 30px rgba(5, 14, 10, 0.35);
 }
 
 .stat-bar-header {
@@ -377,10 +552,10 @@ dl dt {
 }
 
 .stat-label {
-  font-size: 0.75rem;
-  letter-spacing: 0.14em;
+  font-size: 0.74rem;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.72);
+  color: rgba(233, 244, 231, 0.75);
 }
 
 .stat-bar-value {
@@ -391,7 +566,7 @@ dl dt {
 }
 
 .stat-bar-value.is-missing {
-  color: rgba(243, 248, 240, 0.45);
+  color: rgba(233, 244, 231, 0.45);
   font-style: italic;
   font-weight: 500;
 }
@@ -399,18 +574,18 @@ dl dt {
 .stat-bar-track {
   position: relative;
   height: 0.75rem;
-  background: rgba(124, 200, 111, 0.15);
+  background: rgba(143, 209, 138, 0.18);
   border-radius: 999px;
   overflow: hidden;
-  border: 1px solid rgba(124, 200, 111, 0.35);
-  box-shadow: inset 0 0 18px rgba(6, 18, 12, 0.6);
+  border: 1px solid rgba(143, 209, 138, 0.4);
+  box-shadow: inset 0 0 20px rgba(5, 18, 12, 0.7);
 }
 
 .stat-bar-track::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 15% 50%, rgba(243, 248, 240, 0.25), transparent 65%);
+  background: radial-gradient(circle at 15% 50%, rgba(243, 248, 240, 0.28), transparent 65%);
   opacity: 0.45;
 }
 
@@ -419,8 +594,8 @@ dl dt {
   position: absolute;
   inset: 0;
   width: calc(var(--fill, 0) * 1%);
-  background: linear-gradient(90deg, rgba(124, 200, 111, 0.85), rgba(211, 243, 107, 0.95));
-  box-shadow: 0 0 18px rgba(124, 200, 111, 0.55);
+  background: linear-gradient(90deg, rgba(143, 209, 138, 0.9), rgba(227, 247, 178, 0.95));
+  box-shadow: 0 0 18px rgba(143, 209, 138, 0.55);
   transition: width 220ms ease-out;
 }
 
@@ -433,8 +608,9 @@ dl dt {
 }
 
 .special-section {
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  padding-top: 0.9rem;
+  border-top: 1px solid rgba(227, 247, 178, 0.18);
+  padding-top: 1.1rem;
+  margin-top: 0.25rem;
 }
 
 .special-section h4 {
@@ -443,19 +619,36 @@ dl dt {
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--color-highlight);
+  text-shadow: 0 0 12px rgba(143, 209, 138, 0.35);
 }
 
 .special-list {
   margin: 0;
-  padding-left: 1rem;
-  list-style: square;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.65rem;
   font-size: 0.9rem;
   color: var(--color-text-secondary);
   line-height: 1.65;
 }
 
-.special-list li + li {
-  margin-top: 0.5rem;
+.special-list li {
+  position: relative;
+  padding-left: 1.4rem;
+}
+
+.special-list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.35rem;
+  width: 0.6rem;
+  height: 1rem;
+  border-radius: 55% 45% 60% 40%;
+  background: linear-gradient(120deg, rgba(143, 209, 138, 0.85), rgba(122, 184, 198, 0.6));
+  box-shadow: 0 0 8px rgba(143, 209, 138, 0.4);
+  transform: rotate(-20deg);
 }
 
 .special-key {
@@ -465,15 +658,16 @@ dl dt {
 
 .panel-footer {
   font-size: 0.78rem;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.65);
+  color: rgba(231, 240, 232, 0.7);
+  text-shadow: 0 0 10px rgba(143, 209, 138, 0.2);
 }
 
 .weapon-cards,
 .detail-content {
   scrollbar-width: thin;
-  scrollbar-color: rgba(90, 169, 201, 0.55) transparent;
+  scrollbar-color: rgba(122, 184, 198, 0.55) transparent;
 }
 
 .weapon-cards::-webkit-scrollbar,
@@ -488,7 +682,7 @@ dl dt {
 
 .weapon-cards::-webkit-scrollbar-thumb,
 .detail-content::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(90, 169, 201, 0.65), rgba(124, 200, 111, 0.55));
+  background: linear-gradient(180deg, rgba(122, 184, 198, 0.65), rgba(143, 209, 138, 0.55));
   border-radius: 6px;
 }
 
@@ -496,72 +690,74 @@ dl dt {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.4rem 1rem;
+  padding: 0.45rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid rgba(211, 243, 107, 0.6);
+  border: 1px solid rgba(227, 247, 178, 0.5);
   font-size: 0.75rem;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
   color: var(--color-highlight);
-  background: rgba(90, 169, 201, 0.18);
-  min-width: 128px;
+  background: linear-gradient(120deg, rgba(143, 209, 138, 0.24), rgba(122, 184, 198, 0.22));
+  min-width: 138px;
   text-align: center;
+  box-shadow: inset 0 1px 0 rgba(227, 247, 178, 0.35);
 }
 
 .rarity-badge.rarity-common {
-  border-color: rgba(118, 158, 125, 0.55);
-  color: rgba(236, 243, 230, 0.92);
-  background: rgba(118, 158, 125, 0.22);
+  border-color: rgba(148, 186, 150, 0.55);
+  color: rgba(233, 244, 231, 0.92);
+  background: linear-gradient(120deg, rgba(148, 186, 150, 0.25), rgba(105, 153, 120, 0.2));
 }
 
 .rarity-badge.rarity-uncommon {
-  border-color: rgba(124, 200, 111, 0.6);
-  color: rgba(232, 245, 225, 0.96);
-  background: rgba(124, 200, 111, 0.24);
+  border-color: rgba(143, 209, 138, 0.55);
+  color: rgba(234, 247, 232, 0.96);
+  background: linear-gradient(120deg, rgba(143, 209, 138, 0.28), rgba(111, 175, 120, 0.22));
 }
 
 .rarity-badge.rarity-rare {
-  border-color: rgba(90, 169, 201, 0.7);
-  color: rgba(228, 242, 248, 0.98);
-  background: rgba(90, 169, 201, 0.26);
+  border-color: rgba(122, 184, 198, 0.62);
+  color: rgba(228, 242, 244, 0.98);
+  background: linear-gradient(120deg, rgba(122, 184, 198, 0.3), rgba(88, 148, 164, 0.24));
 }
 
 .rarity-badge.rarity-epic {
-  border-color: rgba(101, 138, 201, 0.7);
-  color: rgba(228, 235, 248, 0.98);
-  background: rgba(101, 138, 201, 0.26);
+  border-color: rgba(166, 156, 218, 0.62);
+  color: rgba(234, 235, 248, 0.98);
+  background: linear-gradient(120deg, rgba(166, 156, 218, 0.3), rgba(139, 129, 188, 0.24));
 }
 
 .rarity-badge.rarity-legendary {
-  border-color: rgba(183, 128, 68, 0.75);
+  border-color: rgba(209, 176, 116, 0.7);
   color: rgba(250, 239, 224, 0.98);
-  background: rgba(183, 128, 68, 0.24);
+  background: linear-gradient(120deg, rgba(209, 176, 116, 0.3), rgba(168, 132, 74, 0.24));
 }
 
 .rarity-badge.rarity-mythic {
-  border-color: rgba(211, 243, 107, 0.75);
+  border-color: rgba(227, 247, 178, 0.75);
   color: rgba(246, 250, 231, 0.98);
-  background: rgba(211, 243, 107, 0.3);
+  background: linear-gradient(120deg, rgba(227, 247, 178, 0.35), rgba(191, 222, 132, 0.24));
 }
 
 .stage {
   grid-column: 4;
   grid-row: 1 / span 2;
   position: relative;
-  background: linear-gradient(160deg, rgba(24, 52, 36, 0.95), rgba(20, 47, 57, 0.92));
-  border: 1px solid rgba(90, 169, 201, 0.35);
-  border-radius: calc(var(--border-radius-lg) + 4px);
+  background: linear-gradient(170deg, rgba(21, 44, 32, 0.95), rgba(19, 46, 43, 0.9));
+  border: 1px solid rgba(122, 184, 198, 0.32);
+  border-radius: calc(var(--border-radius-lg) + 6px);
   overflow: hidden;
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 45px 80px rgba(5, 12, 9, 0.6);
   min-height: 0;
+  backdrop-filter: blur(16px);
 }
 
 .stage::before {
   content: '';
   position: absolute;
-  inset: -25% -18% 60% -18%;
-  background: radial-gradient(circle at 62% 35%, rgba(124, 200, 111, 0.28), transparent 62%);
-  opacity: 0.55;
+  inset: -18% -20% 58% -20%;
+  background: radial-gradient(circle at 60% 32%, rgba(143, 209, 138, 0.32), transparent 62%);
+  opacity: 0.58;
   pointer-events: none;
 }
 
@@ -569,9 +765,10 @@ dl dt {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 38% 72%, rgba(90, 169, 201, 0.22), transparent 70%),
-    radial-gradient(circle at 18% 28%, rgba(183, 128, 68, 0.18), transparent 58%);
-  opacity: 0.6;
+  background:
+    radial-gradient(circle at 38% 74%, rgba(122, 184, 198, 0.26), transparent 70%),
+    radial-gradient(circle at 16% 28%, rgba(209, 176, 116, 0.2), transparent 58%);
+  opacity: 0.55;
   pointer-events: none;
 }
 
@@ -586,10 +783,14 @@ dl dt {
     overflow: auto;
   }
 
+  #app {
+    padding: clamp(1.2rem, 3vw, 2.25rem);
+  }
+
   .app-shell {
     grid-template-columns: 160px 320px minmax(280px, 1fr);
     grid-template-rows: auto minmax(0, 1fr) minmax(280px, auto);
-    padding: 2rem;
+    padding: clamp(1.75rem, 2.4vw + 0.6rem, 2.3rem);
   }
 
   .hud-brand {
@@ -618,7 +819,7 @@ dl dt {
   .app-shell {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto auto auto auto auto;
-    padding: 1.9rem;
+    padding: clamp(1.6rem, 4vw, 2.1rem);
     gap: 1.25rem;
   }
 
@@ -626,27 +827,32 @@ dl dt {
     grid-column: 1;
     grid-row: 1;
     align-self: center;
+    justify-content: center;
   }
 
   .hud-nav {
     grid-column: 1;
     grid-row: 2;
     flex-direction: row;
-    align-items: center;
-    gap: 1.1rem;
+    flex-wrap: wrap;
+    align-items: stretch;
+    gap: 0.9rem;
   }
 
   .hud-nav h2 {
-    margin-bottom: 0;
+    margin: 0 auto;
+    flex-basis: 100%;
+    text-align: center;
   }
 
   .nav-tabs {
     flex-direction: row;
+    flex-wrap: wrap;
     gap: 0.75rem;
   }
 
   .nav-tabs li {
-    flex: 1 1 0;
+    flex: 1 1 calc(50% - 0.5rem);
   }
 
   .nav-tabs button {
@@ -671,9 +877,25 @@ dl dt {
   }
 }
 
+@media (max-width: 900px) {
+  .hud-brand {
+    flex-direction: column;
+    gap: 0.75rem;
+    text-align: center;
+  }
+
+  .hud-brand__text {
+    align-items: center;
+  }
+
+  .hud-brand__tagline {
+    letter-spacing: 0.28em;
+  }
+}
+
 @media (max-width: 700px) {
   .app-shell {
-    padding: 1.5rem;
+    padding: 1.4rem;
   }
 
   .nav-tabs {
@@ -684,7 +906,73 @@ dl dt {
     flex: 1 1 calc(50% - 0.5rem);
   }
 
+  .hud-nav {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .stage {
     height: 260px;
+  }
+}
+
+@media (max-width: 600px) {
+  #app {
+    padding: 1.1rem;
+  }
+
+  .hud-nav {
+    padding: 1.4rem 1.1rem;
+  }
+
+  .nav-tabs button {
+    font-size: 0.8rem;
+    gap: 0.45rem;
+    padding: 0.7rem 0.85rem;
+  }
+
+  .hud-brand__title {
+    font-size: 1.6rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .nav-tabs li {
+    flex: 1 1 100%;
+  }
+
+  .hud-brand__tagline {
+    font-size: 0.68rem;
+    letter-spacing: 0.26em;
+  }
+
+  .weapon-card {
+    padding: 1rem 1.1rem;
+  }
+}
+
+@keyframes canopySway {
+  0% {
+    transform: rotate(-14deg) translate3d(0, 0, 0);
+  }
+
+  50% {
+    transform: rotate(-10deg) translate3d(-12px, 12px, 0);
+  }
+
+  100% {
+    transform: rotate(-14deg) translate3d(0, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-shell::after {
+    animation: none;
+  }
+
+  .nav-tabs button,
+  .weapon-card,
+  .stat-bar-fill {
+    transition: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the HUD shell with a new brand block and natural-styled navigation layout
- refresh panels, cards, and badges with an earthy palette, soft lighting effects, and responsive adjustments
- retune the 3D stage lighting and glow colors to match the calmer tone when showcasing models

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c8f8712a9c83299716679af1a11ed7