### PR TITLE
Refresh the armory UI with a natural theme

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -53,31 +53,47 @@ export class WeaponDisplayApp {
 
   buildLayout() {
     this.root.innerHTML = `
-      <div class="app-shell">
-        <div class="hud-brand">Crtiz Armory</div>
-        <nav class="hud-nav" aria-label="Weapon categories">
-          <h2>Categories</h2>
-          <ul class="nav-tabs" data-component="nav-tabs"></ul>
-        </nav>
-        <section class="panel hud-panel hud-list" data-component="weapon-list">
-          <div class="panel-header">
-            <span>Arsenal</span>
-            <span data-role="list-context"></span>
+      <div class="app-surface">
+        <div class="app-ambient" aria-hidden="true">
+          <span class="ambient ambient-sun"></span>
+          <span class="ambient ambient-haze"></span>
+          <span class="ambient ambient-canopy"></span>
+          <span class="ambient-leaf ambient-leaf-one"></span>
+          <span class="ambient-leaf ambient-leaf-two"></span>
+          <span class="ambient-leaf ambient-leaf-three"></span>
+        </div>
+        <div class="app-shell">
+          <div class="hud-brand">
+            <div class="brand-badge" aria-hidden="true"></div>
+            <div class="brand-text">
+              <span class="brand-title">Crtiz Armory</span>
+              <span class="brand-tagline">Wildcrafted Arsenal</span>
+            </div>
           </div>
-          <div class="weapon-cards" data-role="weapon-cards"></div>
-          <div class="panel-footer" data-role="list-footer">Choose a category to see its gear.</div>
-        </section>
-        <section class="panel hud-panel hud-detail" data-component="weapon-detail">
-          <div class="panel-header">
-            <span>Equipment Info</span>
-            <span data-role="rarity-badge"></span>
-          </div>
-          <div class="detail-content" data-role="detail-content">
-            <p class="description">Pick a tool to see its details.</p>
-          </div>
-          <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
-        </section>
-        <section class="stage" data-component="stage"></section>
+          <nav class="hud-nav" aria-label="Weapon categories">
+            <h2>Categories</h2>
+            <ul class="nav-tabs" data-component="nav-tabs"></ul>
+          </nav>
+          <section class="panel hud-panel hud-list" data-component="weapon-list">
+            <div class="panel-header">
+              <span>Arsenal</span>
+              <span data-role="list-context"></span>
+            </div>
+            <div class="weapon-cards" data-role="weapon-cards"></div>
+            <div class="panel-footer" data-role="list-footer">Choose a category to see its gear.</div>
+          </section>
+          <section class="panel hud-panel hud-detail" data-component="weapon-detail">
+            <div class="panel-header">
+              <span>Equipment Info</span>
+              <span data-role="rarity-badge"></span>
+            </div>
+            <div class="detail-content" data-role="detail-content">
+              <p class="description">Pick a tool to see its details.</p>
+            </div>
+            <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
+          </section>
+          <section class="stage" data-component="stage"></section>
+        </div>
       </div>
     `;
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,20 +1,20 @@
 :root {
-  --color-bg: #0f1f17;
-  --color-bg-alt: #142e20;
-  --color-canopy: #1f3d2c;
-  --color-panel: rgba(26, 58, 41, 0.9);
-  --color-panel-border: rgba(169, 213, 179, 0.38);
-  --color-panel-highlight: rgba(116, 182, 139, 0.4);
-  --color-accent: #7cc86f;
-  --color-accent-soft: rgba(124, 200, 111, 0.2);
-  --color-earth: #b78044;
-  --color-water: #5aa9c9;
-  --color-highlight: #d3f36b;
-  --color-text-primary: #f3f8f0;
-  --color-text-secondary: rgba(243, 248, 240, 0.82);
+  --color-bg: #071710;
+  --color-bg-alt: #0e231a;
+  --color-canopy: #1a3526;
+  --color-panel: rgba(19, 44, 31, 0.86);
+  --color-panel-border: rgba(222, 241, 225, 0.22);
+  --color-panel-highlight: rgba(150, 209, 164, 0.35);
+  --color-accent: #84cf96;
+  --color-accent-soft: rgba(132, 207, 150, 0.22);
+  --color-earth: #caa36c;
+  --color-water: #74b0a2;
+  --color-highlight: #f5f0c4;
+  --color-text-primary: #f4f9f3;
+  --color-text-secondary: rgba(244, 249, 243, 0.82);
   --font-display: 'Lilita One', cursive;
   --font-body: 'Nunito', sans-serif;
-  --shadow-soft: 0 24px 60px rgba(8, 22, 16, 0.55);
+  --shadow-soft: 0 36px 80px rgba(4, 18, 12, 0.6);
   --border-radius-lg: 20px;
 }
 
@@ -32,7 +32,7 @@ body {
   font-family: var(--font-body);
   letter-spacing: 0.01em;
   color: var(--color-text-primary);
-  background: linear-gradient(135deg, #0d1f17 0%, #143524 55%, #102330 100%);
+  background: linear-gradient(150deg, #06140f 0%, #0d2016 48%, #19342a 100%);
   overflow: hidden;
   position: relative;
 }
@@ -46,18 +46,18 @@ body::after {
 }
 
 body::before {
-  background: radial-gradient(circle at 18% 26%, rgba(124, 200, 111, 0.16), transparent 55%),
-    radial-gradient(circle at 78% 18%, rgba(90, 169, 201, 0.18), transparent 60%),
-    radial-gradient(circle at 48% 78%, rgba(179, 128, 68, 0.12), transparent 62%);
+  background: radial-gradient(circle at 18% 22%, rgba(245, 240, 196, 0.28), transparent 58%),
+    radial-gradient(circle at 78% 18%, rgba(132, 207, 150, 0.24), transparent 62%),
+    radial-gradient(circle at 50% 82%, rgba(112, 165, 136, 0.18), transparent 64%);
   mix-blend-mode: screen;
-  opacity: 0.6;
+  opacity: 0.68;
 }
 
 body::after {
-  background: radial-gradient(circle at 14% 82%, rgba(16, 63, 42, 0.35), transparent 70%),
-    linear-gradient(120deg, rgba(12, 42, 31, 0.35), transparent 65%),
-    linear-gradient(300deg, rgba(21, 52, 67, 0.3), transparent 55%);
-  opacity: 0.55;
+  background: linear-gradient(125deg, rgba(8, 28, 20, 0.65), transparent 68%),
+    radial-gradient(circle at 16% 78%, rgba(74, 176, 162, 0.22), transparent 66%),
+    radial-gradient(circle at 82% 74%, rgba(202, 163, 104, 0.2), transparent 64%);
+  opacity: 0.52;
 }
 
 #app {
@@ -65,8 +65,117 @@ body::after {
   width: 100%;
   display: flex;
   align-items: stretch;
+  justify-content: center;
   position: relative;
   z-index: 1;
+  padding: clamp(1.2rem, 1.8vw + 1.2rem, 3.5rem);
+}
+
+.app-surface {
+  position: relative;
+  flex: 1;
+  max-width: 1500px;
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.app-ambient {
+  position: absolute;
+  inset: -12% -14% -18% -14%;
+  pointer-events: none;
+  z-index: 0;
+  overflow: hidden;
+}
+
+.ambient {
+  position: absolute;
+  border-radius: 999px;
+  opacity: 0.6;
+  mix-blend-mode: screen;
+}
+
+.ambient-sun {
+  width: clamp(420px, 42vw, 620px);
+  height: clamp(420px, 42vw, 620px);
+  top: clamp(-220px, -12vw, -120px);
+  right: clamp(-160px, -10vw, -60px);
+  background: radial-gradient(circle at 50% 50%, rgba(245, 240, 196, 0.55), rgba(245, 240, 196, 0));
+  filter: blur(0.5px);
+}
+
+.ambient-haze {
+  width: clamp(360px, 38vw, 520px);
+  height: clamp(360px, 38vw, 520px);
+  bottom: clamp(-240px, -14vw, -80px);
+  left: clamp(-200px, -12vw, -60px);
+  background: radial-gradient(circle at 50% 50%, rgba(132, 207, 150, 0.35), rgba(132, 207, 150, 0));
+  filter: blur(1px);
+}
+
+.ambient-canopy {
+  width: clamp(300px, 32vw, 460px);
+  height: clamp(300px, 32vw, 460px);
+  top: clamp(-160px, -10vw, -60px);
+  left: clamp(60px, 6vw, 180px);
+  background: radial-gradient(circle at 35% 35%, rgba(61, 122, 90, 0.55), rgba(61, 122, 90, 0));
+  filter: blur(1.5px);
+}
+
+.ambient-leaf {
+  position: absolute;
+  width: clamp(120px, 12vw, 180px);
+  height: clamp(220px, 22vw, 320px);
+  border-radius: 60% 60% 50% 60% / 70% 70% 40% 60%;
+  background: linear-gradient(135deg, rgba(132, 207, 150, 0.32), rgba(76, 141, 115, 0.18));
+  opacity: 0.35;
+  mix-blend-mode: screen;
+  filter: blur(0.2px);
+  animation: float-drift 16s ease-in-out infinite;
+}
+
+.ambient-leaf::after {
+  content: '';
+  position: absolute;
+  inset: 24% 42% 12% 42%;
+  background: linear-gradient(180deg, rgba(241, 248, 236, 0.3), rgba(241, 248, 236, 0));
+  border-radius: 999px;
+}
+
+.ambient-leaf-one {
+  top: clamp(12%, 18vh, 24%);
+  left: clamp(-40px, 4vw, 140px);
+}
+
+.ambient-leaf-two {
+  bottom: clamp(10%, 18vh, 26%);
+  right: clamp(80px, 10vw, 180px);
+  transform: rotate(24deg);
+  animation-delay: 4s;
+}
+
+.ambient-leaf-three {
+  top: clamp(30%, 36vh, 45%);
+  right: clamp(-20px, 6vw, 120px);
+  transform: rotate(-12deg);
+  animation-delay: 8s;
+}
+
+@keyframes float-drift {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
+  35% {
+    transform: translate3d(18px, -24px, 0) rotate(4deg);
+  }
+  65% {
+    transform: translate3d(-12px, 18px, 0) rotate(-3deg);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0deg);
+  }
 }
 
 .app-shell {
@@ -75,10 +184,16 @@ body::after {
   display: grid;
   grid-template-columns: 180px 320px minmax(320px, 1fr) minmax(240px, 28vw);
   grid-template-rows: auto minmax(0, 1fr);
-  gap: 1.5rem;
-  padding: 2.25rem 2.75rem;
+  gap: 1.6rem;
+  padding: 2.5rem 3rem;
   position: relative;
   align-items: stretch;
+  border-radius: calc(var(--border-radius-lg) + 10px);
+  border: 1px solid rgba(222, 241, 225, 0.14);
+  background: linear-gradient(170deg, rgba(10, 26, 18, 0.65), rgba(12, 30, 21, 0.58));
+  backdrop-filter: blur(24px) saturate(135%);
+  box-shadow: 0 36px 80px rgba(4, 18, 12, 0.55);
+  z-index: 1;
 }
 
 .app-shell > * {
@@ -91,55 +206,96 @@ body::after {
   align-self: end;
   display: flex;
   align-items: center;
-  gap: 0.85rem;
-  font-family: var(--font-display);
-  font-size: 1.75rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--color-highlight);
-  text-shadow: 0 0 18px rgba(124, 200, 111, 0.45);
+  gap: 1rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: calc(var(--border-radius-lg) - 6px);
+  border: 1px solid rgba(245, 240, 196, 0.24);
+  background: linear-gradient(135deg, rgba(23, 55, 36, 0.68), rgba(14, 39, 28, 0.76));
+  box-shadow: 0 20px 40px rgba(6, 24, 16, 0.45);
 }
 
-.hud-brand::before {
+.brand-badge {
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  background: linear-gradient(140deg, rgba(245, 240, 196, 0.55), rgba(132, 207, 150, 0.35));
+  border: 1px solid rgba(245, 240, 196, 0.35);
+  box-shadow: 0 0 26px rgba(245, 240, 196, 0.45);
+  position: relative;
+  overflow: hidden;
+}
+
+.brand-badge::after {
   content: '';
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
-  border: 2px solid rgba(211, 243, 107, 0.6);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.25), rgba(90, 169, 201, 0.4));
-  box-shadow: 0 0 22px rgba(124, 200, 111, 0.35);
+  position: absolute;
+  inset: 16% 28% 18% 28%;
+  border-radius: 60% 60% 40% 60% / 60% 60% 40% 60%;
+  background: linear-gradient(160deg, rgba(89, 153, 109, 0.95), rgba(58, 118, 94, 0.55));
+}
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.brand-title {
+  font-family: var(--font-display);
+  font-size: 1.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+  text-shadow: 0 0 18px rgba(245, 240, 196, 0.38);
+}
+
+.brand-tagline {
+  font-size: 0.78rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(244, 249, 243, 0.7);
 }
 
 .hud-nav {
   grid-column: 1;
   grid-row: 2;
-  background: var(--color-panel);
-  border: 1px solid var(--color-panel-border);
+  background: linear-gradient(185deg, rgba(26, 58, 39, 0.82), rgba(15, 34, 24, 0.9));
+  border: 1px solid rgba(222, 241, 225, 0.18);
   border-radius: var(--border-radius-lg);
-  padding: 1.6rem 1.25rem;
+  padding: 1.75rem 1.35rem;
   display: flex;
   flex-direction: column;
-  gap: 1.35rem;
+  gap: 1.4rem;
   position: relative;
   overflow: hidden;
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 28px 48px rgba(4, 20, 14, 0.45);
+  backdrop-filter: blur(18px);
 }
 
 .hud-nav::before {
   content: '';
   position: absolute;
-  inset: -25% -40% 55% -40%;
-  background: radial-gradient(circle at 50% 38%, var(--color-panel-highlight), transparent 58%);
-  opacity: 0.4;
+  inset: -26% -42% 58% -32%;
+  background: radial-gradient(circle at 52% 36%, rgba(245, 240, 196, 0.28), transparent 62%);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.hud-nav::after {
+  content: '';
+  position: absolute;
+  inset: 52% -34% -26% -30%;
+  background: radial-gradient(circle at 42% 68%, rgba(132, 207, 150, 0.22), transparent 68%);
+  opacity: 0.35;
+  pointer-events: none;
 }
 
 .hud-nav h2 {
   margin: 0;
   font-family: var(--font-display);
   font-size: 1rem;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--color-highlight);
+  color: rgba(245, 240, 196, 0.92);
 }
 
 .nav-tabs {
@@ -157,36 +313,37 @@ body::after {
 
 .nav-tabs button {
   width: 100%;
-  padding: 0.9rem 1rem;
+  padding: 0.95rem 1rem;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(61, 102, 76, 0.35);
-  color: var(--color-text-secondary);
+  border: 1px solid rgba(245, 240, 196, 0.12);
+  background: linear-gradient(135deg, rgba(30, 66, 47, 0.65), rgba(22, 48, 35, 0.6));
+  color: rgba(244, 249, 243, 0.78);
   font-size: 0.95rem;
   font-family: var(--font-display);
-  letter-spacing: 0.1em;
+  letter-spacing: 0.11em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, color 0.2s ease;
   position: relative;
   overflow: hidden;
+  backdrop-filter: blur(8px);
 }
 
 .nav-tabs button::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
+  background: linear-gradient(130deg, rgba(245, 240, 196, 0.22), transparent 60%);
   opacity: 0;
   transition: opacity 0.2s ease;
 }
 
 .nav-tabs button:hover,
 .nav-tabs button:focus-visible {
-  border-color: rgba(124, 200, 111, 0.6);
+  border-color: rgba(245, 240, 196, 0.4);
   color: var(--color-text-primary);
-  transform: translateY(-1px);
-  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(8, 36, 24, 0.45);
   outline: none;
 }
 
@@ -196,9 +353,10 @@ body::after {
 }
 
 .nav-tabs button.active {
-  border-color: rgba(211, 243, 107, 0.75);
+  border-color: rgba(245, 240, 196, 0.55);
+  background: linear-gradient(135deg, rgba(132, 207, 150, 0.55), rgba(116, 173, 150, 0.45));
   color: var(--color-text-primary);
-  box-shadow: 0 14px 32px rgba(20, 52, 36, 0.45);
+  box-shadow: 0 18px 36px rgba(8, 32, 23, 0.5);
 }
 
 .nav-tabs button.active::after {
@@ -206,24 +364,25 @@ body::after {
 }
 
 .panel {
-  background: linear-gradient(165deg, rgba(33, 71, 51, 0.92), rgba(23, 50, 35, 0.92));
-  border: 1px solid var(--color-panel-border);
+  background: linear-gradient(175deg, rgba(24, 56, 39, 0.86), rgba(16, 39, 29, 0.9));
+  border: 1px solid rgba(222, 241, 225, 0.18);
   border-radius: var(--border-radius-lg);
-  padding: 1.6rem 1.75rem;
+  padding: 1.7rem 1.9rem;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
+  gap: 1.15rem;
   position: relative;
   overflow: hidden;
   min-height: 0;
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 28px 52px rgba(4, 22, 15, 0.48);
+  backdrop-filter: blur(20px);
 }
 
 .panel::before {
   content: '';
   position: absolute;
   inset: -20% -35% 65% -25%;
-  background: radial-gradient(circle at 32% 24%, rgba(124, 200, 111, 0.25), transparent 60%);
+  background: radial-gradient(circle at 32% 22%, rgba(245, 240, 196, 0.22), transparent 60%);
   opacity: 0.55;
   pointer-events: none;
 }
@@ -231,8 +390,8 @@ body::after {
 .panel::after {
   content: '';
   position: absolute;
-  inset: 60% -30% -25% -20%;
-  background: radial-gradient(circle at 70% 80%, rgba(90, 169, 201, 0.18), transparent 60%);
+  inset: 58% -32% -24% -22%;
+  background: radial-gradient(circle at 68% 78%, rgba(132, 207, 150, 0.2), transparent 62%);
   opacity: 0.4;
   pointer-events: none;
 }
@@ -264,7 +423,7 @@ body::after {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   font-size: 0.95rem;
-  color: var(--color-highlight);
+  color: rgba(245, 240, 196, 0.9);
   gap: 1rem;
 }
 
@@ -272,7 +431,7 @@ body::after {
   font-size: 0.85rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--color-water);
+  color: rgba(132, 207, 150, 0.85);
 }
 
 .weapon-cards {
@@ -283,40 +442,43 @@ body::after {
   min-height: 0;
   overflow-y: auto;
   padding-right: 0.35rem;
+  padding-top: 0.1rem;
 }
 
 .weapon-card {
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(245, 240, 196, 0.12);
   border-radius: 18px;
-  padding: 1rem 1.2rem;
-  background: rgba(46, 88, 64, 0.4);
-  color: var(--color-text-secondary);
+  padding: 1.05rem 1.25rem;
+  background: linear-gradient(150deg, rgba(23, 54, 37, 0.68), rgba(18, 44, 32, 0.72));
+  color: rgba(244, 249, 243, 0.78);
   cursor: pointer;
-  transition: all 0.18s ease;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  backdrop-filter: blur(12px);
 }
 
 .weapon-card:hover,
 .weapon-card:focus-visible {
-  border-color: rgba(124, 200, 111, 0.55);
-  box-shadow: 0 12px 26px rgba(16, 45, 31, 0.35);
-  background: rgba(46, 88, 64, 0.55);
+  border-color: rgba(245, 240, 196, 0.42);
+  box-shadow: 0 16px 32px rgba(8, 32, 23, 0.45);
+  background: linear-gradient(150deg, rgba(32, 70, 49, 0.75), rgba(20, 48, 33, 0.78));
+  transform: translateY(-2px);
   outline: none;
   color: var(--color-text-primary);
 }
 
 .weapon-card.active {
-  border-color: rgba(211, 243, 107, 0.75);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.38), rgba(90, 169, 201, 0.28));
+  border-color: rgba(245, 240, 196, 0.58);
+  background: linear-gradient(150deg, rgba(132, 207, 150, 0.45), rgba(116, 173, 150, 0.4));
   color: var(--color-text-primary);
-  box-shadow: 0 14px 30px rgba(17, 46, 33, 0.45);
+  box-shadow: 0 18px 36px rgba(8, 32, 23, 0.5);
 }
 
 .weapon-card h3 {
-  margin: 0 0 0.4rem;
-  font-size: 1.1rem;
+  margin: 0 0 0.45rem;
+  font-size: 1.12rem;
   color: var(--color-text-primary);
   font-family: var(--font-display);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.09em;
 }
 
 .weapon-card dl {
@@ -328,7 +490,8 @@ body::after {
 }
 
 dl dt {
-  opacity: 0.7;
+  color: rgba(244, 249, 243, 0.65);
+  font-weight: 600;
 }
 
 .detail-content {
@@ -353,7 +516,7 @@ dl dt {
   margin: 0;
   font-size: 0.92rem;
   line-height: 1.7;
-  color: var(--color-text-secondary);
+  color: rgba(244, 249, 243, 0.75);
 }
 
 .stat-grid {
@@ -385,7 +548,7 @@ dl dt {
 
 .stat-bar-value {
   font-size: 0.85rem;
-  color: var(--color-text-secondary);
+  color: rgba(244, 249, 243, 0.82);
   font-weight: 600;
   white-space: nowrap;
 }
@@ -399,18 +562,18 @@ dl dt {
 .stat-bar-track {
   position: relative;
   height: 0.75rem;
-  background: rgba(124, 200, 111, 0.15);
+  background: rgba(132, 207, 150, 0.18);
   border-radius: 999px;
   overflow: hidden;
-  border: 1px solid rgba(124, 200, 111, 0.35);
-  box-shadow: inset 0 0 18px rgba(6, 18, 12, 0.6);
+  border: 1px solid rgba(245, 240, 196, 0.2);
+  box-shadow: inset 0 0 18px rgba(5, 15, 10, 0.55);
 }
 
 .stat-bar-track::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 15% 50%, rgba(243, 248, 240, 0.25), transparent 65%);
+  background: radial-gradient(circle at 18% 50%, rgba(245, 240, 196, 0.32), transparent 68%);
   opacity: 0.45;
 }
 
@@ -419,8 +582,8 @@ dl dt {
   position: absolute;
   inset: 0;
   width: calc(var(--fill, 0) * 1%);
-  background: linear-gradient(90deg, rgba(124, 200, 111, 0.85), rgba(211, 243, 107, 0.95));
-  box-shadow: 0 0 18px rgba(124, 200, 111, 0.55);
+  background: linear-gradient(90deg, rgba(132, 207, 150, 0.88), rgba(245, 240, 196, 0.95));
+  box-shadow: 0 0 18px rgba(132, 207, 150, 0.55);
   transition: width 220ms ease-out;
 }
 
@@ -433,7 +596,7 @@ dl dt {
 }
 
 .special-section {
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid rgba(245, 240, 196, 0.12);
   padding-top: 0.9rem;
 }
 
@@ -450,7 +613,7 @@ dl dt {
   padding-left: 1rem;
   list-style: square;
   font-size: 0.9rem;
-  color: var(--color-text-secondary);
+  color: rgba(244, 249, 243, 0.78);
   line-height: 1.65;
 }
 
@@ -467,13 +630,13 @@ dl dt {
   font-size: 0.78rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.65);
+  color: rgba(244, 249, 243, 0.6);
 }
 
 .weapon-cards,
 .detail-content {
   scrollbar-width: thin;
-  scrollbar-color: rgba(90, 169, 201, 0.55) transparent;
+  scrollbar-color: rgba(132, 207, 150, 0.5) transparent;
 }
 
 .weapon-cards::-webkit-scrollbar,
@@ -488,7 +651,7 @@ dl dt {
 
 .weapon-cards::-webkit-scrollbar-thumb,
 .detail-content::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(90, 169, 201, 0.65), rgba(124, 200, 111, 0.55));
+  background: linear-gradient(180deg, rgba(132, 207, 150, 0.6), rgba(245, 240, 196, 0.45));
   border-radius: 6px;
 }
 
@@ -498,80 +661,82 @@ dl dt {
   justify-content: center;
   padding: 0.4rem 1rem;
   border-radius: 999px;
-  border: 1px solid rgba(211, 243, 107, 0.6);
+  border: 1px solid rgba(245, 240, 196, 0.32);
   font-size: 0.75rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: var(--color-highlight);
-  background: rgba(90, 169, 201, 0.18);
+  color: rgba(245, 240, 196, 0.92);
+  background: rgba(132, 207, 150, 0.18);
   min-width: 128px;
   text-align: center;
 }
 
 .rarity-badge.rarity-common {
-  border-color: rgba(118, 158, 125, 0.55);
-  color: rgba(236, 243, 230, 0.92);
-  background: rgba(118, 158, 125, 0.22);
+  border-color: rgba(170, 190, 164, 0.45);
+  color: rgba(244, 249, 243, 0.82);
+  background: rgba(170, 190, 164, 0.18);
 }
 
 .rarity-badge.rarity-uncommon {
-  border-color: rgba(124, 200, 111, 0.6);
-  color: rgba(232, 245, 225, 0.96);
-  background: rgba(124, 200, 111, 0.24);
+  border-color: rgba(132, 207, 150, 0.5);
+  color: rgba(244, 249, 243, 0.92);
+  background: rgba(132, 207, 150, 0.2);
 }
 
 .rarity-badge.rarity-rare {
-  border-color: rgba(90, 169, 201, 0.7);
-  color: rgba(228, 242, 248, 0.98);
-  background: rgba(90, 169, 201, 0.26);
+  border-color: rgba(116, 168, 182, 0.6);
+  color: rgba(244, 249, 243, 0.94);
+  background: rgba(116, 168, 182, 0.22);
 }
 
 .rarity-badge.rarity-epic {
-  border-color: rgba(101, 138, 201, 0.7);
-  color: rgba(228, 235, 248, 0.98);
-  background: rgba(101, 138, 201, 0.26);
+  border-color: rgba(130, 160, 206, 0.65);
+  color: rgba(244, 249, 243, 0.95);
+  background: rgba(130, 160, 206, 0.24);
 }
 
 .rarity-badge.rarity-legendary {
-  border-color: rgba(183, 128, 68, 0.75);
-  color: rgba(250, 239, 224, 0.98);
-  background: rgba(183, 128, 68, 0.24);
+  border-color: rgba(202, 163, 104, 0.65);
+  color: rgba(250, 244, 228, 0.96);
+  background: rgba(202, 163, 104, 0.24);
 }
 
 .rarity-badge.rarity-mythic {
-  border-color: rgba(211, 243, 107, 0.75);
-  color: rgba(246, 250, 231, 0.98);
-  background: rgba(211, 243, 107, 0.3);
+  border-color: rgba(245, 240, 196, 0.65);
+  color: rgba(34, 59, 46, 0.82);
+  background: rgba(245, 240, 196, 0.3);
 }
 
 .stage {
   grid-column: 4;
   grid-row: 1 / span 2;
   position: relative;
-  background: linear-gradient(160deg, rgba(24, 52, 36, 0.95), rgba(20, 47, 57, 0.92));
-  border: 1px solid rgba(90, 169, 201, 0.35);
-  border-radius: calc(var(--border-radius-lg) + 4px);
+  background: linear-gradient(188deg, rgba(26, 63, 42, 0.92), rgba(14, 36, 29, 0.95));
+  border: 1px solid rgba(222, 241, 225, 0.18);
+  border-radius: calc(var(--border-radius-lg) + 6px);
   overflow: hidden;
-  box-shadow: var(--shadow-soft);
+  box-shadow: 0 40px 64px rgba(4, 20, 14, 0.52);
   min-height: 0;
+  backdrop-filter: blur(16px);
 }
 
 .stage::before {
   content: '';
   position: absolute;
-  inset: -25% -18% 60% -18%;
-  background: radial-gradient(circle at 62% 35%, rgba(124, 200, 111, 0.28), transparent 62%);
-  opacity: 0.55;
+  inset: -26% -22% 58% -22%;
+  background: radial-gradient(circle at 62% 32%, rgba(245, 240, 196, 0.32), transparent 64%);
+  opacity: 0.6;
   pointer-events: none;
 }
 
 .stage::after {
   content: '';
   position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 38% 72%, rgba(90, 169, 201, 0.22), transparent 70%),
-    radial-gradient(circle at 18% 28%, rgba(183, 128, 68, 0.18), transparent 58%);
-  opacity: 0.6;
+  inset: 42% -18% -24% -18%;
+  background: radial-gradient(circle at 32% 78%, rgba(132, 207, 150, 0.26), transparent 68%),
+    radial-gradient(circle at 70% 42%, rgba(202, 163, 104, 0.18), transparent 62%),
+    linear-gradient(180deg, rgba(12, 32, 25, 0), rgba(12, 32, 25, 0.72));
+  opacity: 0.55;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- wrap the HUD in a new ambient surface with a brand badge and organic background accents
- retheme navigation, panels, and cards with earthy gradients, blur, and softened hover states
- align detail stats, rarity badges, and the 3D stage with the refreshed natural palette

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8f8712a9c83299716679af1a11ed7