### PR TITLE
Add critter selector and animation playback controls

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -1,6 +1,9 @@
 import { SceneManager } from '../core/SceneManager.js';
 import { HUDController } from '../hud/HUDController.js';
 import { sampleWeapons } from '../data/sampleWeapons.js';
+import { critters } from '../data/critters.js';
+import { CritterSelector } from '../hud/components/CritterSelector.js';
+import { AnimationControls } from '../hud/components/AnimationControls.js';
 import { createEventBus } from '../utils/eventBus.js';
 
 export class WeaponDisplayApp {
@@ -9,21 +12,46 @@ export class WeaponDisplayApp {
     this.eventBus = createEventBus();
     this.sceneManager = null;
     this.hudController = null;
+    this.critterSelector = null;
+    this.animationControls = null;
 
     this.weapons = sampleWeapons;
     this.weaponMap = new Map();
     this.categories = ['primary', 'secondary', 'melee', 'utility'];
     this.activeCategory = 'primary';
     this.activeWeapon = null;
+
+    this.critters = critters;
+    this.critterMap = new Map();
+    this.activeCritter = null;
+    this.activeAnimationId = null;
   }
 
   init() {
     const layout = this.buildLayout();
     this.indexWeapons();
+    this.indexCritters();
     this.registerEventHandlers();
 
-    this.sceneManager = new SceneManager(layout.stageElement);
+    this.sceneManager = new SceneManager(layout.stageViewportElement);
     this.sceneManager.init();
+
+    this.critterSelector = new CritterSelector({
+      element: layout.critterSelectorElement,
+      critters: this.critters,
+      activeCritterId: this.activeCritter?.id ?? null,
+      onSelect: (critterId) => {
+        this.handleCritterSelection(critterId);
+      },
+    });
+    this.critterSelector.render();
+
+    this.animationControls = new AnimationControls({
+      element: layout.animationControlsElement,
+      onSelect: (animationId) => {
+        this.handleAnimationSelection(animationId);
+      },
+    });
 
     this.hudController = new HUDController({
       bus: this.eventBus,
@@ -49,15 +77,23 @@ export class WeaponDisplayApp {
       this.activeWeapon = defaultWeapon;
       this.sceneManager.loadWeapon(defaultWeapon);
     }
+
+    this.initializeCritters();
   }
 
   buildLayout() {
     this.root.innerHTML = `
       <div class="app-shell">
         <div class="hud-brand">Crtiz Armory</div>
-        <nav class="hud-nav" aria-label="Weapon categories">
-          <h2>Categories</h2>
-          <ul class="nav-tabs" data-component="nav-tabs"></ul>
+        <nav class="hud-nav" aria-label="Armory navigation">
+          <div class="nav-section" data-section="critters">
+            <h2>Critters</h2>
+            <div class="critter-selector" data-component="critter-selector"></div>
+          </div>
+          <div class="nav-section" data-section="categories">
+            <h2>Categories</h2>
+            <ul class="nav-tabs" data-component="nav-tabs"></ul>
+          </div>
         </nav>
         <section class="panel hud-panel hud-list" data-component="weapon-list">
           <div class="panel-header">
@@ -77,12 +113,18 @@ export class WeaponDisplayApp {
           </div>
           <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
         </section>
-        <section class="stage" data-component="stage"></section>
+        <section class="stage" data-component="stage">
+          <div class="stage-overlay">
+            <div class="stage-toolbar" data-component="animation-controls"></div>
+          </div>
+          <div class="stage-viewport" data-role="stage-viewport"></div>
+        </section>
       </div>
     `;
 
     return {
       stageElement: this.root.querySelector('[data-component="stage"]'),
+      stageViewportElement: this.root.querySelector('[data-role="stage-viewport"]'),
       navTabsElement: this.root.querySelector('[data-component="nav-tabs"]'),
       weaponListPanel: this.root.querySelector('[data-component="weapon-list"]'),
       weaponDetailPanel: this.root.querySelector('[data-component="weapon-detail"]'),
@@ -90,6 +132,8 @@ export class WeaponDisplayApp {
       listFooter: this.root.querySelector('[data-role="list-footer"]'),
       rarityBadge: this.root.querySelector('[data-role="rarity-badge"]'),
       detailFooter: this.root.querySelector('[data-role="detail-footer"]'),
+      critterSelectorElement: this.root.querySelector('[data-component="critter-selector"]'),
+      animationControlsElement: this.root.querySelector('[data-component="animation-controls"]'),
     };
   }
 
@@ -116,6 +160,17 @@ export class WeaponDisplayApp {
     });
   }
 
+  indexCritters() {
+    this.critterMap.clear();
+    this.critters.forEach((critter, index) => {
+      this.critterMap.set(critter.id, critter);
+      if (index === 0) {
+        this.activeCritter = critter;
+        this.activeAnimationId = critter.defaultAnimationId ?? critter.animations?.[0]?.id ?? null;
+      }
+    });
+  }
+
   groupWeaponsByCategory() {
     return this.weapons.reduce((acc, weapon) => {
       const bucket = acc[weapon.category] || [];
@@ -129,5 +184,68 @@ export class WeaponDisplayApp {
     const byCategory = this.groupWeaponsByCategory();
     const defaultList = byCategory[this.activeCategory];
     return defaultList && defaultList.length > 0 ? defaultList[0] : null;
+  }
+
+  async initializeCritters() {
+    if (!this.activeCritter) return;
+
+    if (this.critterSelector) {
+      this.critterSelector.setActive(this.activeCritter.id);
+    }
+
+    if (this.animationControls) {
+      this.animationControls.setAnimations(
+        this.activeCritter.animations,
+        this.activeAnimationId
+      );
+    }
+
+    await this.sceneManager.loadCritter(this.activeCritter);
+    await this.playActiveAnimation();
+  }
+
+  async handleCritterSelection(critterId) {
+    const critter = this.critterMap.get(critterId);
+    if (!critter || critter === this.activeCritter) {
+      return;
+    }
+
+    this.activeCritter = critter;
+    this.activeAnimationId = critter.defaultAnimationId ?? critter.animations?.[0]?.id ?? null;
+
+    if (this.critterSelector) {
+      this.critterSelector.setActive(critter.id);
+    }
+
+    if (this.animationControls) {
+      this.animationControls.setAnimations(critter.animations, this.activeAnimationId);
+    }
+
+    await this.sceneManager.loadCritter(critter);
+    await this.playActiveAnimation();
+  }
+
+  async handleAnimationSelection(animationId) {
+    this.activeAnimationId = animationId || null;
+    if (this.animationControls) {
+      this.animationControls.setActive(animationId);
+    }
+    await this.playActiveAnimation();
+  }
+
+  async playActiveAnimation() {
+    if (!this.activeCritter) {
+      return;
+    }
+
+    const animation = this.activeCritter.animations.find(
+      (clip) => clip.id === this.activeAnimationId
+    );
+
+    if (animation) {
+      await this.sceneManager.playAnimation(animation);
+    } else {
+      this.sceneManager.stopAnimation();
+    }
   }
 }

--- a/src/data/critters.js
+++ b/src/data/critters.js
@@ -1,0 +1,113 @@
+const createAnimation = (file) => {
+  const base = file.replace(/\.glb$/i, '');
+  const cleaned = base.replace(/^TH_(Frog|Lizard)_/i, '');
+  const name = cleaned
+    .split('_')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ');
+
+  const id = base
+    .replace(/^TH_/i, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+
+  return {
+    id,
+    name,
+    path: `assets/models/critters/animations/${file}`,
+  };
+};
+
+const buildAnimations = (files) => files.map((file) => createAnimation(file));
+
+const frogAnimations = buildAnimations([
+  'TH_Frog_Idle.glb',
+  'TH_Frog_Wave.glb',
+  'TH_Frog_Walk.glb',
+  'TH_Frog_Walk_Forward.glb',
+  'TH_Frog_Walk_Back.glb',
+  'TH_Frog_Walk_Backward.glb',
+  'TH_Frog_Run.glb',
+  'TH_Frog_Run_Forward.glb',
+  'TH_Frog_Hop.glb',
+  'TH_Frog_Hop_Forward.glb',
+  'TH_Frog_Jump.glb',
+  'TH_Frog_Clap.glb',
+  'TH_Frog_Finger_Wag.glb',
+  'TH_Frog_Frustration.glb',
+  'TH_Frog_One_Thumb_Up.glb',
+  'TH_Frog_One_Thumb_Down.glb',
+  'TH_Frog_Two_Thumbs_Up.glb',
+  'TH_Frog_Two_Thumbs_Down.glb',
+  'TH_Frog_Victory.glb',
+  'TH_Frog_Push_Up.glb',
+  'TH_Frog_Sleep.glb',
+  'TH_Frog_Sit_01.glb',
+  'TH_Frog_Sit_02.glb',
+  'TH_Frog_Sit_Raise_Hand_01_A.glb',
+  'TH_Frog_Sit_Raise_Hand_01_B.glb',
+  'TH_Frog_Sit_Raise_Hand_02_A.glb',
+  'TH_Frog_Sit_Raise_Hand_02_B.glb',
+  'TH_Frog_Turn_Left_90.glb',
+  'TH_Frog_Turn_Right_90.glb',
+  'TH_Frog_Take_Hit.glb',
+  'TH_Frog_Strike.glb',
+  'TH_Frog_Sad_Walk.glb',
+  'TH_Frog_Sad_Walk_Forward.glb',
+  'TH_Frog_Death.glb',
+]);
+
+const lizardAnimations = buildAnimations([
+  'TH_Lizard_Idle.glb',
+  'TH_Lizard_Wave.glb',
+  'TH_Lizard_Walk.glb',
+  'TH_Lizard_Walk_Forward.glb',
+  'TH_Lizard_Walk_Back.glb',
+  'TH_Lizard_Walk_Backward.glb',
+  'TH_Lizard_Run.glb',
+  'TH_Lizard_Run_Forward.glb',
+  'TH_Lizard_Hop.glb',
+  'TH_Lizard_Hop_Forward.glb',
+  'TH_Lizard_Jump.glb',
+  'TH_Lizard_Clap.glb',
+  'TH_Lizard_Finger_Wag.glb',
+  'TH_Lizard_Frustration.glb',
+  'TH_Lizard_One_Thumb_Up.glb',
+  'TH_Lizard_One_Thumb_Down.glb',
+  'TH_Lizard_Two_Thumbs_Up.glb',
+  'TH_Lizard_Two_Thumbs_Down.glb',
+  'TH_Lizard_Victory.glb',
+  'TH_Lizard_Push_Up.glb',
+  'TH_Lizard_Sleep.glb',
+  'TH_Lizard_Sit_01.glb',
+  'TH_Lizard_Sit_02.glb',
+  'TH_Lizard_Sit_Raise_Hand_01_A.glb',
+  'TH_Lizard_Sit_Raise_Hand_01_B.glb',
+  'TH_Lizard_Sit_Raise_Hand_02_A.glb',
+  'TH_Lizard_Sit_Raise_Hand_02_B.glb',
+  'TH_Lizard_Turn_Left_90.glb',
+  'TH_Lizard_Turn_Right_90.glb',
+  'TH_Lizard_Take_Hit.glb',
+  'TH_Lizard_Strike.glb',
+  'TH_Lizard_Sad_Walk.glb',
+  'TH_Lizard_Sad_Walk_Forward.glb',
+  'TH_Lizard_Death.glb',
+]);
+
+export const critters = [
+  {
+    id: 'frog',
+    name: 'Frog',
+    modelPath: 'assets/models/critters/models/SK_TH_Frog_Rigged_01.glb',
+    defaultAnimationId: 'frog-idle',
+    animations: frogAnimations,
+  },
+  {
+    id: 'lizard',
+    name: 'Lizard',
+    modelPath: 'assets/models/critters/models/SK_TH_Lizard_Rigged_01.glb',
+    defaultAnimationId: 'lizard-idle',
+    animations: lizardAnimations,
+  },
+];
+

--- a/src/hud/components/AnimationControls.js
+++ b/src/hud/components/AnimationControls.js
@@ -1,0 +1,66 @@
+export class AnimationControls {
+  constructor({ element, onSelect }) {
+    this.element = element;
+    this.onSelect = onSelect;
+    this.animations = [];
+    this.activeAnimationId = null;
+    this.selectElement = null;
+
+    this.render();
+  }
+
+  render() {
+    if (!this.element) return;
+
+    this.element.innerHTML = `
+      <label class="animation-label" for="animation-select">Animation</label>
+      <select id="animation-select" class="animation-select" data-role="animation-select">
+        <option value="">Choose animation</option>
+      </select>
+    `;
+
+    this.selectElement = this.element.querySelector('[data-role="animation-select"]');
+    if (this.selectElement) {
+      this.selectElement.addEventListener('change', (event) => {
+        const value = event.target.value || null;
+        this.activeAnimationId = value;
+        if (typeof this.onSelect === 'function') {
+          this.onSelect(value);
+        }
+      });
+    }
+
+    this.refreshOptions();
+  }
+
+  setAnimations(animations = [], activeId = null) {
+    this.animations = animations.slice();
+    this.activeAnimationId = activeId || null;
+    this.refreshOptions();
+  }
+
+  setActive(animationId) {
+    this.activeAnimationId = animationId || null;
+    if (this.selectElement) {
+      this.selectElement.value = this.activeAnimationId || '';
+    }
+  }
+
+  refreshOptions() {
+    if (!this.selectElement) return;
+
+    const sorted = this.animations.slice().sort((a, b) => a.name.localeCompare(b.name));
+    const options = [`<option value="">Choose animation</option>`].concat(
+      sorted.map((animation) => {
+        const selected = animation.id === this.activeAnimationId ? ' selected' : '';
+        return `<option value="${animation.id}"${selected}>${animation.name}</option>`;
+      })
+    );
+
+    this.selectElement.innerHTML = options.join('');
+    if (this.activeAnimationId) {
+      this.selectElement.value = this.activeAnimationId;
+    }
+  }
+}
+

--- a/src/hud/components/CritterSelector.js
+++ b/src/hud/components/CritterSelector.js
@@ -1,0 +1,66 @@
+export class CritterSelector {
+  constructor({ element, critters = [], activeCritterId = null, onSelect }) {
+    this.element = element;
+    this.critters = critters;
+    this.activeCritterId = activeCritterId;
+    this.onSelect = onSelect;
+  }
+
+  render() {
+    if (!this.element) return;
+
+    this.element.innerHTML = `
+      <div class="critter-selector-grid">
+        ${this.critters
+          .map((critter) => this.createButtonMarkup(critter))
+          .join('')}
+      </div>
+    `;
+
+    this.element
+      .querySelectorAll('[data-role="critter-button"]')
+      .forEach((button) => {
+        button.addEventListener('click', () => {
+          const critterId = button.getAttribute('data-critter-id');
+          this.setActive(critterId);
+          if (typeof this.onSelect === 'function') {
+            this.onSelect(critterId);
+          }
+        });
+      });
+
+    this.setActive(this.activeCritterId);
+  }
+
+  createButtonMarkup(critter) {
+    const isActive = critter.id === this.activeCritterId;
+    const activeClass = isActive ? ' is-active' : '';
+    const ariaPressed = isActive ? 'true' : 'false';
+
+    return `
+      <button
+        type="button"
+        class="critter-button${activeClass}"
+        data-role="critter-button"
+        data-critter-id="${critter.id}"
+        aria-pressed="${ariaPressed}"
+      >
+        <span class="critter-name">${critter.name}</span>
+      </button>
+    `;
+  }
+
+  setActive(critterId) {
+    this.activeCritterId = critterId;
+    if (!this.element) return;
+
+    this.element
+      .querySelectorAll('[data-role="critter-button"]')
+      .forEach((button) => {
+        const isMatch = button.getAttribute('data-critter-id') === critterId;
+        button.classList.toggle('is-active', isMatch);
+        button.setAttribute('aria-pressed', isMatch ? 'true' : 'false');
+      });
+  }
+}
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -119,7 +119,7 @@ body::after {
   padding: 1.6rem 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 1.35rem;
+  gap: 1.5rem;
   position: relative;
   overflow: hidden;
   box-shadow: var(--shadow-soft);
@@ -140,6 +140,67 @@ body::after {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--color-highlight);
+}
+
+.nav-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+}
+
+.nav-section[data-section='critters'] {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.critter-selector {
+  display: flex;
+  flex-direction: column;
+}
+
+.critter-selector-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.critter-button {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(55, 96, 71, 0.35);
+  color: var(--color-text-secondary);
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.critter-button:hover,
+.critter-button:focus-visible {
+  border-color: rgba(124, 200, 111, 0.6);
+  color: var(--color-text-primary);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+  outline: none;
+}
+
+.critter-button.is-active {
+  border-color: rgba(211, 243, 107, 0.75);
+  color: var(--color-text-primary);
+  background: linear-gradient(140deg, rgba(124, 200, 111, 0.32), rgba(90, 169, 201, 0.28));
+  box-shadow: 0 16px 32px rgba(20, 52, 34, 0.42);
+}
+
+.critter-name {
+  position: relative;
+  z-index: 1;
 }
 
 .nav-tabs {
@@ -575,10 +636,67 @@ dl dt {
   pointer-events: none;
 }
 
+.stage-viewport {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .stage canvas {
   width: 100%;
   height: 100%;
   display: block;
+}
+
+.stage-overlay {
+  position: absolute;
+  inset: 0;
+  padding: 1.5rem 1.5rem 1.5rem 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  pointer-events: none;
+}
+
+.stage-toolbar {
+  pointer-events: auto;
+  background: rgba(14, 34, 28, 0.78);
+  border: 1px solid rgba(90, 169, 201, 0.45);
+  border-radius: 14px;
+  padding: 0.85rem 1.1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 12px 30px rgba(6, 18, 14, 0.5);
+}
+
+.animation-label {
+  font-family: var(--font-display);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--color-highlight);
+}
+
+.animation-select {
+  appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 10px;
+  background: rgba(33, 68, 52, 0.65);
+  color: var(--color-text-primary);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  padding: 0.55rem 2.2rem 0.55rem 0.75rem;
+  position: relative;
+  min-width: 180px;
+}
+
+.animation-select:focus-visible {
+  outline: none;
+  border-color: rgba(124, 200, 111, 0.65);
+  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.2);
 }
 
 @media (max-width: 1400px) {
@@ -631,13 +749,23 @@ dl dt {
   .hud-nav {
     grid-column: 1;
     grid-row: 2;
-    flex-direction: row;
-    align-items: center;
-    gap: 1.1rem;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.2rem;
   }
 
   .hud-nav h2 {
     margin-bottom: 0;
+  }
+
+  .nav-section[data-section='critters'] {
+    border-bottom: none;
+    padding-bottom: 0.5rem;
+  }
+
+  .nav-section[data-section='categories'] {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding-top: 0.75rem;
   }
 
   .nav-tabs {


### PR DESCRIPTION
## Summary
- add a critter selector and animation controls to the HUD so the stage can preview frog or lizard rigs
- describe the frog and lizard animation sets so the scene manager can request clips from disk
- update scene management to support orbit controls, critter loading, and animation playback while refreshing the stage styling

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ca27d0c6bc8329ab460fa4c9bfe9fa