### PR TITLE
Enhance viewport controls and remove placeholder models

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -32,8 +32,12 @@ export class WeaponDisplayApp {
     this.indexCritters();
     this.registerEventHandlers();
 
-    this.sceneManager = new SceneManager(layout.stageViewportElement);
+    this.sceneManager = new SceneManager(layout.stageViewportElement, {
+      overlayElement: layout.viewportOverlayElement,
+      statusElement: layout.viewportStatusElement,
+    });
     this.sceneManager.init();
+    this.sceneManager.setStatus('Select a critter to explore.', 'idle');
 
     this.hudController = new HUDController({
       bus: this.eventBus,
@@ -136,7 +140,49 @@ export class WeaponDisplayApp {
             data-role="stage-viewport"
             aria-label="Critter viewer"
             tabindex="0"
-          ></div>
+          >
+            <div class="viewport-overlay" data-component="viewport-overlay">
+              <div class="viewport-overlay__top">
+                <div
+                  class="viewport-status"
+                  data-role="viewport-status"
+                  data-state="idle"
+                  role="status"
+                  aria-live="polite"
+                >
+                  Select a critter to explore.
+                </div>
+              </div>
+              <div class="viewport-overlay__bottom">
+                <div class="viewport-shortcuts">
+                  <span><strong>Drag</strong> to orbit • <strong>Scroll</strong> to zoom • <strong>Shift + Drag</strong> to pan</span>
+                  <span>Use the arrow keys or buttons to nudge the view. Press <kbd>F</kbd> to refocus.</span>
+                </div>
+                <div class="viewport-controls" role="group" aria-label="Viewport controls">
+                  <button type="button" data-action="focus-model" aria-label="Focus on critter">
+                    <span class="viewport-controls__icon">◎</span>
+                    <span>Focus</span>
+                  </button>
+                  <button type="button" data-action="reset-view" aria-label="Reset view">
+                    <span class="viewport-controls__icon">↺</span>
+                    <span>Reset</span>
+                  </button>
+                  <div class="viewport-controls__cluster" role="group" aria-label="Rotate view">
+                    <button type="button" data-action="rotate-up" aria-label="Tilt up">▲</button>
+                    <div class="viewport-controls__row">
+                      <button type="button" data-action="rotate-left" aria-label="Rotate left">◀</button>
+                      <button type="button" data-action="rotate-right" aria-label="Rotate right">▶</button>
+                    </div>
+                    <button type="button" data-action="rotate-down" aria-label="Tilt down">▼</button>
+                  </div>
+                  <div class="viewport-controls__cluster" role="group" aria-label="Zoom controls">
+                    <button type="button" data-action="zoom-in" aria-label="Zoom in">＋</button>
+                    <button type="button" data-action="zoom-out" aria-label="Zoom out">－</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </section>
       </div>
     `;
@@ -144,6 +190,8 @@ export class WeaponDisplayApp {
     return {
       stageElement: this.root.querySelector('[data-component="stage"]'),
       stageViewportElement: this.root.querySelector('[data-role="stage-viewport"]'),
+      viewportOverlayElement: this.root.querySelector('[data-component="viewport-overlay"]'),
+      viewportStatusElement: this.root.querySelector('[data-role="viewport-status"]'),
       navTabsElement: this.root.querySelector('[data-component="nav-tabs"]'),
       critterSelectorElement: this.root.querySelector('[data-component="critter-selector"]'),
       weaponListPanel: this.root.querySelector('[data-component="weapon-list"]'),

--- a/src/core/ResourceLoader.js
+++ b/src/core/ResourceLoader.js
@@ -9,18 +9,14 @@ export class ResourceLoader {
 
   async loadModel(path) {
     if (!path) {
-      return this._createPlaceholder();
+      return null;
     }
 
     const cached = this.cache.get(path);
     if (cached) {
-      if (cached.type === 'model') {
+      if (cached.type === 'model' && cached.scene) {
         const { SkeletonUtils } = await this._getSkeletonUtils();
         return SkeletonUtils.clone(cached.scene);
-      }
-
-      if (cached.type === 'placeholder') {
-        return cached.object.clone();
       }
     }
 
@@ -34,12 +30,10 @@ export class ResourceLoader {
         return SkeletonUtils.clone(scene);
       }
     } catch (error) {
-      console.warn(`Failed to load model at ${path}. Using fallback geometry instead.`, error);
+      console.warn(`Failed to load model at ${path}.`, error);
     }
 
-    const fallback = this._createPlaceholder();
-    this.cache.set(path, { type: 'placeholder', object: fallback });
-    return fallback.clone();
+    return null;
   }
 
   async loadAnimationClip(path) {
@@ -106,19 +100,4 @@ export class ResourceLoader {
     return this.skeletonUtilsPromise;
   }
 
-  _createPlaceholder() {
-    const geometry = new THREE.IcosahedronGeometry(0.8, 1);
-    const material = new THREE.MeshStandardMaterial({
-      color: 0x7a5dd1,
-      emissive: 0x140d2f,
-      metalness: 0.45,
-      roughness: 0.4,
-    });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.name = 'placeholder-weapon';
-
-    const group = new THREE.Group();
-    group.add(mesh);
-    return group;
-  }
 }

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -14,7 +14,7 @@ const RARITY_GLOWS = {
 };
 
 export class SceneManager {
-  constructor(container) {
+  constructor(container, uiOptions = {}) {
     this.container = container;
     this.scene = new THREE.Scene();
     this.camera = null;
@@ -33,6 +33,19 @@ export class SceneManager {
     this.mixer = null;
     this.activeAction = null;
     this.orbitControls = null;
+    this.ui = {
+      overlay: uiOptions.overlayElement ?? null,
+      status: uiOptions.statusElement ?? null,
+    };
+    this.lastFocusedView = {
+      position: new THREE.Vector3(0, 1.1, 3.3),
+      target: new THREE.Vector3(0, 0.65, 0),
+      minDistance: 2.0,
+      maxDistance: 6.0,
+    };
+    this.handleUIClick = this.handleUIClick.bind(this);
+    this.handleKeyboardShortcut = this.handleKeyboardShortcut.bind(this);
+    this.handlePointerDown = this.handlePointerDown.bind(this);
 
     this.handleResize = this.handleResize.bind(this);
     this.animate = this.animate.bind(this);
@@ -40,11 +53,13 @@ export class SceneManager {
 
   init() {
     this.renderer = createRenderer(this.container);
+    this.renderer.domElement.addEventListener('pointerdown', this.handlePointerDown);
     this.camera = this.createCamera();
     this.setupLights();
     this.setupEnvironment();
     this.scene.add(this.stageGroup);
     this.setupControls();
+    this.bindUI();
 
     window.addEventListener('resize', this.handleResize);
     this.handleResize();
@@ -90,12 +105,27 @@ export class SceneManager {
     this.orbitControls = new module.OrbitControls(this.camera, this.renderer.domElement);
     this.orbitControls.enableDamping = true;
     this.orbitControls.dampingFactor = 0.08;
-    this.orbitControls.enablePan = false;
-    this.orbitControls.maxPolarAngle = Math.PI * 0.52;
-    this.orbitControls.minDistance = 2.0;
-    this.orbitControls.maxDistance = 6.0;
-    this.orbitControls.target.set(0, 0.65, 0);
+    this.orbitControls.enablePan = true;
+    this.orbitControls.screenSpacePanning = true;
+    this.orbitControls.rotateSpeed = 0.6;
+    this.orbitControls.zoomSpeed = 1.0;
+    this.orbitControls.panSpeed = 0.8;
+    this.orbitControls.maxPolarAngle = Math.PI * 0.62;
+    this.orbitControls.minDistance = this.lastFocusedView.minDistance;
+    this.orbitControls.maxDistance = this.lastFocusedView.maxDistance;
+    this.orbitControls.target.copy(this.lastFocusedView.target);
+    this.orbitControls.listenToKeyEvents?.(this.container);
     this.orbitControls.update();
+  }
+
+  bindUI() {
+    if (this.ui.overlay) {
+      this.ui.overlay.addEventListener('click', this.handleUIClick);
+    }
+
+    if (this.container) {
+      this.container.addEventListener('keydown', this.handleKeyboardShortcut);
+    }
   }
 
   setupLights() {
@@ -143,6 +173,7 @@ export class SceneManager {
     if (!weapon) return;
 
     const requestId = (this.pendingWeaponId = weapon.id);
+    this.setStatus(`Loading ${weapon.name ?? 'weapon'}…`, 'loading');
 
     let model = null;
     if (weapon.modelPath) {
@@ -153,8 +184,10 @@ export class SceneManager {
       return;
     }
 
+    this.disposeCurrentModel();
     if (!model) {
-      model = this.createPlaceholderModel();
+      this.setStatus('Unable to load this weapon preview.', 'error');
+      return;
     }
 
     model.position.set(0, 0, 0);
@@ -163,17 +196,23 @@ export class SceneManager {
     const scale = weapon.preview?.scale ?? 1.2;
     model.scale.setScalar(scale);
 
-    this.disposeCurrentModel();
     this.currentModel = model;
     this.stageGroup.add(model);
 
+    this.focusCameraOn(model);
     this.applyRarityGlow(weapon.rarity);
+    this.setStatus(weapon.name ?? 'Weapon ready', 'ready');
   }
 
   async loadCritter(critter) {
-    if (!critter) return;
+    if (!critter) {
+      this.disposeCurrentModel();
+      this.setStatus('Pick a critter to bring it to life.', 'idle');
+      return;
+    }
 
     const requestId = (this.pendingCritterId = critter.id);
+    this.setStatus(`Welcoming ${critter.name}…`, 'loading');
 
     let model = null;
     if (critter.modelPath) {
@@ -184,26 +223,29 @@ export class SceneManager {
       return;
     }
 
-    if (!model) {
-      model = this.createPlaceholderModel();
-    }
-
     this.disposeCurrentModel();
 
     const offset = critter.offset ?? {};
     const rotation = critter.rotation ?? {};
-    model.position.set(offset.x ?? 0, offset.y ?? 0, offset.z ?? 0);
-    model.rotation.set(rotation.x ?? 0, rotation.y ?? 0, rotation.z ?? 0);
+    if (model) {
+      model.position.set(offset.x ?? 0, offset.y ?? 0, offset.z ?? 0);
+      model.rotation.set(rotation.x ?? 0, rotation.y ?? 0, rotation.z ?? 0);
 
-    const scale = critter.scale ?? 1;
-    model.scale.setScalar(scale);
+      const scale = critter.scale ?? 1;
+      model.scale.setScalar(scale);
 
-    this.currentModel = model;
-    this.currentCritterId = critter.id;
-    this.stageGroup.add(model);
+      this.currentModel = model;
+      this.currentCritterId = critter.id;
+      this.stageGroup.add(model);
 
-    this.mixer = new THREE.AnimationMixer(model);
-    this.activeAction = null;
+      this.mixer = new THREE.AnimationMixer(model);
+      this.activeAction = null;
+
+      this.focusCameraOn(model, critter.cameraPadding ?? 1.2);
+      this.setStatus(`${critter.name} ready`, 'ready');
+    } else {
+      this.setStatus(`We couldn't load ${critter.name}.`, 'error');
+    }
   }
 
   async playAnimation(animation) {
@@ -275,18 +317,189 @@ export class SceneManager {
     }
   }
 
-  createPlaceholderModel() {
-    const geometry = new THREE.TorusKnotGeometry(0.65, 0.18, 128, 16);
-    const material = new THREE.MeshStandardMaterial({
-      color: 0xff9dce,
-      emissive: 0x2b0f35,
-      metalness: 0.28,
-      roughness: 0.28,
-      emissiveIntensity: 0.6,
-    });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.castShadow = false;
-    return mesh;
+  focusCameraOn(object, padding = 1.25) {
+    if (!this.camera || !this.orbitControls || !object) {
+      return;
+    }
+
+    const box = new THREE.Box3().setFromObject(object);
+    if (!box.isEmpty()) {
+      const size = box.getSize(new THREE.Vector3());
+      const center = box.getCenter(new THREE.Vector3());
+
+      const maxDim = Math.max(size.x, size.y, size.z);
+      const fov = THREE.MathUtils.degToRad(this.camera.fov);
+      const distance = (maxDim / Math.sin(fov / 2)) * 0.5 * padding;
+
+      const direction = new THREE.Vector3()
+        .subVectors(this.camera.position, this.orbitControls.target)
+        .normalize();
+
+      if (!Number.isFinite(direction.lengthSq()) || direction.lengthSq() === 0) {
+        direction.set(0, 0, 1);
+      }
+
+      const newPosition = center.clone().add(direction.multiplyScalar(distance));
+
+      this.camera.position.copy(newPosition);
+      this.camera.near = Math.max(0.05, distance / 100);
+      this.camera.far = Math.max(20, distance * 10);
+      this.camera.updateProjectionMatrix();
+
+      this.orbitControls.target.copy(center);
+      this.orbitControls.minDistance = Math.max(distance * 0.25, 0.5);
+      this.orbitControls.maxDistance = distance * 3;
+      this.orbitControls.update();
+
+      this.lastFocusedView = {
+        position: this.camera.position.clone(),
+        target: this.orbitControls.target.clone(),
+        minDistance: this.orbitControls.minDistance,
+        maxDistance: this.orbitControls.maxDistance,
+      };
+    }
+  }
+
+  resetCamera() {
+    if (!this.camera || !this.orbitControls) {
+      return;
+    }
+
+    const view = this.lastFocusedView ?? {
+      position: new THREE.Vector3(0, 1.1, 3.3),
+      target: new THREE.Vector3(0, 0.65, 0),
+      minDistance: 2.0,
+      maxDistance: 6.0,
+    };
+
+    this.camera.position.copy(view.position);
+    this.orbitControls.target.copy(view.target);
+    this.orbitControls.minDistance = view.minDistance;
+    this.orbitControls.maxDistance = view.maxDistance;
+    this.orbitControls.update();
+  }
+
+  adjustZoom(multiplier) {
+    if (!this.orbitControls) return;
+    if (multiplier < 1) {
+      this.orbitControls.dollyOut(1 / multiplier);
+    } else {
+      this.orbitControls.dollyIn(multiplier);
+    }
+    this.orbitControls.update();
+  }
+
+  rotateView(deltaAzimuth, deltaPolar = 0) {
+    if (!this.orbitControls) return;
+    if (deltaAzimuth) {
+      this.orbitControls.rotateLeft(deltaAzimuth);
+    }
+    if (deltaPolar) {
+      this.orbitControls.rotateUp(deltaPolar);
+    }
+    this.orbitControls.update();
+  }
+
+  handleUIClick(event) {
+    const button = event.target.closest('[data-action]');
+    if (!button) {
+      return;
+    }
+
+    const action = button.dataset.action;
+    if (!action) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.executeAction(action);
+  }
+
+  handleKeyboardShortcut(event) {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    const key = event.key.toLowerCase();
+    switch (key) {
+      case 'r':
+        event.preventDefault();
+        this.resetCamera();
+        break;
+      case 'f':
+        event.preventDefault();
+        this.focusCameraOn(this.currentModel ?? this.stageGroup);
+        break;
+      case '+':
+      case '=':
+        event.preventDefault();
+        this.adjustZoom(1.15);
+        break;
+      case '-':
+      case '_':
+        event.preventDefault();
+        this.adjustZoom(0.85);
+        break;
+      case 'arrowleft':
+        event.preventDefault();
+        this.rotateView(THREE.MathUtils.degToRad(20));
+        break;
+      case 'arrowright':
+        event.preventDefault();
+        this.rotateView(THREE.MathUtils.degToRad(-20));
+        break;
+      case 'arrowup':
+        event.preventDefault();
+        this.rotateView(0, THREE.MathUtils.degToRad(12));
+        break;
+      case 'arrowdown':
+        event.preventDefault();
+        this.rotateView(0, THREE.MathUtils.degToRad(-12));
+        break;
+      default:
+        break;
+    }
+  }
+
+  executeAction(action) {
+    switch (action) {
+      case 'reset-view':
+        this.resetCamera();
+        break;
+      case 'zoom-in':
+        this.adjustZoom(1.18);
+        break;
+      case 'zoom-out':
+        this.adjustZoom(0.82);
+        break;
+      case 'rotate-left':
+        this.rotateView(THREE.MathUtils.degToRad(18));
+        break;
+      case 'rotate-right':
+        this.rotateView(THREE.MathUtils.degToRad(-18));
+        break;
+      case 'rotate-up':
+        this.rotateView(0, THREE.MathUtils.degToRad(12));
+        break;
+      case 'rotate-down':
+        this.rotateView(0, THREE.MathUtils.degToRad(-12));
+        break;
+      case 'focus-model':
+        this.focusCameraOn(this.currentModel ?? this.stageGroup);
+        break;
+      default:
+        break;
+    }
+  }
+
+  setStatus(message, state = 'idle') {
+    if (!this.ui.status) {
+      return;
+    }
+
+    this.ui.status.textContent = message ?? '';
+    this.ui.status.dataset.state = state;
   }
 
   handleResize() {
@@ -300,6 +513,13 @@ export class SceneManager {
   dispose() {
     cancelAnimationFrame(this.animationFrame);
     window.removeEventListener('resize', this.handleResize);
+    if (this.ui.overlay) {
+      this.ui.overlay.removeEventListener('click', this.handleUIClick);
+    }
+    if (this.container) {
+      this.container.removeEventListener('keydown', this.handleKeyboardShortcut);
+    }
+    this.renderer?.domElement?.removeEventListener('pointerdown', this.handlePointerDown);
     this.scene.traverse((object) => {
       if (object.isMesh) {
         object.geometry?.dispose?.();
@@ -312,5 +532,9 @@ export class SceneManager {
     });
     this.renderer?.dispose?.();
     this.orbitControls?.dispose?.();
+  }
+
+  handlePointerDown() {
+    this.container?.focus?.();
   }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -665,6 +665,218 @@ dl dt {
   inset: 0;
 }
 
+.viewport-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1.25rem 1.4rem;
+  pointer-events: none;
+  color: rgba(231, 245, 239, 0.95);
+  text-shadow: 0 1px 2px rgba(6, 16, 12, 0.6);
+  z-index: 2;
+}
+
+.viewport-overlay__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  pointer-events: none;
+}
+
+.viewport-overlay__bottom {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  pointer-events: none;
+}
+
+.viewport-status {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: linear-gradient(120deg, rgba(22, 58, 41, 0.85), rgba(26, 72, 66, 0.7));
+  border: 1px solid rgba(133, 203, 190, 0.35);
+  border-radius: 16px;
+  padding: 0.75rem 1.8rem 0.75rem 1.15rem;
+  box-shadow: 0 12px 32px rgba(7, 20, 15, 0.4);
+  backdrop-filter: blur(8px);
+  pointer-events: none;
+  position: relative;
+  transition: background 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+}
+
+.viewport-status[data-state='loading'] {
+  border-color: rgba(133, 203, 190, 0.55);
+}
+
+.viewport-status[data-state='loading']::after {
+  content: '';
+  position: absolute;
+  right: 0.95rem;
+  top: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-top: -0.375rem;
+  border-radius: 50%;
+  border: 2px solid rgba(200, 245, 232, 0.5);
+  border-top-color: rgba(200, 245, 232, 0.05);
+  animation: viewport-spin 0.8s linear infinite;
+}
+
+.viewport-status[data-state='error'] {
+  background: linear-gradient(120deg, rgba(80, 26, 40, 0.82), rgba(107, 36, 62, 0.72));
+  border-color: rgba(235, 116, 159, 0.45);
+  color: rgba(252, 231, 238, 0.95);
+}
+
+.viewport-status[data-state='ready'] {
+  background: linear-gradient(120deg, rgba(24, 66, 43, 0.85), rgba(36, 98, 82, 0.76));
+  border-color: rgba(152, 228, 203, 0.55);
+}
+
+.viewport-shortcuts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  color: rgba(214, 236, 226, 0.85);
+  background: linear-gradient(180deg, rgba(11, 28, 22, 0.58), rgba(11, 28, 22, 0.18));
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(133, 203, 190, 0.22);
+  box-shadow: 0 16px 24px rgba(5, 15, 11, 0.35);
+  backdrop-filter: blur(10px);
+  pointer-events: none;
+}
+
+.viewport-shortcuts strong {
+  color: rgba(245, 255, 252, 0.95);
+}
+
+.viewport-shortcuts kbd {
+  background: rgba(18, 50, 37, 0.65);
+  border-radius: 6px;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid rgba(143, 213, 197, 0.3);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.viewport-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(88px, max-content));
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: flex-end;
+  pointer-events: auto;
+}
+
+.viewport-controls button {
+  appearance: none;
+  border: 1px solid rgba(164, 228, 212, 0.2);
+  background: rgba(22, 52, 44, 0.68);
+  color: rgba(230, 248, 243, 0.92);
+  font-family: var(--font-display);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 14px;
+  padding: 0.55rem 0.85rem;
+  min-width: 88px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.2s ease, background 0.2s ease;
+  box-shadow: 0 8px 18px rgba(4, 15, 11, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+.viewport-controls button:focus-visible {
+  outline: 2px solid rgba(164, 228, 212, 0.8);
+  outline-offset: 2px;
+}
+
+.viewport-controls button:hover {
+  transform: translateY(-2px);
+  border-color: rgba(164, 228, 212, 0.5);
+  background: rgba(28, 70, 60, 0.82);
+}
+
+.viewport-controls__icon {
+  font-size: 1.1rem;
+}
+
+.viewport-controls__cluster {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.35rem;
+  justify-items: center;
+  pointer-events: auto;
+}
+
+.viewport-controls__cluster button {
+  min-width: 64px;
+  padding: 0.45rem 0.6rem;
+}
+
+.viewport-controls__row {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.viewport-controls__row button {
+  min-width: 64px;
+}
+
+.viewport-controls__cluster[aria-label='Rotate view'] button {
+  font-size: 0.9rem;
+}
+
+.viewport-controls__cluster[aria-label='Zoom controls'] button {
+  font-size: 1.05rem;
+}
+
+@media (max-width: 1280px) {
+  .viewport-controls {
+    grid-template-columns: repeat(auto-fit, minmax(72px, 1fr));
+    justify-content: stretch;
+  }
+
+  .viewport-controls button {
+    min-width: auto;
+  }
+}
+
+@media (max-width: 980px) {
+  .viewport-overlay {
+    padding: 1rem;
+  }
+
+  .viewport-shortcuts {
+    font-size: 0.75rem;
+  }
+
+  .viewport-controls {
+    gap: 0.4rem;
+  }
+}
+
+@keyframes viewport-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .animation-selector {
   display: grid;
   gap: 0.6rem;


### PR DESCRIPTION
## Summary
- remove the fallback torus placeholder so only real critter and weapon assets render in the stage
- add a status/controls overlay with keyboard hints and action buttons to make the viewport easier to navigate
- extend the scene manager with richer orbit controls, camera focusing, and status updates wired to the new UI

## Testing
- not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68ca2d2220188329bf32b4df9ebb6858