### PR TITLE
Refresh UI with organic styling

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -54,7 +54,17 @@ export class WeaponDisplayApp {
   buildLayout() {
     this.root.innerHTML = `
       <div class="app-shell">
-        <div class="hud-brand">Crtiz Armory</div>
+        <div class="hud-brand">
+          <div class="brand-crest" aria-hidden="true">
+            <span class="brand-crest__leaf brand-crest__leaf--left"></span>
+            <span class="brand-crest__leaf brand-crest__leaf--right"></span>
+            <span class="brand-crest__seed"></span>
+          </div>
+          <div class="brand-copy">
+            <span class="brand-title">Crtiz Armory</span>
+            <span class="brand-subtitle">Field-crafted arsenal guide</span>
+          </div>
+        </div>
         <nav class="hud-nav" aria-label="Weapon categories">
           <h2>Categories</h2>
           <ul class="nav-tabs" data-component="nav-tabs"></ul>
@@ -65,7 +75,7 @@ export class WeaponDisplayApp {
             <span data-role="list-context"></span>
           </div>
           <div class="weapon-cards" data-role="weapon-cards"></div>
-          <div class="panel-footer" data-role="list-footer">Choose a category to see its gear.</div>
+          <div class="panel-footer" data-role="list-footer">Select a category to explore the crafted gear.</div>
         </section>
         <section class="panel hud-panel hud-detail" data-component="weapon-detail">
           <div class="panel-header">
@@ -75,7 +85,7 @@ export class WeaponDisplayApp {
           <div class="detail-content" data-role="detail-content">
             <p class="description">Pick a tool to see its details.</p>
           </div>
-          <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
+          <div class="panel-footer" data-role="detail-footer">Awaiting your chosen tool</div>
         </section>
         <section class="stage" data-component="stage"></section>
       </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,20 +1,23 @@
 :root {
-  --color-bg: #0f1f17;
-  --color-bg-alt: #142e20;
-  --color-canopy: #1f3d2c;
-  --color-panel: rgba(26, 58, 41, 0.9);
-  --color-panel-border: rgba(169, 213, 179, 0.38);
-  --color-panel-highlight: rgba(116, 182, 139, 0.4);
-  --color-accent: #7cc86f;
-  --color-accent-soft: rgba(124, 200, 111, 0.2);
-  --color-earth: #b78044;
-  --color-water: #5aa9c9;
-  --color-highlight: #d3f36b;
-  --color-text-primary: #f3f8f0;
-  --color-text-secondary: rgba(243, 248, 240, 0.82);
+  --color-bg: #07140e;
+  --color-bg-alt: #0f271a;
+  --color-canopy: #1a3b29;
+  --color-panel: rgba(19, 44, 30, 0.88);
+  --color-panel-border: rgba(148, 210, 189, 0.3);
+  --color-panel-highlight: rgba(122, 190, 142, 0.32);
+  --color-panel-glow: rgba(96, 165, 137, 0.26);
+  --color-accent: #7ddf9c;
+  --color-accent-soft: rgba(125, 223, 156, 0.22);
+  --color-earth: #c38a56;
+  --color-water: #66b8c7;
+  --color-highlight: #e9f87a;
+  --color-text-primary: #f5f8f2;
+  --color-text-secondary: rgba(245, 248, 242, 0.82);
+  --color-text-muted: rgba(245, 248, 242, 0.64);
+  --color-haze: rgba(131, 196, 170, 0.25);
   --font-display: 'Lilita One', cursive;
   --font-body: 'Nunito', sans-serif;
-  --shadow-soft: 0 24px 60px rgba(8, 22, 16, 0.55);
+  --shadow-soft: 0 28px 70px rgba(6, 15, 12, 0.55);
   --border-radius-lg: 20px;
 }
 
@@ -32,9 +35,15 @@ body {
   font-family: var(--font-body);
   letter-spacing: 0.01em;
   color: var(--color-text-primary);
-  background: linear-gradient(135deg, #0d1f17 0%, #143524 55%, #102330 100%);
+  background-color: var(--color-bg);
+  background-image:
+    radial-gradient(circle at 16% 22%, rgba(125, 223, 156, 0.14), transparent 60%),
+    radial-gradient(circle at 72% 12%, rgba(102, 184, 199, 0.18), transparent 62%),
+    linear-gradient(135deg, var(--color-bg) 0%, var(--color-bg-alt) 52%, #0d2530 100%);
   overflow: hidden;
   position: relative;
+  min-height: 100%;
+  -webkit-font-smoothing: antialiased;
 }
 
 body::before,
@@ -46,18 +55,29 @@ body::after {
 }
 
 body::before {
-  background: radial-gradient(circle at 18% 26%, rgba(124, 200, 111, 0.16), transparent 55%),
-    radial-gradient(circle at 78% 18%, rgba(90, 169, 201, 0.18), transparent 60%),
-    radial-gradient(circle at 48% 78%, rgba(179, 128, 68, 0.12), transparent 62%);
+  background-image:
+    radial-gradient(circle at 14% 28%, rgba(125, 223, 156, 0.22), transparent 58%),
+    radial-gradient(circle at 78% 18%, rgba(102, 184, 199, 0.24), transparent 60%),
+    radial-gradient(circle at 48% 76%, rgba(195, 138, 86, 0.22), transparent 60%);
+  background-size: auto;
+  background-repeat: no-repeat;
   mix-blend-mode: screen;
-  opacity: 0.6;
+  opacity: 0.65;
+  animation: canopyDrift 48s ease-in-out infinite alternate;
 }
 
 body::after {
-  background: radial-gradient(circle at 14% 82%, rgba(16, 63, 42, 0.35), transparent 70%),
-    linear-gradient(120deg, rgba(12, 42, 31, 0.35), transparent 65%),
-    linear-gradient(300deg, rgba(21, 52, 67, 0.3), transparent 55%);
-  opacity: 0.55;
+  background-image:
+    radial-gradient(circle at 12% 82%, rgba(13, 47, 31, 0.55), transparent 70%),
+    linear-gradient(120deg, rgba(9, 32, 23, 0.5), transparent 65%),
+    radial-gradient(circle at 86% 74%, rgba(14, 50, 63, 0.5), transparent 62%),
+    radial-gradient(1px 1px, rgba(255, 255, 255, 0.12) 25%, transparent 60%),
+    radial-gradient(1px 1px, rgba(255, 255, 255, 0.08) 25%, transparent 60%);
+  background-size: auto, auto, auto, 180px 180px, 240px 240px;
+  background-repeat: no-repeat, no-repeat, no-repeat, repeat, repeat;
+  opacity: 0.6;
+  mix-blend-mode: lighten;
+  animation: canopyDrift 60s linear infinite reverse;
 }
 
 #app {
@@ -75,14 +95,46 @@ body::after {
   display: grid;
   grid-template-columns: 180px 320px minmax(320px, 1fr) minmax(240px, 28vw);
   grid-template-rows: auto minmax(0, 1fr);
-  gap: 1.5rem;
-  padding: 2.25rem 2.75rem;
+  gap: 1.75rem;
+  padding: 2.4rem 2.95rem;
   position: relative;
   align-items: stretch;
+  background: linear-gradient(135deg, rgba(15, 40, 27, 0.84), rgba(12, 30, 29, 0.88));
+  border: 1px solid rgba(125, 223, 156, 0.18);
+  border-radius: calc(var(--border-radius-lg) + 12px);
+  box-shadow: var(--shadow-soft), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+  overflow: hidden;
+  backdrop-filter: blur(18px);
+}
+
+.app-shell::before,
+.app-shell::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.app-shell::before {
+  background: radial-gradient(circle at 18% 26%, rgba(125, 223, 156, 0.22), transparent 60%),
+    radial-gradient(circle at 82% 20%, rgba(102, 184, 199, 0.18), transparent 65%),
+    radial-gradient(circle at 48% 82%, rgba(195, 138, 86, 0.24), transparent 65%);
+  opacity: 0.55;
+  animation: floatGlow 32s ease-in-out infinite;
+}
+
+.app-shell::after {
+  background: radial-gradient(circle at 16% 68%, rgba(102, 184, 199, 0.2), transparent 65%),
+    radial-gradient(circle at 88% 74%, rgba(125, 223, 156, 0.18), transparent 70%);
+  opacity: 0.45;
+  animation: floatGlow 42s linear infinite reverse;
 }
 
 .app-shell > * {
   min-height: 0;
+  position: relative;
+  z-index: 1;
 }
 
 .hud-brand {
@@ -91,55 +143,186 @@ body::after {
   align-self: end;
   display: flex;
   align-items: center;
-  gap: 0.85rem;
+  gap: 1.25rem;
+  padding: 0.95rem 1.4rem;
   font-family: var(--font-display);
-  font-size: 1.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-highlight);
-  text-shadow: 0 0 18px rgba(124, 200, 111, 0.45);
+  background: linear-gradient(135deg, rgba(31, 71, 49, 0.92), rgba(21, 53, 38, 0.96));
+  border-radius: calc(var(--border-radius-lg) + 10px);
+  border: 1px solid rgba(233, 248, 122, 0.28);
+  box-shadow: 0 18px 40px rgba(8, 22, 16, 0.65);
+  text-shadow: 0 0 18px rgba(124, 200, 111, 0.4);
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.hud-brand::before,
+.hud-brand::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 }
 
 .hud-brand::before {
-  content: '';
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
-  border: 2px solid rgba(211, 243, 107, 0.6);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.25), rgba(90, 169, 201, 0.4));
-  box-shadow: 0 0 22px rgba(124, 200, 111, 0.35);
+  inset: -65% 55% 22% -18%;
+  background: radial-gradient(circle at 50% 50%, rgba(125, 223, 156, 0.35), transparent 70%);
+  opacity: 0.45;
+  animation: floatGlow 26s ease-in-out infinite;
 }
+
+.hud-brand::after {
+  inset: -32% -38% 60% 42%;
+  background: radial-gradient(circle at 50% 50%, rgba(102, 184, 199, 0.28), transparent 72%);
+  opacity: 0.4;
+}
+
+.brand-crest {
+  position: relative;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: radial-gradient(circle at 28% 26%, rgba(233, 248, 122, 0.4), transparent 60%),
+    linear-gradient(135deg, rgba(95, 170, 118, 0.95), rgba(64, 136, 100, 0.95));
+  border: 1.5px solid rgba(233, 248, 122, 0.6);
+  box-shadow: 0 0 22px rgba(125, 223, 156, 0.35), inset 0 0 24px rgba(6, 18, 12, 0.65);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.brand-crest::before {
+  content: '';
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(233, 248, 122, 0.4), transparent 75%);
+  opacity: 0.7;
+}
+
+.brand-crest__leaf {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 22px;
+  height: 38px;
+  border-radius: 50% 50% 40% 40%;
+  background: radial-gradient(circle at 30% 32%, rgba(233, 248, 122, 0.6), rgba(125, 223, 156, 0.25) 55%, transparent 75%);
+  border: 1px solid rgba(233, 248, 122, 0.28);
+  filter: drop-shadow(0 6px 12px rgba(6, 18, 12, 0.45));
+  opacity: 0.85;
+  transform-origin: center;
+  z-index: 1;
+}
+
+.brand-crest__leaf--left {
+  transform: translate(-115%, -58%) rotate(-26deg);
+  animation: leafSwayLeft 12s ease-in-out infinite;
+}
+
+.brand-crest__leaf--right {
+  transform: translate(15%, -58%) rotate(26deg);
+  animation: leafSwayRight 12s ease-in-out infinite;
+}
+
+.brand-crest__seed {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(233, 248, 122, 0.85), rgba(125, 223, 156, 0.3) 65%, transparent 75%);
+  box-shadow: 0 0 16px rgba(233, 248, 122, 0.55);
+  z-index: 2;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  animation: crestPulse 5.6s ease-in-out infinite;
+}
+
+.brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+  position: relative;
+  z-index: 1;
+  align-items: flex-start;
+}
+
+.brand-copy span {
+  display: block;
+}
+
+.brand-title {
+  font-size: 1.65rem;
+  letter-spacing: 0.24em;
+  color: var(--color-highlight);
+  text-shadow: 0 0 22px rgba(124, 200, 111, 0.45);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.brand-subtitle {
+  font-family: var(--font-body);
+  font-size: 0.72rem;
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  text-shadow: 0 0 12px rgba(102, 184, 199, 0.3);
+  font-weight: 600;
+  line-height: 1.4;
+}
+
 
 .hud-nav {
   grid-column: 1;
   grid-row: 2;
-  background: var(--color-panel);
-  border: 1px solid var(--color-panel-border);
-  border-radius: var(--border-radius-lg);
-  padding: 1.6rem 1.25rem;
+  background: linear-gradient(165deg, rgba(23, 55, 37, 0.92), rgba(16, 42, 29, 0.92));
+  border: 1px solid rgba(148, 210, 189, 0.3);
+  border-radius: calc(var(--border-radius-lg) + 4px);
+  padding: 1.7rem 1.35rem;
   display: flex;
   flex-direction: column;
-  gap: 1.35rem;
+  gap: 1.45rem;
   position: relative;
   overflow: hidden;
   box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(14px);
+}
+
+.hud-nav::before,
+.hud-nav::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 }
 
 .hud-nav::before {
-  content: '';
-  position: absolute;
-  inset: -25% -40% 55% -40%;
-  background: radial-gradient(circle at 50% 38%, var(--color-panel-highlight), transparent 58%);
-  opacity: 0.4;
+  inset: -32% -55% 48% -42%;
+  background: radial-gradient(circle at 35% 40%, var(--color-panel-highlight), transparent 60%);
+  opacity: 0.45;
+}
+
+.hud-nav::after {
+  inset: 55% -42% -52% -28%;
+  background: radial-gradient(circle at 70% 60%, rgba(102, 184, 199, 0.28), transparent 70%);
+  opacity: 0.35;
 }
 
 .hud-nav h2 {
   margin: 0;
   font-family: var(--font-display);
   font-size: 1rem;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--color-highlight);
+  text-shadow: 0 0 14px rgba(125, 223, 156, 0.35);
 }
 
 .nav-tabs {
@@ -148,7 +331,7 @@ body::after {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 1rem;
 }
 
 .nav-tabs li {
@@ -157,48 +340,67 @@ body::after {
 
 .nav-tabs button {
   width: 100%;
-  padding: 0.9rem 1rem;
-  border-radius: 16px;
+  padding: 0.95rem 1.1rem;
+  border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(61, 102, 76, 0.35);
+  background: linear-gradient(135deg, rgba(44, 84, 61, 0.48), rgba(27, 61, 43, 0.52));
   color: var(--color-text-secondary);
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   font-family: var(--font-display);
-  letter-spacing: 0.1em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease, color 0.22s ease,
+    background 0.22s ease, filter 0.22s ease;
   position: relative;
   overflow: hidden;
+  isolation: isolate;
+  text-shadow: 0 0 12px rgba(125, 223, 156, 0.3);
+  backdrop-filter: blur(6px);
 }
 
+.nav-tabs button::before,
 .nav-tabs button::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
+  border-radius: inherit;
+  pointer-events: none;
+  transition: opacity 0.22s ease;
+}
+
+.nav-tabs button::before {
+  background: radial-gradient(circle at 18% 24%, rgba(125, 223, 156, 0.2), transparent 65%),
+    radial-gradient(circle at 82% 72%, rgba(102, 184, 199, 0.16), transparent 70%);
+  opacity: 0.55;
+  mix-blend-mode: screen;
+}
+
+.nav-tabs button::after {
+  background: linear-gradient(135deg, rgba(125, 223, 156, 0.28), rgba(102, 184, 199, 0.18));
   opacity: 0;
-  transition: opacity 0.2s ease;
+  z-index: -1;
 }
 
 .nav-tabs button:hover,
 .nav-tabs button:focus-visible {
-  border-color: rgba(124, 200, 111, 0.6);
+  border-color: rgba(125, 223, 156, 0.55);
   color: var(--color-text-primary);
-  transform: translateY(-1px);
-  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(13, 36, 24, 0.45);
   outline: none;
 }
 
 .nav-tabs button:hover::after,
 .nav-tabs button:focus-visible::after {
-  opacity: 1;
+  opacity: 0.8;
 }
 
 .nav-tabs button.active {
-  border-color: rgba(211, 243, 107, 0.75);
+  border-color: rgba(233, 248, 122, 0.72);
   color: var(--color-text-primary);
-  box-shadow: 0 14px 32px rgba(20, 52, 36, 0.45);
+  box-shadow: 0 16px 34px rgba(15, 45, 30, 0.55);
+  background: linear-gradient(135deg, rgba(125, 223, 156, 0.35), rgba(102, 184, 199, 0.28));
 }
 
 .nav-tabs button.active::after {
@@ -206,35 +408,39 @@ body::after {
 }
 
 .panel {
-  background: linear-gradient(165deg, rgba(33, 71, 51, 0.92), rgba(23, 50, 35, 0.92));
-  border: 1px solid var(--color-panel-border);
-  border-radius: var(--border-radius-lg);
-  padding: 1.6rem 1.75rem;
+  background: linear-gradient(165deg, rgba(27, 60, 41, 0.92), rgba(15, 40, 29, 0.92));
+  border: 1px solid rgba(148, 210, 189, 0.28);
+  border-radius: calc(var(--border-radius-lg) + 2px);
+  padding: 1.75rem 1.9rem;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
+  gap: 1.2rem;
   position: relative;
   overflow: hidden;
   min-height: 0;
   box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(16px);
 }
 
-.panel::before {
-  content: '';
-  position: absolute;
-  inset: -20% -35% 65% -25%;
-  background: radial-gradient(circle at 32% 24%, rgba(124, 200, 111, 0.25), transparent 60%);
-  opacity: 0.55;
-  pointer-events: none;
-}
-
+.panel::before,
 .panel::after {
   content: '';
   position: absolute;
-  inset: 60% -30% -25% -20%;
-  background: radial-gradient(circle at 70% 80%, rgba(90, 169, 201, 0.18), transparent 60%);
-  opacity: 0.4;
   pointer-events: none;
+}
+
+.panel::before {
+  inset: -24% -32% 60% -26%;
+  background: radial-gradient(circle at 32% 24%, rgba(125, 223, 156, 0.3), transparent 62%);
+  opacity: 0.58;
+  animation: floatGlow 36s linear infinite;
+}
+
+.panel::after {
+  inset: 58% -26% -30% -18%;
+  background: radial-gradient(circle at 70% 80%, rgba(102, 184, 199, 0.22), transparent 62%);
+  opacity: 0.42;
+  animation: floatGlow 44s ease-in-out infinite reverse;
 }
 
 .panel > * {
@@ -261,24 +467,28 @@ body::after {
   align-items: flex-end;
   justify-content: space-between;
   font-family: var(--font-display);
-  letter-spacing: 0.14em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  font-size: 0.95rem;
+  font-size: 0.96rem;
   color: var(--color-highlight);
-  gap: 1rem;
+  gap: 1.2rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  text-shadow: 0 0 12px rgba(125, 223, 156, 0.35);
 }
 
 .panel-header [data-role='list-context'] {
-  font-size: 0.85rem;
-  letter-spacing: 0.16em;
+  font-size: 0.82rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-water);
+  text-shadow: 0 0 10px rgba(102, 184, 199, 0.35);
 }
 
 .weapon-cards {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 1rem;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
@@ -286,105 +496,155 @@ body::after {
 }
 
 .weapon-card {
+  position: relative;
   border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: 18px;
-  padding: 1rem 1.2rem;
-  background: rgba(46, 88, 64, 0.4);
+  border-radius: 20px;
+  padding: 1.1rem 1.35rem;
+  background: linear-gradient(145deg, rgba(34, 76, 52, 0.55), rgba(20, 54, 36, 0.6));
   color: var(--color-text-secondary);
   cursor: pointer;
-  transition: all 0.18s ease;
+  transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease, color 0.22s ease,
+    background 0.22s ease;
+  overflow: hidden;
+}
+
+.weapon-card::before,
+.weapon-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  transition: opacity 0.22s ease;
+}
+
+.weapon-card::before {
+  background: radial-gradient(circle at 18% 20%, rgba(125, 223, 156, 0.26), transparent 60%),
+    radial-gradient(circle at 82% 78%, rgba(102, 184, 199, 0.18), transparent 65%);
+  opacity: 0.55;
+}
+
+.weapon-card::after {
+  inset: 12% 18%;
+  border: 1px solid rgba(233, 248, 122, 0.2);
+  opacity: 0;
 }
 
 .weapon-card:hover,
 .weapon-card:focus-visible {
-  border-color: rgba(124, 200, 111, 0.55);
-  box-shadow: 0 12px 26px rgba(16, 45, 31, 0.35);
-  background: rgba(46, 88, 64, 0.55);
+  border-color: rgba(125, 223, 156, 0.55);
+  box-shadow: 0 14px 30px rgba(12, 34, 24, 0.45);
+  background: linear-gradient(145deg, rgba(44, 92, 64, 0.62), rgba(24, 58, 40, 0.68));
   outline: none;
   color: var(--color-text-primary);
+  transform: translateY(-2px);
+}
+
+.weapon-card:hover::after,
+.weapon-card:focus-visible::after {
+  opacity: 1;
 }
 
 .weapon-card.active {
-  border-color: rgba(211, 243, 107, 0.75);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.38), rgba(90, 169, 201, 0.28));
+  border-color: rgba(233, 248, 122, 0.75);
+  background: linear-gradient(140deg, rgba(125, 223, 156, 0.38), rgba(102, 184, 199, 0.3));
   color: var(--color-text-primary);
-  box-shadow: 0 14px 30px rgba(17, 46, 33, 0.45);
+  box-shadow: 0 16px 34px rgba(14, 38, 28, 0.55);
+}
+
+.weapon-card.active::after {
+  opacity: 1;
+  border-color: rgba(233, 248, 122, 0.45);
 }
 
 .weapon-card h3 {
-  margin: 0 0 0.4rem;
-  font-size: 1.1rem;
+  margin: 0 0 0.45rem;
+  font-size: 1.12rem;
   color: var(--color-text-primary);
   font-family: var(--font-display);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
+  text-shadow: 0 0 12px rgba(125, 223, 156, 0.28);
 }
 
 .weapon-card dl {
   margin: 0;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.3rem 0.6rem;
-  font-size: 0.8rem;
+  gap: 0.35rem 0.75rem;
+  font-size: 0.82rem;
 }
 
-dl dt {
-  opacity: 0.7;
+.weapon-card dl dt {
+  opacity: 0.72;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
 }
+
+.weapon-card dl dd {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
 
 .detail-content {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
+  gap: 1.2rem;
   min-height: 0;
   overflow-y: auto;
-  padding-right: 0.4rem;
+  padding-right: 0.45rem;
 }
 
 .detail-content h3 {
   margin: 0;
-  font-size: 1.4rem;
+  font-size: 1.45rem;
   font-family: var(--font-display);
-  letter-spacing: 0.16em;
+  letter-spacing: 0.18em;
   color: var(--color-text-primary);
+  text-shadow: 0 0 16px rgba(125, 223, 156, 0.35);
 }
 
 .description {
   margin: 0;
-  font-size: 0.92rem;
+  font-size: 0.94rem;
   line-height: 1.7;
   color: var(--color-text-secondary);
+  text-shadow: 0 0 10px rgba(21, 52, 38, 0.35);
 }
+
 
 .stat-grid {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.15rem;
   font-size: 0.9rem;
 }
 
 .stat-grid .stat {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.5rem;
 }
 
 .stat-bar-header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .stat-label {
   font-size: 0.75rem;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.72);
+  color: var(--color-text-muted);
 }
 
 .stat-bar-value {
-  font-size: 0.85rem;
+  font-size: 0.86rem;
   color: var(--color-text-secondary);
   font-weight: 600;
   white-space: nowrap;
@@ -399,10 +659,10 @@ dl dt {
 .stat-bar-track {
   position: relative;
   height: 0.75rem;
-  background: rgba(124, 200, 111, 0.15);
+  background: linear-gradient(90deg, rgba(22, 48, 34, 0.68), rgba(18, 42, 30, 0.78));
   border-radius: 999px;
   overflow: hidden;
-  border: 1px solid rgba(124, 200, 111, 0.35);
+  border: 1px solid rgba(125, 223, 156, 0.38);
   box-shadow: inset 0 0 18px rgba(6, 18, 12, 0.6);
 }
 
@@ -410,8 +670,9 @@ dl dt {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 15% 50%, rgba(243, 248, 240, 0.25), transparent 65%);
-  opacity: 0.45;
+  background: radial-gradient(circle at 18% 50%, rgba(233, 248, 122, 0.25), transparent 65%),
+    linear-gradient(90deg, rgba(125, 223, 156, 0.18), rgba(102, 184, 199, 0.08));
+  opacity: 0.5;
 }
 
 .stat-bar-fill {
@@ -419,8 +680,8 @@ dl dt {
   position: absolute;
   inset: 0;
   width: calc(var(--fill, 0) * 1%);
-  background: linear-gradient(90deg, rgba(124, 200, 111, 0.85), rgba(211, 243, 107, 0.95));
-  box-shadow: 0 0 18px rgba(124, 200, 111, 0.55);
+  background: linear-gradient(90deg, rgba(125, 223, 156, 0.85), rgba(233, 248, 122, 0.95));
+  box-shadow: 0 0 18px rgba(125, 223, 156, 0.55);
   transition: width 220ms ease-out;
 }
 
@@ -434,78 +695,120 @@ dl dt {
 
 .special-section {
   border-top: 1px solid rgba(255, 255, 255, 0.08);
-  padding-top: 0.9rem;
+  padding-top: 1rem;
 }
 
 .special-section h4 {
-  margin: 0 0 0.6rem;
+  margin: 0 0 0.65rem;
   font-size: 0.8rem;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--color-highlight);
+  text-shadow: 0 0 12px rgba(125, 223, 156, 0.3);
 }
 
 .special-list {
   margin: 0;
-  padding-left: 1rem;
-  list-style: square;
+  padding-left: 0;
+  list-style: none;
   font-size: 0.9rem;
   color: var(--color-text-secondary);
   line-height: 1.65;
+  display: grid;
+  gap: 0.5rem;
 }
 
-.special-list li + li {
-  margin-top: 0.5rem;
+.special-list li {
+  position: relative;
+  padding-left: 1.15rem;
+}
+
+.special-list li::before {
+  content: '';
+  position: absolute;
+  top: 0.55rem;
+  left: 0;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, rgba(125, 223, 156, 0.75), rgba(102, 184, 199, 0.5));
+  box-shadow: 0 0 8px rgba(125, 223, 156, 0.35);
 }
 
 .special-key {
-  color: var(--color-text-primary);
+  color: var(--color-highlight);
   font-weight: 600;
+  text-shadow: 0 0 10px rgba(125, 223, 156, 0.3);
 }
 
 .panel-footer {
-  font-size: 0.78rem;
-  letter-spacing: 0.14em;
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.76rem;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.65);
+  color: var(--color-text-muted);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding-top: 0.85rem;
+  text-shadow: 0 0 8px rgba(102, 184, 199, 0.25);
+}
+
+.panel-footer::before {
+  content: '';
+  display: inline-block;
+  width: 24px;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(125, 223, 156, 0.55), rgba(102, 184, 199, 0));
+  opacity: 0.7;
 }
 
 .weapon-cards,
 .detail-content {
   scrollbar-width: thin;
-  scrollbar-color: rgba(90, 169, 201, 0.55) transparent;
+  scrollbar-color: rgba(125, 223, 156, 0.5) rgba(21, 48, 35, 0.55);
 }
 
 .weapon-cards::-webkit-scrollbar,
 .detail-content::-webkit-scrollbar {
-  width: 6px;
+  width: 7px;
 }
 
 .weapon-cards::-webkit-scrollbar-track,
 .detail-content::-webkit-scrollbar-track {
-  background: transparent;
+  background: rgba(21, 48, 35, 0.45);
+  border-radius: 999px;
 }
 
 .weapon-cards::-webkit-scrollbar-thumb,
 .detail-content::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(90, 169, 201, 0.65), rgba(124, 200, 111, 0.55));
-  border-radius: 6px;
+  background: linear-gradient(180deg, rgba(125, 223, 156, 0.7), rgba(102, 184, 199, 0.6));
+  border-radius: 999px;
+}
+
+.weapon-cards::-webkit-scrollbar-thumb:hover,
+.detail-content::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, rgba(125, 223, 156, 0.85), rgba(102, 184, 199, 0.72));
 }
 
 .rarity-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.4rem 1rem;
+  padding: 0.45rem 1.1rem;
   border-radius: 999px;
-  border: 1px solid rgba(211, 243, 107, 0.6);
+  border: 1px solid rgba(233, 248, 122, 0.5);
   font-size: 0.75rem;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--color-highlight);
-  background: rgba(90, 169, 201, 0.18);
+  background: rgba(102, 184, 199, 0.18);
   min-width: 128px;
   text-align: center;
+  text-shadow: 0 0 12px rgba(102, 184, 199, 0.35);
+  box-shadow: 0 0 16px rgba(102, 184, 199, 0.25);
+  backdrop-filter: blur(4px);
 }
 
 .rarity-badge.rarity-common {
@@ -548,37 +851,131 @@ dl dt {
   grid-column: 4;
   grid-row: 1 / span 2;
   position: relative;
-  background: linear-gradient(160deg, rgba(24, 52, 36, 0.95), rgba(20, 47, 57, 0.92));
-  border: 1px solid rgba(90, 169, 201, 0.35);
-  border-radius: calc(var(--border-radius-lg) + 4px);
+  background: linear-gradient(160deg, rgba(20, 52, 34, 0.95), rgba(17, 42, 46, 0.92));
+  border: 1px solid rgba(102, 184, 199, 0.32);
+  border-radius: calc(var(--border-radius-lg) + 6px);
   overflow: hidden;
   box-shadow: var(--shadow-soft);
   min-height: 0;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  isolation: isolate;
+  backdrop-filter: blur(12px);
 }
 
 .stage::before {
   content: '';
   position: absolute;
-  inset: -25% -18% 60% -18%;
-  background: radial-gradient(circle at 62% 35%, rgba(124, 200, 111, 0.28), transparent 62%);
-  opacity: 0.55;
+  inset: -28% -22% 58% -18%;
+  background: radial-gradient(circle at 62% 35%, rgba(125, 223, 156, 0.32), transparent 62%),
+    radial-gradient(circle at 24% 72%, rgba(102, 184, 199, 0.24), transparent 68%);
+  opacity: 0.6;
   pointer-events: none;
+  animation: floatGlow 36s ease-in-out infinite;
 }
 
 .stage::after {
   content: '';
   position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 38% 72%, rgba(90, 169, 201, 0.22), transparent 70%),
-    radial-gradient(circle at 18% 28%, rgba(183, 128, 68, 0.18), transparent 58%);
-  opacity: 0.6;
+  inset: -15% -10% -12% -10%;
+  background:
+    radial-gradient(2px 2px at 18% 24%, rgba(233, 248, 122, 0.8), transparent 70%),
+    radial-gradient(2px 2px at 42% 72%, rgba(102, 184, 199, 0.75), transparent 70%),
+    radial-gradient(2px 2px at 78% 38%, rgba(233, 248, 122, 0.85), transparent 70%),
+    radial-gradient(2px 2px at 62% 82%, rgba(125, 223, 156, 0.8), transparent 70%);
+  opacity: 0.75;
+  mix-blend-mode: screen;
   pointer-events: none;
+  animation: fireflyTwinkle 18s linear infinite;
 }
 
 .stage canvas {
   width: 100%;
   height: 100%;
   display: block;
+  position: relative;
+  z-index: 1;
+}
+
+@keyframes canopyDrift {
+  0% {
+    transform: translate3d(-2%, -1%, 0) scale(1);
+  }
+
+  50% {
+    transform: translate3d(1.5%, 1.5%, 0) scale(1.02);
+  }
+
+  100% {
+    transform: translate3d(-1%, 2%, 0) scale(1);
+  }
+}
+
+@keyframes floatGlow {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+
+  50% {
+    transform: translate3d(1.5%, -1.5%, 0) scale(1.03);
+  }
+
+  100% {
+    transform: translate3d(-1.2%, 1.2%, 0) scale(1);
+  }
+}
+
+@keyframes crestPulse {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+
+  50% {
+    transform: translate(-50%, -50%) scale(1.12);
+    opacity: 0.85;
+  }
+}
+
+@keyframes leafSwayLeft {
+  0%,
+  100% {
+    transform: translate(-115%, -58%) rotate(-26deg);
+  }
+
+  50% {
+    transform: translate(-110%, -60%) rotate(-18deg);
+  }
+}
+
+@keyframes leafSwayRight {
+  0%,
+  100% {
+    transform: translate(15%, -58%) rotate(26deg);
+  }
+
+  50% {
+    transform: translate(10%, -60%) rotate(18deg);
+  }
+}
+
+@keyframes fireflyTwinkle {
+  0% {
+    opacity: 0.45;
+    transform: translate3d(0, 0, 0);
+  }
+
+  50% {
+    opacity: 0.9;
+    transform: translate3d(1.4%, -1.4%, 0);
+  }
+
+  100% {
+    opacity: 0.45;
+    transform: translate3d(-1.4%, 1.4%, 0);
+  }
 }
 
 @media (max-width: 1400px) {
@@ -626,6 +1023,10 @@ dl dt {
     grid-column: 1;
     grid-row: 1;
     align-self: center;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.9rem;
   }
 
   .hud-nav {
@@ -634,10 +1035,19 @@ dl dt {
     flex-direction: row;
     align-items: center;
     gap: 1.1rem;
+    padding: 1.3rem;
   }
 
   .hud-nav h2 {
     margin-bottom: 0;
+  }
+
+  .brand-copy {
+    align-items: center;
+  }
+
+  .brand-title {
+    white-space: normal;
   }
 
   .nav-tabs {
@@ -676,8 +1086,31 @@ dl dt {
     padding: 1.5rem;
   }
 
+  .hud-brand {
+    padding: 0.85rem 1.1rem;
+  }
+
+  .brand-title {
+    font-size: 1.45rem;
+  }
+
+  .brand-subtitle {
+    letter-spacing: 0.34em;
+    font-size: 0.7rem;
+  }
+
   .nav-tabs {
     flex-wrap: wrap;
+  }
+
+  .hud-nav {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.1rem;
+  }
+
+  .nav-tabs {
+    width: 100%;
   }
 
   .nav-tabs li {
@@ -686,5 +1119,15 @@ dl dt {
 
   .stage {
     height: 260px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- rebuild the HUD brand markup with a crest emblem, tagline, and warmer default messaging to set a natural tone for the interface
- retheme the global background and layout shell with organic gradients and floating glow animations for a forest-inspired atmosphere
- restyle navigation, panels, weapon cards, detail content, scrollbars, and the 3D stage with earthy palettes, soft lighting, and motion while respecting reduced-motion preferences

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c8f8712a9c83299716679af1a11ed7