### PR TITLE
Add critter viewer with selectable animations

### DIFF
--- a/src/core/ResourceLoader.js
+++ b/src/core/ResourceLoader.js
@@ -4,6 +4,7 @@ export class ResourceLoader {
   constructor() {
     this.cache = new Map();
     this.loaderPromise = null;
+    this.skeletonUtilsPromise = null;
   }
 
   async loadModel(path) {
@@ -11,8 +12,16 @@ export class ResourceLoader {
       return this._createPlaceholder();
     }
 
-    if (this.cache.has(path)) {
-      return this.cache.get(path).clone();
+    const cached = this.cache.get(path);
+    if (cached) {
+      if (cached.type === 'model') {
+        const { SkeletonUtils } = await this._getSkeletonUtils();
+        return SkeletonUtils.clone(cached.scene);
+      }
+
+      if (cached.type === 'placeholder') {
+        return cached.object.clone();
+      }
     }
 
     try {
@@ -20,28 +29,58 @@ export class ResourceLoader {
       const gltf = await loader.loadAsync(path);
       const scene = gltf.scene || gltf.scenes?.[0];
       if (scene) {
-        this.cache.set(path, scene);
-        return scene.clone(true);
+        this.cache.set(path, { type: 'model', scene });
+        const { SkeletonUtils } = await this._getSkeletonUtils();
+        return SkeletonUtils.clone(scene);
       }
     } catch (error) {
       console.warn(`Failed to load model at ${path}. Using fallback geometry instead.`, error);
     }
 
     const fallback = this._createPlaceholder();
-    this.cache.set(path, fallback);
+    this.cache.set(path, { type: 'placeholder', object: fallback });
     return fallback.clone();
+  }
+
+  async loadAnimationClip(path) {
+    if (!path) {
+      return null;
+    }
+
+    const cached = this.cache.get(path);
+    if (cached && cached.type === 'animation') {
+      return cached.clip.clone();
+    }
+
+    try {
+      const loader = await this._getLoader();
+      const gltf = await loader.loadAsync(path);
+      const [clip] = gltf.animations || [];
+      if (clip) {
+        this.cache.set(path, { type: 'animation', clip });
+        return clip.clone();
+      }
+    } catch (error) {
+      console.warn(`Failed to load animation at ${path}.`, error);
+    }
+
+    return null;
   }
 
   async loadTexture(path) {
     if (!path) return null;
     if (this.cache.has(path)) {
-      return this.cache.get(path);
+      const cached = this.cache.get(path);
+      if (cached?.type === 'texture') {
+        return cached.texture;
+      }
+      return cached;
     }
 
     const textureLoader = new THREE.TextureLoader();
     try {
       const texture = await textureLoader.loadAsync(path);
-      this.cache.set(path, texture);
+      this.cache.set(path, { type: 'texture', texture });
       return texture;
     } catch (error) {
       console.warn(`Failed to load texture at ${path}.`, error);
@@ -56,6 +95,15 @@ export class ResourceLoader {
       ).then((module) => new module.GLTFLoader());
     }
     return this.loaderPromise;
+  }
+
+  async _getSkeletonUtils() {
+    if (!this.skeletonUtilsPromise) {
+      this.skeletonUtilsPromise = import(
+        'https://unpkg.com/three@0.160.0/examples/jsm/utils/SkeletonUtils.js'
+      );
+    }
+    return this.skeletonUtilsPromise;
   }
 
   _createPlaceholder() {

--- a/src/data/critters.js
+++ b/src/data/critters.js
@@ -1,0 +1,152 @@
+export const critters = [
+  {
+    id: 'frog',
+    name: 'Frog',
+    modelPath: 'assets/models/critters/models/SK_TH_Frog_Rigged_01.glb',
+    scale: 1.15,
+    offset: { y: -0.6 },
+    defaultAnimationId: 'frog_idle',
+    animations: [
+      { id: 'frog_idle', label: 'Idle', path: 'assets/models/critters/animations/TH_Frog_Idle.glb' },
+      {
+        id: 'frog_walk_forward',
+        label: 'Walk Forward',
+        path: 'assets/models/critters/animations/TH_Frog_Walk_Forward.glb',
+      },
+      {
+        id: 'frog_run_forward',
+        label: 'Run Forward',
+        path: 'assets/models/critters/animations/TH_Frog_Run_Forward.glb',
+      },
+      { id: 'frog_hop', label: 'Hop', path: 'assets/models/critters/animations/TH_Frog_Hop.glb' },
+      {
+        id: 'frog_clap',
+        label: 'Clap',
+        path: 'assets/models/critters/animations/TH_Frog_Clap.glb',
+      },
+      {
+        id: 'frog_wave',
+        label: 'Wave',
+        path: 'assets/models/critters/animations/TH_Frog_Wave.glb',
+      },
+      {
+        id: 'frog_victory',
+        label: 'Victory',
+        path: 'assets/models/critters/animations/TH_Frog_Victory.glb',
+      },
+      {
+        id: 'frog_frustration',
+        label: 'Frustration',
+        path: 'assets/models/critters/animations/TH_Frog_Frustration.glb',
+      },
+      {
+        id: 'frog_sleep',
+        label: 'Sleep',
+        path: 'assets/models/critters/animations/TH_Frog_Sleep.glb',
+        loop: 'once',
+      },
+      {
+        id: 'frog_sit',
+        label: 'Sit',
+        path: 'assets/models/critters/animations/TH_Frog_Sit_01.glb',
+      },
+      {
+        id: 'frog_take_hit',
+        label: 'Take Hit',
+        path: 'assets/models/critters/animations/TH_Frog_Take_Hit.glb',
+        loop: 'once',
+      },
+      {
+        id: 'frog_death',
+        label: 'Death',
+        path: 'assets/models/critters/animations/TH_Frog_Death.glb',
+        loop: 'once',
+      },
+      {
+        id: 'frog_strike',
+        label: 'Strike',
+        path: 'assets/models/critters/animations/TH_Frog_Strike.glb',
+      },
+      {
+        id: 'frog_push_up',
+        label: 'Push Up',
+        path: 'assets/models/critters/animations/TH_Frog_Push_Up.glb',
+      },
+    ],
+  },
+  {
+    id: 'lizard',
+    name: 'Lizard',
+    modelPath: 'assets/models/critters/models/SK_TH_Lizard_Rigged_01.glb',
+    scale: 1.25,
+    offset: { y: -0.6 },
+    defaultAnimationId: 'lizard_idle',
+    animations: [
+      { id: 'lizard_idle', label: 'Idle', path: 'assets/models/critters/animations/TH_Lizard_Idle.glb' },
+      {
+        id: 'lizard_walk_forward',
+        label: 'Walk Forward',
+        path: 'assets/models/critters/animations/TH_Lizard_Walk_Forward.glb',
+      },
+      {
+        id: 'lizard_run_forward',
+        label: 'Run Forward',
+        path: 'assets/models/critters/animations/TH_Lizard_Run_Forward.glb',
+      },
+      { id: 'lizard_hop', label: 'Hop', path: 'assets/models/critters/animations/TH_Lizard_Hop.glb' },
+      {
+        id: 'lizard_clap',
+        label: 'Clap',
+        path: 'assets/models/critters/animations/TH_Lizard_Clap.glb',
+      },
+      {
+        id: 'lizard_wave',
+        label: 'Wave',
+        path: 'assets/models/critters/animations/TH_Lizard_Wave.glb',
+      },
+      {
+        id: 'lizard_victory',
+        label: 'Victory',
+        path: 'assets/models/critters/animations/TH_Lizard_Victory.glb',
+      },
+      {
+        id: 'lizard_frustration',
+        label: 'Frustration',
+        path: 'assets/models/critters/animations/TH_Lizard_Frustration.glb',
+      },
+      {
+        id: 'lizard_sleep',
+        label: 'Sleep',
+        path: 'assets/models/critters/animations/TH_Lizard_Sleep.glb',
+        loop: 'once',
+      },
+      {
+        id: 'lizard_sit',
+        label: 'Sit',
+        path: 'assets/models/critters/animations/TH_Lizard_Sit_01.glb',
+      },
+      {
+        id: 'lizard_take_hit',
+        label: 'Take Hit',
+        path: 'assets/models/critters/animations/TH_Lizard_Take_Hit.glb',
+        loop: 'once',
+      },
+      {
+        id: 'lizard_death',
+        label: 'Death',
+        path: 'assets/models/critters/animations/TH_Lizard_Death.glb',
+        loop: 'once',
+      },
+      {
+        id: 'lizard_strike',
+        label: 'Strike',
+        path: 'assets/models/critters/animations/TH_Lizard_Strike.glb',
+      },
+      {
+        id: 'lizard_push_up',
+        label: 'Push Up',
+        path: 'assets/models/critters/animations/TH_Lizard_Push_Up.glb',
+      },
+    ],
+  },
+];

--- a/src/hud/components/AnimationSelector.js
+++ b/src/hud/components/AnimationSelector.js
@@ -1,0 +1,83 @@
+export class AnimationSelector {
+  constructor({ container, bus }) {
+    this.container = container;
+    this.bus = bus;
+    this.animations = [];
+    this.activeAnimationId = null;
+    this.selectElement = null;
+    this.critterNameElement = null;
+    this.animationLabelId = `animation-label-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  init() {
+    if (!this.container) return;
+
+    this.container.innerHTML = `
+      <div class="animation-selector">
+        <div class="animation-selector__header">
+          <span class="animation-selector__label">Critter</span>
+          <strong class="animation-selector__name" data-role="critter-name">--</strong>
+        </div>
+        <label class="animation-selector__control" for="${this.animationLabelId}">
+          <span>Animation</span>
+          <select id="${this.animationLabelId}" data-role="animation-select"></select>
+        </label>
+        <p class="animation-selector__hint">Drag to orbit • Scroll to zoom</p>
+      </div>
+    `;
+
+    this.selectElement = this.container.querySelector('[data-role="animation-select"]');
+    this.critterNameElement = this.container.querySelector('[data-role="critter-name"]');
+
+    if (this.selectElement) {
+      this.selectElement.addEventListener('change', (event) => {
+        const value = event.target.value;
+        this.selectAnimation(value, { emit: true });
+      });
+    }
+  }
+
+  setCritterName(name) {
+    if (this.critterNameElement) {
+      this.critterNameElement.textContent = name || '--';
+    }
+  }
+
+  setAnimations(animations = [], activeId = null) {
+    this.animations = animations;
+    if (!this.selectElement) return;
+
+    this.selectElement.innerHTML = '';
+
+    animations.forEach((animation) => {
+      const option = document.createElement('option');
+      option.value = animation.id;
+      option.textContent = animation.label;
+      this.selectElement.appendChild(option);
+    });
+
+    this.selectElement.disabled = animations.length === 0;
+
+    const targetId = activeId || animations[0]?.id || null;
+    this.selectAnimation(targetId, { emit: false });
+  }
+
+  selectAnimation(id, { emit }) {
+    if (!this.selectElement) return;
+
+    this.activeAnimationId = id;
+    if (id) {
+      this.selectElement.value = id;
+    } else {
+      this.selectElement.selectedIndex = -1;
+    }
+
+    if (emit && id) {
+      this.bus?.emit?.('critter:animation-selected', id);
+    }
+  }
+
+  getActiveAnimationId() {
+    return this.activeAnimationId;
+  }
+}

--- a/src/hud/components/CritterSelector.js
+++ b/src/hud/components/CritterSelector.js
@@ -1,0 +1,59 @@
+export class CritterSelector {
+  constructor({ element, critters = [], bus }) {
+    this.element = element;
+    this.critters = critters;
+    this.bus = bus;
+    this.activeId = null;
+    this.buttons = new Map();
+  }
+
+  render(defaultId) {
+    if (!this.element) return;
+
+    this.element.innerHTML = '';
+    this.buttons.clear();
+    this.element.setAttribute('role', 'radiogroup');
+    this.element.classList.add('critter-selector');
+
+    this.critters.forEach((critter) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'critter-button';
+      button.dataset.critterId = critter.id;
+      button.textContent = critter.name;
+      button.setAttribute('role', 'radio');
+      button.setAttribute('aria-pressed', 'false');
+      button.setAttribute('aria-checked', 'false');
+      button.addEventListener('click', () => this.selectCritter(critter.id, { emit: true }));
+      this.element.appendChild(button);
+      this.buttons.set(critter.id, button);
+    });
+
+    const initialId = defaultId || this.critters[0]?.id || null;
+    if (initialId) {
+      this.selectCritter(initialId, { emit: false });
+    }
+  }
+
+  selectCritter(id, { emit }) {
+    if (!id || this.activeId === id) {
+      if (emit && id) {
+        this.bus?.emit?.('critter:selected', id);
+      }
+      return;
+    }
+
+    this.activeId = id;
+
+    this.buttons.forEach((button, critterId) => {
+      const isActive = critterId === id;
+      button.classList.toggle('active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      button.setAttribute('aria-checked', isActive ? 'true' : 'false');
+    });
+
+    if (emit) {
+      this.bus?.emit?.('critter:selected', id);
+    }
+  }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -142,6 +142,70 @@ body::after {
   color: var(--color-highlight);
 }
 
+.nav-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  position: relative;
+  z-index: 1;
+}
+
+.nav-section + .nav-section {
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.critter-selector {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.critter-button {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(53, 94, 70, 0.55);
+  color: var(--color-text-secondary);
+  font-family: var(--font-display);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.critter-button::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.critter-button:hover,
+.critter-button:focus-visible {
+  border-color: rgba(124, 200, 111, 0.6);
+  color: var(--color-text-primary);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+  outline: none;
+}
+
+.critter-button:hover::after,
+.critter-button:focus-visible::after,
+.critter-button.active::after {
+  opacity: 1;
+}
+
+.critter-button.active {
+  border-color: rgba(211, 243, 107, 0.75);
+  color: var(--color-text-primary);
+  box-shadow: 0 16px 32px rgba(21, 58, 37, 0.45);
+}
+
 .nav-tabs {
   list-style: none;
   margin: 0;
@@ -548,6 +612,8 @@ dl dt {
   grid-column: 4;
   grid-row: 1 / span 2;
   position: relative;
+  display: flex;
+  flex-direction: column;
   background: linear-gradient(160deg, rgba(24, 52, 36, 0.95), rgba(20, 47, 57, 0.92));
   border: 1px solid rgba(90, 169, 201, 0.35);
   border-radius: calc(var(--border-radius-lg) + 4px);
@@ -575,10 +641,95 @@ dl dt {
   pointer-events: none;
 }
 
+.stage-toolbar {
+  position: relative;
+  z-index: 1;
+  padding: 1.4rem 1.6rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  background: linear-gradient(180deg, rgba(13, 31, 23, 0.95), rgba(13, 31, 23, 0));
+}
+
+.stage-viewport {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+
 .stage canvas {
   width: 100%;
   height: 100%;
   display: block;
+  position: absolute;
+  inset: 0;
+}
+
+.animation-selector {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.animation-selector__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.9);
+}
+
+.animation-selector__label {
+  font-family: var(--font-display);
+  color: var(--color-highlight);
+}
+
+.animation-selector__name {
+  font-family: var(--font-display);
+  color: var(--color-text-primary);
+}
+
+.animation-selector__control {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.animation-selector__control span {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+}
+
+.animation-selector__control select {
+  appearance: none;
+  padding: 0.75rem 0.9rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(33, 70, 51, 0.65);
+  color: var(--color-text-primary);
+  font-family: var(--font-display);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.animation-selector__control select:focus-visible {
+  border-color: rgba(124, 200, 111, 0.7);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.25);
+}
+
+.animation-selector__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.6);
+}
 }
 
 @media (max-width: 1400px) {


### PR DESCRIPTION
## Summary
- add a critter selector and animation controls so the stage can preview either the frog or lizard
- teach the scene manager/resource loader to clone rigged models, load animation clips, and enable orbit camera controls
- refresh the HUD layout and styles to integrate the new critter tooling alongside the existing weapon panels

## Testing
- python3 -m http.server 4173 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68ca27d0c6bc8329ab460fa4c9bfe9fa