### PR TITLE
Add critter viewport with animation controls

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -2,6 +2,9 @@ import { SceneManager } from '../core/SceneManager.js';
 import { HUDController } from '../hud/HUDController.js';
 import { sampleWeapons } from '../data/sampleWeapons.js';
 import { createEventBus } from '../utils/eventBus.js';
+import { CRITTERS, getCritterById } from '../data/critters.js';
+import { CritterSelector } from '../hud/components/CritterSelector.js';
+import { AnimationSelector } from '../hud/components/AnimationSelector.js';
 
 export class WeaponDisplayApp {
   constructor(rootElement) {
@@ -15,6 +18,15 @@ export class WeaponDisplayApp {
     this.categories = ['primary', 'secondary', 'melee', 'utility'];
     this.activeCategory = 'primary';
     this.activeWeapon = null;
+
+    this.critters = CRITTERS;
+    this.critterMap = new Map(this.critters.map((critter) => [critter.id, critter]));
+    this.activeCritterId = this.critters[0]?.id ?? null;
+    this.activeAnimationId = null;
+
+    this.critterSelector = null;
+    this.animationSelector = null;
+    this.critterNameElement = null;
   }
 
   init() {
@@ -36,6 +48,22 @@ export class WeaponDisplayApp {
       detailFooter: layout.detailFooter,
     });
 
+    this.critterSelector = new CritterSelector({
+      element: layout.critterSelectorElement,
+      critters: this.critters,
+      activeCritterId: this.activeCritterId,
+      onSelect: (critterId) => this.handleCritterSelection(critterId),
+    });
+    this.critterSelector.render();
+
+    this.animationSelector = new AnimationSelector({
+      element: layout.animationSelectorElement,
+      onSelect: (animationId) => this.handleAnimationSelection(animationId),
+    });
+    this.animationSelector.setLoading(true);
+
+    this.critterNameElement = layout.critterNameLabel;
+
     const defaultWeapon = this.findDefaultWeapon();
 
     this.hudController.init({
@@ -49,6 +77,10 @@ export class WeaponDisplayApp {
       this.activeWeapon = defaultWeapon;
       this.sceneManager.loadWeapon(defaultWeapon);
     }
+
+    if (this.activeCritterId) {
+      this.loadCritterById(this.activeCritterId);
+    }
   }
 
   buildLayout() {
@@ -56,8 +88,15 @@ export class WeaponDisplayApp {
       <div class="app-shell">
         <div class="hud-brand">Crtiz Armory</div>
         <nav class="hud-nav" aria-label="Weapon categories">
-          <h2>Categories</h2>
-          <ul class="nav-tabs" data-component="nav-tabs"></ul>
+          <div class="nav-section nav-section--critters">
+            <p class="nav-section-label">Critter</p>
+            <div data-component="critter-selector"></div>
+          </div>
+          <div class="nav-section-divider" role="presentation"></div>
+          <div class="nav-section nav-section--categories">
+            <h2>Categories</h2>
+            <ul class="nav-tabs" data-component="nav-tabs"></ul>
+          </div>
         </nav>
         <section class="panel hud-panel hud-list" data-component="weapon-list">
           <div class="panel-header">
@@ -77,19 +116,39 @@ export class WeaponDisplayApp {
           </div>
           <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
         </section>
-        <section class="stage" data-component="stage"></section>
+        <section class="stage" data-component="stage">
+          <div class="stage-overlay">
+            <div class="stage-toolbar">
+              <div class="stage-meta">
+                <span class="stage-label">Companion</span>
+                <h3 class="stage-critter-name" data-role="active-critter-name">---</h3>
+              </div>
+              <div class="stage-animation" data-component="animation-selector">
+                <span class="stage-label">Animation</span>
+                <div class="animation-select-wrapper">
+                  <select data-role="animation-select" aria-label="Critter animation"></select>
+                  <span class="animation-select-display" data-role="animation-status"></span>
+                </div>
+              </div>
+            </div>
+            <p class="stage-hint">Drag to orbit • Scroll to zoom</p>
+          </div>
+        </section>
       </div>
     `;
 
     return {
       stageElement: this.root.querySelector('[data-component="stage"]'),
       navTabsElement: this.root.querySelector('[data-component="nav-tabs"]'),
+      critterSelectorElement: this.root.querySelector('[data-component="critter-selector"]'),
       weaponListPanel: this.root.querySelector('[data-component="weapon-list"]'),
       weaponDetailPanel: this.root.querySelector('[data-component="weapon-detail"]'),
       listContextLabel: this.root.querySelector('[data-role="list-context"]'),
       listFooter: this.root.querySelector('[data-role="list-footer"]'),
       rarityBadge: this.root.querySelector('[data-role="rarity-badge"]'),
       detailFooter: this.root.querySelector('[data-role="detail-footer"]'),
+      animationSelectorElement: this.root.querySelector('[data-component="animation-selector"]'),
+      critterNameLabel: this.root.querySelector('[data-role="active-critter-name"]'),
     };
   }
 
@@ -107,6 +166,55 @@ export class WeaponDisplayApp {
       this.activeWeapon = weapon;
       this.sceneManager.loadWeapon(weapon);
     });
+  }
+
+  handleCritterSelection(critterId) {
+    if (!critterId || critterId === this.activeCritterId) {
+      return;
+    }
+
+    this.activeCritterId = critterId;
+    this.loadCritterById(critterId);
+  }
+
+  async loadCritterById(critterId) {
+    const critter = getCritterById(critterId);
+    if (!critter) {
+      console.warn(`Critter with id "${critterId}" was not found.`);
+      return;
+    }
+
+    if (this.critterNameElement) {
+      this.critterNameElement.textContent = critter.name;
+    }
+
+    this.animationSelector?.setLoading(true);
+    const animations = await this.sceneManager.loadCritter(critter);
+
+    if (critterId !== this.activeCritterId) {
+      return;
+    }
+
+    this.activeAnimationId = critter.defaultAnimationId || animations[0]?.id || null;
+    this.animationSelector?.setAnimations(animations, this.activeAnimationId);
+
+    if (this.activeAnimationId) {
+      this.sceneManager.playAnimation(this.activeAnimationId);
+      this.animationSelector?.setSelected(this.activeAnimationId);
+    }
+  }
+
+  handleAnimationSelection(animationId) {
+    if (!animationId || animationId === this.activeAnimationId) {
+      return;
+    }
+
+    const played = this.sceneManager.playAnimation(animationId);
+    if (played) {
+      this.activeAnimationId = animationId;
+    } else {
+      this.animationSelector?.setSelected(this.activeAnimationId ?? '');
+    }
   }
 
   indexWeapons() {

--- a/src/core/ResourceLoader.js
+++ b/src/core/ResourceLoader.js
@@ -2,7 +2,8 @@ import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
 
 export class ResourceLoader {
   constructor() {
-    this.cache = new Map();
+    this.gltfCache = new Map();
+    this.textureCache = new Map();
     this.loaderPromise = null;
   }
 
@@ -11,42 +12,64 @@ export class ResourceLoader {
       return this._createPlaceholder();
     }
 
-    if (this.cache.has(path)) {
-      return this.cache.get(path).clone();
+    const gltf = await this.loadGLTF(path);
+    if (gltf?.scene) {
+      return gltf.scene;
     }
 
-    try {
-      const loader = await this._getLoader();
-      const gltf = await loader.loadAsync(path);
-      const scene = gltf.scene || gltf.scenes?.[0];
-      if (scene) {
-        this.cache.set(path, scene);
-        return scene.clone(true);
-      }
-    } catch (error) {
-      console.warn(`Failed to load model at ${path}. Using fallback geometry instead.`, error);
-    }
-
-    const fallback = this._createPlaceholder();
-    this.cache.set(path, fallback);
-    return fallback.clone();
+    console.warn(`Failed to load model at ${path}. Using fallback geometry instead.`);
+    return this._createPlaceholder();
   }
 
   async loadTexture(path) {
     if (!path) return null;
-    if (this.cache.has(path)) {
-      return this.cache.get(path);
+    if (this.textureCache.has(path)) {
+      return this.textureCache.get(path);
     }
 
     const textureLoader = new THREE.TextureLoader();
     try {
       const texture = await textureLoader.loadAsync(path);
-      this.cache.set(path, texture);
+      this.textureCache.set(path, texture);
       return texture;
     } catch (error) {
       console.warn(`Failed to load texture at ${path}.`, error);
       return null;
     }
+  }
+
+  async loadGLTF(path) {
+    if (!path) return null;
+
+    if (this.gltfCache.has(path)) {
+      const cached = this.gltfCache.get(path);
+      return {
+        scene: cached.scene?.clone(true) ?? null,
+        animations: cached.animations.map((clip) => clip.clone()),
+      };
+    }
+
+    try {
+      const loader = await this._getLoader();
+      const gltf = await loader.loadAsync(path);
+      const scene = gltf.scene || gltf.scenes?.[0] || null;
+      const animations = (gltf.animations || []).map((clip) => clip.clone());
+
+      if (scene) {
+        this.gltfCache.set(path, {
+          scene,
+          animations: gltf.animations || [],
+        });
+        return {
+          scene: scene.clone(true),
+          animations,
+        };
+      }
+    } catch (error) {
+      console.warn(`Failed to load GLTF at ${path}.`, error);
+    }
+
+    return null;
   }
 
   async _getLoader() {

--- a/src/data/critters.js
+++ b/src/data/critters.js
@@ -1,0 +1,104 @@
+export const CRITTERS = [
+  {
+    id: 'frog',
+    name: 'Frog',
+    accentColor: '#7cc86f',
+    modelPath: 'assets/models/critters/models/SK_TH_Frog_Rigged_01.glb',
+    defaultAnimationId: 'idle',
+    animations: [
+      {
+        id: 'idle',
+        name: 'Idle',
+        path: 'assets/models/critters/animations/TH_Frog_Idle.glb',
+      },
+      {
+        id: 'run-forward',
+        name: 'Run Forward',
+        path: 'assets/models/critters/animations/TH_Frog_Run_Forward.glb',
+      },
+      {
+        id: 'walk-forward',
+        name: 'Walk Forward',
+        path: 'assets/models/critters/animations/TH_Frog_Walk_Forward.glb',
+      },
+      {
+        id: 'jump',
+        name: 'Jump',
+        path: 'assets/models/critters/animations/TH_Frog_Jump.glb',
+      },
+      {
+        id: 'clap',
+        name: 'Clap',
+        path: 'assets/models/critters/animations/TH_Frog_Clap.glb',
+      },
+      {
+        id: 'wave',
+        name: 'Wave',
+        path: 'assets/models/critters/animations/TH_Frog_Wave.glb',
+      },
+      {
+        id: 'victory',
+        name: 'Victory',
+        path: 'assets/models/critters/animations/TH_Frog_Victory.glb',
+      },
+      {
+        id: 'frustration',
+        name: 'Frustration',
+        path: 'assets/models/critters/animations/TH_Frog_Frustration.glb',
+      },
+    ],
+  },
+  {
+    id: 'lizard',
+    name: 'Lizard',
+    accentColor: '#5aa9c9',
+    modelPath: 'assets/models/critters/models/SK_TH_Lizard_Rigged_01.glb',
+    defaultAnimationId: 'idle',
+    animations: [
+      {
+        id: 'idle',
+        name: 'Idle',
+        path: 'assets/models/critters/animations/TH_Lizard_Idle.glb',
+      },
+      {
+        id: 'run-forward',
+        name: 'Run Forward',
+        path: 'assets/models/critters/animations/TH_Lizard_Run_Forward.glb',
+      },
+      {
+        id: 'walk-forward',
+        name: 'Walk Forward',
+        path: 'assets/models/critters/animations/TH_Lizard_Walk_Forward.glb',
+      },
+      {
+        id: 'jump',
+        name: 'Jump',
+        path: 'assets/models/critters/animations/TH_Lizard_Jump.glb',
+      },
+      {
+        id: 'clap',
+        name: 'Clap',
+        path: 'assets/models/critters/animations/TH_Lizard_Clap.glb',
+      },
+      {
+        id: 'wave',
+        name: 'Wave',
+        path: 'assets/models/critters/animations/TH_Lizard_Wave.glb',
+      },
+      {
+        id: 'victory',
+        name: 'Victory',
+        path: 'assets/models/critters/animations/TH_Lizard_Victory.glb',
+      },
+      {
+        id: 'frustration',
+        name: 'Frustration',
+        path: 'assets/models/critters/animations/TH_Lizard_Frustration.glb',
+      },
+    ],
+  },
+];
+
+export const CRITTER_MAP = new Map(CRITTERS.map((critter) => [critter.id, critter]));
+
+export const getCritterById = (id) => CRITTER_MAP.get(id) ?? null;

--- a/src/hud/components/AnimationSelector.js
+++ b/src/hud/components/AnimationSelector.js
@@ -1,0 +1,91 @@
+export class AnimationSelector {
+  constructor({ element, onSelect }) {
+    this.element = element;
+    this.onSelect = onSelect;
+    this.selectElement = this.element?.querySelector('[data-role="animation-select"]') || null;
+    this.statusElement = this.element?.querySelector('[data-role="animation-status"]') || null;
+    this.loading = false;
+
+    this.handleChange = this.handleChange.bind(this);
+    this.selectElement?.addEventListener('change', this.handleChange);
+  }
+
+  setLoading(isLoading) {
+    this.loading = isLoading;
+    if (!this.selectElement) return;
+
+    this.selectElement.disabled = isLoading;
+    if (isLoading) {
+      this.renderOptions([{ id: 'loading', name: 'Loading…', disabled: true }], 'loading');
+    }
+  }
+
+  setAnimations(animations = [], activeId = null) {
+    if (!this.selectElement) return;
+
+    if (this.loading) {
+      this.loading = false;
+      this.selectElement.disabled = false;
+    }
+
+    const entries = animations.map((animation) => ({
+      id: animation.id,
+      name: animation.name,
+    }));
+
+    if (entries.length === 0) {
+      this.renderOptions(
+        [{ id: 'none', name: 'No animations available', disabled: true }],
+        'none'
+      );
+      this.selectElement.disabled = true;
+      return;
+    }
+
+    const targetId = activeId && entries.some((entry) => entry.id === activeId)
+      ? activeId
+      : entries[0].id;
+    this.renderOptions(entries, targetId);
+    this.selectElement.disabled = false;
+  }
+
+  renderOptions(options, activeId) {
+    if (!this.selectElement) return;
+    this.selectElement.innerHTML = '';
+
+    options.forEach((option) => {
+      const opt = document.createElement('option');
+      opt.value = option.id;
+      opt.textContent = option.name;
+      if (option.disabled) {
+        opt.disabled = true;
+      }
+      if (option.id === activeId) {
+        opt.selected = true;
+      }
+      this.selectElement.appendChild(opt);
+    });
+
+    if (this.statusElement) {
+      this.statusElement.textContent = this.selectElement.selectedOptions[0]?.textContent || '';
+    }
+  }
+
+  setSelected(animationId) {
+    if (!this.selectElement) return;
+    this.selectElement.value = animationId;
+    if (this.statusElement) {
+      const option = this.selectElement.selectedOptions[0];
+      this.statusElement.textContent = option?.textContent ?? '';
+    }
+  }
+
+  handleChange(event) {
+    const value = event.target.value;
+    if (this.statusElement) {
+      const option = event.target.selectedOptions[0];
+      this.statusElement.textContent = option?.textContent ?? '';
+    }
+    this.onSelect?.(value);
+  }
+}

--- a/src/hud/components/CritterSelector.js
+++ b/src/hud/components/CritterSelector.js
@@ -1,0 +1,65 @@
+export class CritterSelector {
+  constructor({ element, critters = [], activeCritterId = null, onSelect }) {
+    this.element = element;
+    this.critters = critters;
+    this.activeCritterId = activeCritterId;
+    this.onSelect = onSelect;
+    this.buttons = new Map();
+  }
+
+  render() {
+    if (!this.element) return;
+
+    this.element.innerHTML = '';
+    this.buttons.clear();
+
+    const list = document.createElement('div');
+    list.className = 'critter-selector-buttons';
+
+    this.critters.forEach((critter) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'critter-button';
+      button.dataset.critterId = critter.id;
+      button.textContent = critter.name;
+      if (critter.accentColor) {
+        button.style.setProperty('--critter-accent', critter.accentColor);
+      }
+
+      if (critter.id === this.activeCritterId) {
+        button.classList.add('active');
+        button.setAttribute('aria-pressed', 'true');
+      } else {
+        button.setAttribute('aria-pressed', 'false');
+      }
+
+      button.addEventListener('click', () => this.handleSelect(critter.id));
+      button.addEventListener('keyup', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          this.handleSelect(critter.id);
+        }
+      });
+
+      this.buttons.set(critter.id, button);
+      list.appendChild(button);
+    });
+
+    this.element.appendChild(list);
+  }
+
+  handleSelect(critterId) {
+    if (this.activeCritterId === critterId) return;
+    this.setActive(critterId);
+    this.onSelect?.(critterId);
+  }
+
+  setActive(critterId) {
+    this.activeCritterId = critterId;
+    this.buttons.forEach((button, id) => {
+      const isActive = id === critterId;
+      button.classList.toggle('active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -142,6 +142,91 @@ body::after {
   color: var(--color-highlight);
 }
 
+.nav-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.nav-section--critters {
+  padding-bottom: 0.4rem;
+}
+
+.nav-section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(124, 200, 111, 0.4), transparent);
+  opacity: 0.6;
+}
+
+.nav-section-label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.72);
+}
+
+.critter-selector-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.critter-button {
+  width: 100%;
+  padding: 0.65rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(61, 102, 76, 0.28);
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  font-family: var(--font-display);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.critter-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.critter-button:hover,
+.critter-button:focus-visible {
+  border-color: rgba(211, 243, 107, 0.65);
+  color: var(--color-text-primary);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.critter-button:hover::after,
+.critter-button:focus-visible::after,
+.critter-button.active::after {
+  opacity: 1;
+}
+
+.critter-button.active {
+  border-color: rgba(211, 243, 107, 0.85);
+  color: var(--color-text-primary);
+  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+}
+
+.critter-button {
+  --critter-accent: rgba(124, 200, 111, 0.35);
+}
+
+.critter-button.active {
+  background: rgba(124, 200, 111, 0.18);
+  background: linear-gradient(135deg, var(--critter-accent), rgba(90, 169, 201, 0.16));
+}
+
 .nav-tabs {
   list-style: none;
   margin: 0;
@@ -544,7 +629,7 @@ dl dt {
   background: rgba(211, 243, 107, 0.3);
 }
 
-.stage {
+.stage { 
   grid-column: 4;
   grid-row: 1 / span 2;
   position: relative;
@@ -579,6 +664,105 @@ dl dt {
   width: 100%;
   height: 100%;
   display: block;
+}
+
+.stage-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(15, 31, 23, 0.55), transparent 55%);
+}
+
+.stage-toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.2rem;
+  pointer-events: none;
+}
+
+.stage-meta,
+.stage-animation {
+  pointer-events: auto;
+}
+
+.stage-label {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.68);
+  margin-bottom: 0.35rem;
+}
+
+.stage-critter-name {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.35rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+  text-shadow: 0 0 18px rgba(124, 200, 111, 0.3);
+}
+
+.animation-select-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  min-width: 180px;
+}
+
+.animation-select-wrapper select {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.animation-select-display {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid rgba(211, 243, 107, 0.4);
+  background: rgba(32, 53, 42, 0.72);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+  pointer-events: none;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.animation-select-wrapper::after {
+  content: '▾';
+  position: absolute;
+  right: 0.9rem;
+  font-size: 0.75rem;
+  pointer-events: none;
+  color: rgba(243, 248, 240, 0.7);
+}
+
+.animation-select-wrapper:focus-within .animation-select-display,
+.animation-select-wrapper select:focus-visible + .animation-select-display {
+  border-color: rgba(211, 243, 107, 0.8);
+  background: rgba(35, 65, 48, 0.9);
+  color: var(--color-text-primary);
+}
+
+.stage-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.6);
+  pointer-events: none;
 }
 
 @media (max-width: 1400px) {
@@ -636,6 +820,24 @@ dl dt {
     gap: 1.1rem;
   }
 
+  .nav-section {
+    flex: 1 1 0;
+  }
+
+  .nav-section-divider {
+    width: 1px;
+    height: 60%;
+    background: linear-gradient(180deg, transparent, rgba(124, 200, 111, 0.4), transparent);
+  }
+
+  .critter-selector-buttons {
+    flex-direction: row;
+  }
+
+  .critter-button {
+    flex: 1 1 0;
+  }
+
   .hud-nav h2 {
     margin-bottom: 0;
   }
@@ -668,6 +870,10 @@ dl dt {
     grid-row: 5;
     grid-column: 1;
     height: 320px;
+  }
+
+  .stage-overlay {
+    padding: 1rem 1.2rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add frog and lizard selectors above the weapon categories and surface critter data for the HUD
- upgrade the Three.js scene manager with critter loading, animation playback, and orbit controls
- style the stage overlay and navigation to support the new critter workflow

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ca27d0c6bc8329ab460fa4c9bfe9fa