### PR TITLE
Fix critter models by using ESM-friendly three.js modules

### DIFF
--- a/src/core/RendererFactory.js
+++ b/src/core/RendererFactory.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import * as THREE from 'https://esm.sh/three@0.160.0';
 
 export const createRenderer = (container) => {
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });

--- a/src/core/ResourceLoader.js
+++ b/src/core/ResourceLoader.js
@@ -1,10 +1,10 @@
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import * as THREE from 'https://esm.sh/three@0.160.0';
 
 export class ResourceLoader {
   constructor() {
     this.cache = new Map();
     this.loaderPromise = null;
-    this.skeletonUtilsPromise = null;
+    this.clonePromise = null;
   }
 
   async loadModel(path) {
@@ -15,8 +15,8 @@ export class ResourceLoader {
     const cached = this.cache.get(path);
     if (cached) {
       if (cached.type === 'model') {
-        const { SkeletonUtils } = await this._getSkeletonUtils();
-        return SkeletonUtils.clone(cached.scene);
+        const clone = await this._getCloneFunction();
+        return clone(cached.scene);
       }
 
       if (cached.type === 'placeholder') {
@@ -30,8 +30,8 @@ export class ResourceLoader {
       const scene = gltf.scene || gltf.scenes?.[0];
       if (scene) {
         this.cache.set(path, { type: 'model', scene });
-        const { SkeletonUtils } = await this._getSkeletonUtils();
-        return SkeletonUtils.clone(scene);
+        const clone = await this._getCloneFunction();
+        return clone(scene);
       }
     } catch (error) {
       console.warn(`Failed to load model at ${path}. Using fallback geometry instead.`, error);
@@ -91,19 +91,19 @@ export class ResourceLoader {
   async _getLoader() {
     if (!this.loaderPromise) {
       this.loaderPromise = import(
-        'https://unpkg.com/three@0.160.0/examples/jsm/loaders/GLTFLoader.js'
+        'https://esm.sh/three@0.160.0/examples/jsm/loaders/GLTFLoader.js'
       ).then((module) => new module.GLTFLoader());
     }
     return this.loaderPromise;
   }
 
-  async _getSkeletonUtils() {
-    if (!this.skeletonUtilsPromise) {
-      this.skeletonUtilsPromise = import(
-        'https://unpkg.com/three@0.160.0/examples/jsm/utils/SkeletonUtils.js'
-      );
+  async _getCloneFunction() {
+    if (!this.clonePromise) {
+      this.clonePromise = import(
+        'https://esm.sh/three@0.160.0/examples/jsm/utils/SkeletonUtils.js'
+      ).then((module) => module.clone);
     }
-    return this.skeletonUtilsPromise;
+    return this.clonePromise;
   }
 
   _createPlaceholder() {

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -1,9 +1,9 @@
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import * as THREE from 'https://esm.sh/three@0.160.0';
 import { createRenderer } from './RendererFactory.js';
 import { ResourceLoader } from './ResourceLoader.js';
 
 const ORBIT_CONTROLS_MODULE =
-  'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+  'https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js';
 
 const RARITY_GLOWS = {
   common: 0x7c6cff,


### PR DESCRIPTION
## Summary
- switch core three.js imports to esm.sh so the browser can resolve bare module specifiers without a bundler
- load GLTFLoader, SkeletonUtils clone helper, and OrbitControls from the same CDN and update the loader to clone scenes via the exported helper
- ensure cached critter models clone correctly so Frog and Lizard models render instead of the placeholder geometry

## Testing
- Manual verification: started the dev server with `python -m http.server` and confirmed the Frog critter model loads without falling back to the placeholder


------
https://chatgpt.com/codex/tasks/task_e_68ca3172bdb0832985adbbfdaece2fc4