### PR TITLE
Enhance critter viewport controls and remove placeholders

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -5,6 +5,7 @@ import { createEventBus } from '../utils/eventBus.js';
 import { critters } from '../data/critters.js';
 import { CritterSelector } from '../hud/components/CritterSelector.js';
 import { AnimationSelector } from '../hud/components/AnimationSelector.js';
+import { ViewportOverlay } from '../hud/components/ViewportOverlay.js';
 
 export class WeaponDisplayApp {
   constructor(rootElement) {
@@ -14,6 +15,7 @@ export class WeaponDisplayApp {
     this.hudController = null;
     this.critterSelector = null;
     this.animationSelector = null;
+    this.viewportOverlay = null;
 
     this.weapons = sampleWeapons;
     this.weaponMap = new Map();
@@ -32,8 +34,14 @@ export class WeaponDisplayApp {
     this.indexCritters();
     this.registerEventHandlers();
 
-    this.sceneManager = new SceneManager(layout.stageViewportElement);
+    this.sceneManager = new SceneManager(layout.stageViewportElement, { bus: this.eventBus });
     this.sceneManager.init();
+
+    this.viewportOverlay = new ViewportOverlay({
+      container: layout.stageViewportElement,
+      bus: this.eventBus,
+    });
+    this.viewportOverlay.init();
 
     this.hudController = new HUDController({
       bus: this.eventBus,

--- a/src/core/ResourceLoader.js
+++ b/src/core/ResourceLoader.js
@@ -107,18 +107,9 @@ export class ResourceLoader {
   }
 
   _createPlaceholder() {
-    const geometry = new THREE.IcosahedronGeometry(0.8, 1);
-    const material = new THREE.MeshStandardMaterial({
-      color: 0x7a5dd1,
-      emissive: 0x140d2f,
-      metalness: 0.45,
-      roughness: 0.4,
-    });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.name = 'placeholder-weapon';
-
     const group = new THREE.Group();
-    group.add(mesh);
+    group.name = 'missing-model-placeholder';
+    group.userData.isPlaceholder = true;
     return group;
   }
 }

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -13,9 +13,18 @@ const RARITY_GLOWS = {
   mythic: 0xffb7ff,
 };
 
+const CAMERA_DEFAULT_POSITION = new THREE.Vector3(0, 1.1, 3.3);
+const CAMERA_DEFAULT_TARGET = new THREE.Vector3(0, 0.65, 0);
+const CAMERA_TRANSITION_SPEED = 2.25;
+const FOCUS_OFFSET_DIRECTION = new THREE.Vector3(0.45, 0.3, 1).normalize();
+const FOCUS_PADDING = 1.25;
+
+const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+
 export class SceneManager {
-  constructor(container) {
+  constructor(container, options = {}) {
     this.container = container;
+    this.bus = options.bus ?? null;
     this.scene = new THREE.Scene();
     this.camera = null;
     this.renderer = null;
@@ -33,9 +42,25 @@ export class SceneManager {
     this.mixer = null;
     this.activeAction = null;
     this.orbitControls = null;
+    this.autoRotateEnabled = false;
 
     this.handleResize = this.handleResize.bind(this);
     this.animate = this.animate.bind(this);
+
+    this.defaultCameraPosition = CAMERA_DEFAULT_POSITION.clone();
+    this.defaultCameraTarget = CAMERA_DEFAULT_TARGET.clone();
+
+    this.cameraStartPosition = CAMERA_DEFAULT_POSITION.clone();
+    this.cameraTargetPosition = CAMERA_DEFAULT_POSITION.clone();
+    this.controlsStartTarget = CAMERA_DEFAULT_TARGET.clone();
+    this.controlsTarget = CAMERA_DEFAULT_TARGET.clone();
+    this.cameraLerpAlpha = 1;
+    this.cameraLerpSpeed = CAMERA_TRANSITION_SPEED;
+
+    this.boundingBox = new THREE.Box3();
+    this.boundingSphere = new THREE.Sphere();
+
+    this.busOffHandlers = [];
   }
 
   init() {
@@ -45,6 +70,9 @@ export class SceneManager {
     this.setupEnvironment();
     this.scene.add(this.stageGroup);
     this.setupControls();
+    this.registerBusHandlers();
+    this.resetView(true);
+    this.emitStageEvent('stage:auto-rotate-changed', { enabled: this.autoRotateEnabled });
 
     window.addEventListener('resize', this.handleResize);
     this.handleResize();
@@ -63,7 +91,17 @@ export class SceneManager {
   }
 
   update(delta) {
-    if (this.orbitControls) {
+    if (this.cameraLerpAlpha < 1 && this.camera) {
+      this.cameraLerpAlpha = Math.min(1, this.cameraLerpAlpha + delta * this.cameraLerpSpeed);
+      const eased = easeOutCubic(this.cameraLerpAlpha);
+      this.camera.position.lerpVectors(this.cameraStartPosition, this.cameraTargetPosition, eased);
+      if (this.orbitControls) {
+        this.orbitControls.target.lerpVectors(this.controlsStartTarget, this.controlsTarget, eased);
+        this.orbitControls.update();
+      } else {
+        this.camera.lookAt(this.controlsTarget);
+      }
+    } else if (this.orbitControls) {
       this.orbitControls.update();
     }
 
@@ -79,8 +117,8 @@ export class SceneManager {
   createCamera() {
     const aspect = this.container.clientWidth / Math.max(this.container.clientHeight, 1);
     const camera = new THREE.PerspectiveCamera(40, aspect, 0.1, 100);
-    camera.position.set(0, 1.1, 3.3);
-    camera.lookAt(0, 0.4, 0);
+    camera.position.copy(this.defaultCameraPosition);
+    camera.lookAt(this.defaultCameraTarget);
     return camera;
   }
 
@@ -90,12 +128,128 @@ export class SceneManager {
     this.orbitControls = new module.OrbitControls(this.camera, this.renderer.domElement);
     this.orbitControls.enableDamping = true;
     this.orbitControls.dampingFactor = 0.08;
-    this.orbitControls.enablePan = false;
-    this.orbitControls.maxPolarAngle = Math.PI * 0.52;
-    this.orbitControls.minDistance = 2.0;
-    this.orbitControls.maxDistance = 6.0;
-    this.orbitControls.target.set(0, 0.65, 0);
+    this.orbitControls.enablePan = true;
+    this.orbitControls.screenSpacePanning = true;
+    this.orbitControls.panSpeed = 0.65;
+    this.orbitControls.rotateSpeed = 0.6;
+    this.orbitControls.zoomSpeed = 1.1;
+    this.orbitControls.maxPolarAngle = Math.PI * 0.58;
+    this.orbitControls.minDistance = 1.6;
+    this.orbitControls.maxDistance = 6.5;
+    this.orbitControls.target.copy(this.defaultCameraTarget);
+    this.orbitControls.autoRotate = this.autoRotateEnabled;
+    this.orbitControls.autoRotateSpeed = 1.2;
+    this.orbitControls.addEventListener('start', () => {
+      if (this.autoRotateEnabled) {
+        this.setAutoRotate(false);
+      }
+    });
     this.orbitControls.update();
+  }
+
+  registerBusHandlers() {
+    if (!this.bus) return;
+    this.busOffHandlers.push(
+      this.bus.on('stage:focus-requested', () => this.focusOnCurrentModel()),
+      this.bus.on('stage:reset-requested', () => this.resetView()),
+      this.bus.on('stage:auto-rotate-requested', (payload) => {
+        const next = payload?.enabled;
+        if (typeof next === 'boolean') {
+          this.setAutoRotate(next);
+        } else {
+          this.setAutoRotate(!this.autoRotateEnabled);
+        }
+      })
+    );
+  }
+
+  emitStageEvent(event, detail) {
+    this.bus?.emit?.(event, detail);
+  }
+
+  startCameraTransition(position, target, { immediate = false } = {}) {
+    if (!this.camera) {
+      return;
+    }
+
+    const safePosition = position || this.defaultCameraPosition;
+    const safeTarget = target || this.defaultCameraTarget;
+
+    if (immediate || !this.orbitControls) {
+      this.camera.position.copy(safePosition);
+      if (this.orbitControls) {
+        this.orbitControls.target.copy(safeTarget);
+        this.orbitControls.update();
+      } else {
+        this.camera.lookAt(safeTarget);
+      }
+      this.cameraLerpAlpha = 1;
+      return;
+    }
+
+    this.cameraStartPosition.copy(this.camera.position);
+    this.cameraTargetPosition.copy(safePosition);
+    this.controlsStartTarget.copy(this.orbitControls.target);
+    this.controlsTarget.copy(safeTarget);
+    this.cameraLerpAlpha = 0;
+  }
+
+  computeFrameDistance(radius) {
+    if (!this.camera || radius <= 0) {
+      return 3;
+    }
+
+    const fov = THREE.MathUtils.degToRad(this.camera.fov);
+    const aspect = this.container.clientWidth / Math.max(this.container.clientHeight, 1);
+    const horizontalFov = 2 * Math.atan(Math.tan(fov / 2) * aspect);
+    const minFov = Math.min(fov, horizontalFov);
+    const distance = radius / Math.sin(minFov / 2);
+    return distance * FOCUS_PADDING;
+  }
+
+  focusOnCurrentModel({ immediate = false } = {}) {
+    if (!this.currentModel) {
+      return false;
+    }
+
+    this.currentModel.updateWorldMatrix?.(true, true);
+    this.boundingBox.setFromObject(this.currentModel);
+    if (this.boundingBox.isEmpty()) {
+      return false;
+    }
+
+    this.boundingBox.getBoundingSphere(this.boundingSphere);
+    if (!Number.isFinite(this.boundingSphere.radius) || this.boundingSphere.radius <= 0) {
+      return false;
+    }
+
+    const center = this.boundingSphere.center.clone();
+    if (!Number.isFinite(center.x) || !Number.isFinite(center.y) || !Number.isFinite(center.z)) {
+      return false;
+    }
+    const distance = this.computeFrameDistance(this.boundingSphere.radius);
+    const offset = FOCUS_OFFSET_DIRECTION.clone().multiplyScalar(distance);
+    const position = center.clone().add(offset);
+
+    this.startCameraTransition(position, center, { immediate });
+    this.emitStageEvent('stage:focus-achieved', {
+      position: position.toArray(),
+      target: center.toArray(),
+    });
+    return true;
+  }
+
+  resetView(immediate = false) {
+    this.startCameraTransition(this.defaultCameraPosition, this.defaultCameraTarget, { immediate });
+    this.emitStageEvent('stage:view-reset');
+  }
+
+  setAutoRotate(enabled) {
+    this.autoRotateEnabled = Boolean(enabled);
+    if (this.orbitControls) {
+      this.orbitControls.autoRotate = this.autoRotateEnabled;
+    }
+    this.emitStageEvent('stage:auto-rotate-changed', { enabled: this.autoRotateEnabled });
   }
 
   setupLights() {
@@ -143,6 +297,11 @@ export class SceneManager {
     if (!weapon) return;
 
     const requestId = (this.pendingWeaponId = weapon.id);
+    this.emitStageEvent('stage:model-loading', {
+      type: 'weapon',
+      id: weapon.id,
+      name: weapon.name,
+    });
 
     let model = null;
     if (weapon.modelPath) {
@@ -153,8 +312,17 @@ export class SceneManager {
       return;
     }
 
-    if (!model) {
-      model = this.createPlaceholderModel();
+    this.disposeCurrentModel();
+
+    if (!model || model.userData?.isPlaceholder) {
+      this.emitStageEvent('stage:model-missing', {
+        type: 'weapon',
+        id: weapon.id,
+        name: weapon.name,
+      });
+      this.setAutoRotate(false);
+      this.pendingWeaponId = null;
+      return;
     }
 
     model.position.set(0, 0, 0);
@@ -163,17 +331,28 @@ export class SceneManager {
     const scale = weapon.preview?.scale ?? 1.2;
     model.scale.setScalar(scale);
 
-    this.disposeCurrentModel();
     this.currentModel = model;
     this.stageGroup.add(model);
 
     this.applyRarityGlow(weapon.rarity);
+    this.focusOnCurrentModel({ immediate: false });
+    this.emitStageEvent('stage:model-ready', {
+      type: 'weapon',
+      id: weapon.id,
+      name: weapon.name,
+    });
+    this.pendingWeaponId = null;
   }
 
   async loadCritter(critter) {
     if (!critter) return;
 
     const requestId = (this.pendingCritterId = critter.id);
+    this.emitStageEvent('stage:model-loading', {
+      type: 'critter',
+      id: critter.id,
+      name: critter.name,
+    });
 
     let model = null;
     if (critter.modelPath) {
@@ -184,11 +363,19 @@ export class SceneManager {
       return;
     }
 
-    if (!model) {
-      model = this.createPlaceholderModel();
-    }
-
     this.disposeCurrentModel();
+
+    if (!model || model.userData?.isPlaceholder) {
+      this.emitStageEvent('stage:model-missing', {
+        type: 'critter',
+        id: critter.id,
+        name: critter.name,
+      });
+      this.stopAnimation();
+      this.setAutoRotate(false);
+      this.pendingCritterId = null;
+      return;
+    }
 
     const offset = critter.offset ?? {};
     const rotation = critter.rotation ?? {};
@@ -204,6 +391,13 @@ export class SceneManager {
 
     this.mixer = new THREE.AnimationMixer(model);
     this.activeAction = null;
+    this.focusOnCurrentModel({ immediate: false });
+    this.emitStageEvent('stage:model-ready', {
+      type: 'critter',
+      id: critter.id,
+      name: critter.name,
+    });
+    this.pendingCritterId = null;
   }
 
   async playAnimation(animation) {
@@ -276,17 +470,10 @@ export class SceneManager {
   }
 
   createPlaceholderModel() {
-    const geometry = new THREE.TorusKnotGeometry(0.65, 0.18, 128, 16);
-    const material = new THREE.MeshStandardMaterial({
-      color: 0xff9dce,
-      emissive: 0x2b0f35,
-      metalness: 0.28,
-      roughness: 0.28,
-      emissiveIntensity: 0.6,
-    });
-    const mesh = new THREE.Mesh(geometry, material);
-    mesh.castShadow = false;
-    return mesh;
+    const group = new THREE.Group();
+    group.name = 'scene-placeholder';
+    group.userData.isPlaceholder = true;
+    return group;
   }
 
   handleResize() {
@@ -312,5 +499,7 @@ export class SceneManager {
     });
     this.renderer?.dispose?.();
     this.orbitControls?.dispose?.();
+    this.busOffHandlers.forEach((off) => off?.());
+    this.busOffHandlers = [];
   }
 }

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -1,0 +1,216 @@
+export class ViewportOverlay {
+  constructor({ container, bus }) {
+    this.container = container;
+    this.bus = bus;
+    this.root = null;
+    this.statusElement = null;
+    this.statusText = null;
+    this.autoRotateButton = null;
+    this.focusButton = null;
+    this.resetButton = null;
+    this.autoRotateEnabled = false;
+    this.state = 'idle';
+    this.unsubscribe = [];
+    this.pulseTimeout = null;
+    this.isLoading = false;
+  }
+
+  init() {
+    if (!this.container) {
+      throw new Error('ViewportOverlay requires a container element.');
+    }
+
+    this.build();
+    this.bindControls();
+    this.bindBusEvents();
+    this.setStatus('idle', 'Select a critter to preview.');
+  }
+
+  build() {
+    this.root = document.createElement('div');
+    this.root.className = 'viewport-ui';
+    this.root.innerHTML = `
+      <div class="viewport-ui__top">
+        <div class="viewport-status" data-role="viewport-status" data-state="idle">
+          <span class="viewport-status__indicator" data-role="viewport-status-indicator"></span>
+          <span class="viewport-status__text" data-role="viewport-status-text"></span>
+        </div>
+      </div>
+      <div class="viewport-ui__bottom">
+        <div class="viewport-instructions">
+          <p class="viewport-instructions__title">Camera Tips</p>
+          <ul class="viewport-instructions__list" aria-label="Viewport camera controls">
+            <li><span>Drag</span> Orbit around</li>
+            <li><span>Right-drag</span> Pan the view</li>
+            <li><span>Scroll</span> Zoom in or out</li>
+          </ul>
+        </div>
+        <div class="viewport-controls" role="group" aria-label="Viewport controls">
+          <button type="button" class="viewport-button" data-action="focus">Focus Model</button>
+          <button type="button" class="viewport-button" data-action="reset">Reset View</button>
+          <button
+            type="button"
+            class="viewport-button viewport-button--toggle"
+            data-action="autorotate"
+            aria-pressed="false"
+          >
+            Auto Orbit
+          </button>
+        </div>
+      </div>
+    `;
+
+    this.container.appendChild(this.root);
+    this.statusElement = this.root.querySelector('[data-role="viewport-status"]');
+    this.statusText = this.root.querySelector('[data-role="viewport-status-text"]');
+    this.autoRotateButton = this.root.querySelector('[data-action="autorotate"]');
+    this.focusButton = this.root.querySelector('[data-action="focus"]');
+    this.resetButton = this.root.querySelector('[data-action="reset"]');
+  }
+
+  bindControls() {
+    if (!this.bus) {
+      return;
+    }
+
+    if (this.focusButton) {
+      this.focusButton.addEventListener('click', () => {
+        this.bus.emit('stage:focus-requested');
+      });
+    }
+
+    if (this.resetButton) {
+      this.resetButton.addEventListener('click', () => {
+        this.bus.emit('stage:reset-requested');
+        this.flashStatus();
+      });
+    }
+
+    if (this.autoRotateButton) {
+      this.autoRotateButton.addEventListener('click', () => {
+        const next = !this.autoRotateEnabled;
+        this.bus.emit('stage:auto-rotate-requested', { enabled: next });
+      });
+    }
+  }
+
+  bindBusEvents() {
+    if (!this.bus) {
+      return;
+    }
+
+    this.unsubscribe.push(
+      this.bus.on('stage:model-loading', (payload) => {
+        const name = payload?.name ?? 'Model';
+        this.setStatus('loading', `Loading ${name}...`);
+        this.setLoading(true);
+      }),
+      this.bus.on('stage:model-ready', (payload) => {
+        const name = payload?.name ?? 'Model';
+        this.setStatus('ready', `${name} ready for inspection.`);
+        this.setLoading(false);
+        this.setControlsAvailability({ focus: true, reset: true, autorotate: true });
+        this.flashStatus();
+      }),
+      this.bus.on('stage:model-missing', (payload) => {
+        const name = payload?.name ?? 'model';
+        this.setStatus('empty', `We couldn't load the ${name}.`);
+        this.setLoading(false);
+        this.setControlsAvailability({ focus: false, reset: true, autorotate: false });
+      }),
+      this.bus.on('stage:focus-achieved', () => {
+        this.flashStatus();
+      }),
+      this.bus.on('stage:view-reset', () => {
+        this.flashStatus();
+      }),
+      this.bus.on('stage:auto-rotate-changed', (payload) => {
+        this.autoRotateEnabled = Boolean(payload?.enabled);
+        this.updateAutoRotateButton();
+      })
+    );
+  }
+
+  setStatus(state, message) {
+    this.state = state;
+    if (this.statusElement) {
+      this.statusElement.dataset.state = state;
+    }
+    if (this.statusText) {
+      this.statusText.textContent = message;
+    }
+  }
+
+  updateAutoRotateButton() {
+    if (!this.autoRotateButton) {
+      return;
+    }
+    this.autoRotateButton.setAttribute('aria-pressed', this.autoRotateEnabled ? 'true' : 'false');
+    this.autoRotateButton.classList.toggle('is-active', this.autoRotateEnabled);
+  }
+
+  flashStatus() {
+    if (!this.statusElement) {
+      return;
+    }
+    this.statusElement.classList.remove('is-pulsing');
+    // Force reflow so the animation can restart consistently.
+    // eslint-disable-next-line no-unused-expressions
+    this.statusElement.offsetWidth;
+    this.statusElement.classList.add('is-pulsing');
+    if (this.pulseTimeout) {
+      clearTimeout(this.pulseTimeout);
+    }
+    this.pulseTimeout = setTimeout(() => {
+      this.statusElement?.classList.remove('is-pulsing');
+    }, 900);
+  }
+
+  setLoading(isLoading) {
+    this.isLoading = isLoading;
+    this.root?.classList.toggle('is-loading', isLoading);
+    this.setControlsAvailability({
+      focus: !isLoading,
+      reset: !isLoading,
+      autorotate: !isLoading,
+    });
+  }
+
+  setControlsAvailability({ focus, reset, autorotate }) {
+    this.updateButtonState(this.focusButton, focus);
+    this.updateButtonState(this.resetButton, reset);
+    this.updateButtonState(this.autoRotateButton, autorotate);
+  }
+
+  updateButtonState(button, isEnabled) {
+    if (!button || typeof isEnabled === 'undefined') {
+      return;
+    }
+    button.disabled = !isEnabled;
+    button.classList.toggle('is-disabled', !isEnabled);
+  }
+
+  destroy() {
+    this.unsubscribe.forEach((off) => off?.());
+    this.unsubscribe = [];
+    if (this.autoRotateButton) {
+      this.autoRotateButton.replaceWith(this.autoRotateButton.cloneNode(true));
+      this.autoRotateButton = null;
+    }
+    if (this.focusButton) {
+      this.focusButton.replaceWith(this.focusButton.cloneNode(true));
+      this.focusButton = null;
+    }
+    if (this.resetButton) {
+      this.resetButton.replaceWith(this.resetButton.cloneNode(true));
+      this.resetButton = null;
+    }
+    if (this.root?.parentNode) {
+      this.root.parentNode.removeChild(this.root);
+    }
+    if (this.pulseTimeout) {
+      clearTimeout(this.pulseTimeout);
+      this.pulseTimeout = null;
+    }
+  }
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -665,6 +665,225 @@ dl dt {
   inset: 0;
 }
 
+.viewport-ui {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 1.5rem 1.75rem;
+  pointer-events: none;
+  z-index: 2;
+  color: var(--color-text-primary);
+  background: linear-gradient(180deg, rgba(12, 32, 23, 0.28), rgba(12, 32, 23, 0));
+  backdrop-filter: blur(1px);
+}
+
+.viewport-ui__top,
+.viewport-ui__bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  pointer-events: none;
+}
+
+.viewport-status {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.15rem;
+  border-radius: 16px;
+  border: 1px solid rgba(124, 200, 111, 0.32);
+  background: linear-gradient(135deg, rgba(20, 52, 37, 0.82), rgba(18, 47, 58, 0.65));
+  box-shadow: 0 16px 32px rgba(8, 20, 14, 0.45);
+  transition: border-color 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
+}
+
+.viewport-status.is-pulsing {
+  box-shadow: 0 0 0 0 rgba(124, 200, 111, 0.45), 0 16px 42px rgba(8, 20, 14, 0.5);
+  animation: viewport-status-pulse 0.9s ease;
+}
+
+.viewport-status__indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid rgba(124, 200, 111, 0.35);
+  border-top-color: rgba(124, 200, 111, 0.95);
+  opacity: 0.2;
+  transform: scale(0.85);
+  transition: opacity 0.2s ease, transform 0.2s ease, border-color 0.3s ease,
+    background-color 0.3s ease;
+}
+
+.viewport-status__text {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.viewport-status[data-state='loading'] .viewport-status__indicator {
+  opacity: 1;
+  animation: viewport-status-spin 1s linear infinite;
+}
+
+.viewport-status[data-state='ready'] {
+  border-color: rgba(124, 200, 111, 0.6);
+  background: linear-gradient(135deg, rgba(22, 56, 40, 0.9), rgba(30, 70, 52, 0.75));
+}
+
+.viewport-status[data-state='ready'] .viewport-status__indicator {
+  opacity: 1;
+  animation: none;
+  border: none;
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.95), rgba(211, 243, 107, 0.95));
+  box-shadow: 0 0 10px rgba(211, 243, 107, 0.6);
+}
+
+.viewport-status[data-state='empty'] {
+  border-color: rgba(229, 132, 96, 0.6);
+  background: linear-gradient(135deg, rgba(52, 26, 22, 0.82), rgba(52, 34, 27, 0.68));
+}
+
+.viewport-status[data-state='empty'] .viewport-status__indicator {
+  opacity: 1;
+  animation: none;
+  border: none;
+  background: linear-gradient(135deg, rgba(229, 132, 96, 0.9), rgba(255, 196, 132, 0.9));
+  box-shadow: 0 0 10px rgba(229, 132, 96, 0.6);
+}
+
+.viewport-instructions {
+  pointer-events: auto;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  border: 1px solid rgba(124, 200, 111, 0.28);
+  background: linear-gradient(160deg, rgba(16, 40, 29, 0.82), rgba(16, 37, 47, 0.78));
+  box-shadow: 0 18px 30px rgba(8, 20, 14, 0.35);
+  max-width: 240px;
+}
+
+.viewport-instructions__title {
+  margin: 0 0 0.65rem;
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+}
+
+.viewport-instructions__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.05em;
+  color: rgba(243, 248, 240, 0.82);
+}
+
+.viewport-instructions__list span {
+  display: inline-block;
+  min-width: 88px;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  margin-right: 0.4rem;
+  background: rgba(124, 200, 111, 0.2);
+  border: 1px solid rgba(124, 200, 111, 0.45);
+  color: var(--color-highlight);
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.72rem;
+}
+
+.viewport-controls {
+  pointer-events: auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-left: auto;
+}
+
+.viewport-button {
+  border: 1px solid rgba(124, 200, 111, 0.35);
+  border-radius: 999px;
+  padding: 0.55rem 1.35rem;
+  background: rgba(12, 31, 23, 0.68);
+  color: var(--color-text-primary);
+  font-family: var(--font-display);
+  letter-spacing: 0.14em;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.viewport-button:hover,
+.viewport-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(124, 200, 111, 0.65);
+  box-shadow: 0 16px 32px rgba(10, 28, 20, 0.45);
+  outline: none;
+}
+
+.viewport-button.is-disabled,
+.viewport-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+  border-color: rgba(124, 200, 111, 0.18);
+  background: rgba(12, 31, 23, 0.45);
+}
+
+.viewport-button.is-disabled:hover,
+.viewport-button.is-disabled:focus-visible,
+.viewport-button:disabled:hover,
+.viewport-button:disabled:focus-visible {
+  transform: none;
+  box-shadow: none;
+  border-color: rgba(124, 200, 111, 0.18);
+}
+
+.viewport-button--toggle.is-active {
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.95), rgba(211, 243, 107, 0.95));
+  color: #0c1c14;
+  border-color: rgba(124, 200, 111, 0.85);
+  box-shadow: 0 18px 32px rgba(14, 36, 26, 0.55);
+}
+
+.viewport-button--toggle.is-active:hover,
+.viewport-button--toggle.is-active:focus-visible {
+  border-color: rgba(124, 200, 111, 0.9);
+}
+
+@keyframes viewport-status-spin {
+  from {
+    transform: rotate(0deg) scale(0.85);
+  }
+  to {
+    transform: rotate(360deg) scale(0.85);
+  }
+}
+
+@keyframes viewport-status-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(124, 200, 111, 0.55);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(124, 200, 111, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(124, 200, 111, 0);
+  }
+}
+
 .animation-selector {
   display: grid;
   gap: 0.6rem;
@@ -763,6 +982,18 @@ dl dt {
     height: 320px;
     border-radius: var(--border-radius-lg);
   }
+
+  .viewport-ui {
+    padding: 1.25rem 1.4rem;
+  }
+
+  .viewport-instructions {
+    max-width: none;
+  }
+
+  .viewport-controls {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 1100px) {
@@ -820,6 +1051,19 @@ dl dt {
     grid-column: 1;
     height: 320px;
   }
+
+  .viewport-ui {
+    padding: 1.1rem 1.3rem;
+  }
+
+  .viewport-ui__bottom {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .viewport-controls {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 700px) {
@@ -837,5 +1081,13 @@ dl dt {
 
   .stage {
     height: 260px;
+  }
+
+  .viewport-ui {
+    padding: 1rem 1.1rem;
+  }
+
+  .viewport-instructions__list span {
+    min-width: auto;
   }
 }


### PR DESCRIPTION
## Summary
- prevent placeholder meshes from rendering by flagging missing models and emitting viewport events
- upgrade the scene manager with orbit-control improvements, camera framing, and status notifications for the viewport
- add a styled overlay that shows navigation tips and focus/reset/auto-rotate controls tailored to the 3D viewer

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca2d2220188329bf32b4df9ebb6858