### PR TITLE
Add category placeholder models for weapons

### DIFF
--- a/assets/models/melee/placeholder.gltf
+++ b/assets/models/melee/placeholder.gltf
@@ -1,0 +1,104 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "Critz Placeholder Builder"
+  },
+  "extensionsUsed": [
+    "KHR_materials_unlit"
+  ],
+  "extensionsRequired": [
+    "KHR_materials_unlit"
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAGZm5j4AAAAAXI/CvgAAgL4K16M+XI/CPgAAgL4K16M+AAAAAGZm5r4zM7O+AAABAAIAAAACAAMAAAADAAEAAQADAAIA",
+      "byteLength": 72
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 48,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 48,
+      "byteLength": 24,
+      "target": 34963
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 4,
+      "type": "VEC3",
+      "min": [
+        -0.38,
+        -0.45,
+        -0.35
+      ],
+      "max": [
+        0.38,
+        0.45,
+        0.32
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5123,
+      "count": 12,
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "name": "Melee Placeholder",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.2,
+          0.8,
+          0.4,
+          1.0
+        ],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 1.0
+      },
+      "doubleSided": true,
+      "extensions": {
+        "KHR_materials_unlit": {}
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "name": "PlaceholderMesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0
+          },
+          "indices": 1,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Placeholder",
+      "mesh": 0
+    }
+  ],
+  "scenes": [
+    {
+      "name": "Scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "scene": 0
+}

--- a/assets/models/primary/placeholder.gltf
+++ b/assets/models/primary/placeholder.gltf
@@ -1,0 +1,104 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "Critz Placeholder Builder"
+  },
+  "extensionsUsed": [
+    "KHR_materials_unlit"
+  ],
+  "extensionsRequired": [
+    "KHR_materials_unlit"
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAGZm5j4AAAAAXI/CvgAAgL4K16M+XI/CPgAAgL4K16M+AAAAAGZm5r4zM7O+AAABAAIAAAACAAMAAAADAAEAAQADAAIA",
+      "byteLength": 72
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 48,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 48,
+      "byteLength": 24,
+      "target": 34963
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 4,
+      "type": "VEC3",
+      "min": [
+        -0.38,
+        -0.45,
+        -0.35
+      ],
+      "max": [
+        0.38,
+        0.45,
+        0.32
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5123,
+      "count": 12,
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "name": "Primary Placeholder",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.85,
+          0.25,
+          0.25,
+          1.0
+        ],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 1.0
+      },
+      "doubleSided": true,
+      "extensions": {
+        "KHR_materials_unlit": {}
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "name": "PlaceholderMesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0
+          },
+          "indices": 1,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Placeholder",
+      "mesh": 0
+    }
+  ],
+  "scenes": [
+    {
+      "name": "Scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "scene": 0
+}

--- a/assets/models/secondary/placeholder.gltf
+++ b/assets/models/secondary/placeholder.gltf
@@ -1,0 +1,104 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "Critz Placeholder Builder"
+  },
+  "extensionsUsed": [
+    "KHR_materials_unlit"
+  ],
+  "extensionsRequired": [
+    "KHR_materials_unlit"
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAGZm5j4AAAAAXI/CvgAAgL4K16M+XI/CPgAAgL4K16M+AAAAAGZm5r4zM7O+AAABAAIAAAACAAMAAAADAAEAAQADAAIA",
+      "byteLength": 72
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 48,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 48,
+      "byteLength": 24,
+      "target": 34963
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 4,
+      "type": "VEC3",
+      "min": [
+        -0.38,
+        -0.45,
+        -0.35
+      ],
+      "max": [
+        0.38,
+        0.45,
+        0.32
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5123,
+      "count": 12,
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "name": "Secondary Placeholder",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.2,
+          0.55,
+          0.95,
+          1.0
+        ],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 1.0
+      },
+      "doubleSided": true,
+      "extensions": {
+        "KHR_materials_unlit": {}
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "name": "PlaceholderMesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0
+          },
+          "indices": 1,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Placeholder",
+      "mesh": 0
+    }
+  ],
+  "scenes": [
+    {
+      "name": "Scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "scene": 0
+}

--- a/assets/models/utility/placeholder.gltf
+++ b/assets/models/utility/placeholder.gltf
@@ -1,0 +1,104 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "Critz Placeholder Builder"
+  },
+  "extensionsUsed": [
+    "KHR_materials_unlit"
+  ],
+  "extensionsRequired": [
+    "KHR_materials_unlit"
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAGZm5j4AAAAAXI/CvgAAgL4K16M+XI/CPgAAgL4K16M+AAAAAGZm5r4zM7O+AAABAAIAAAACAAMAAAADAAEAAQADAAIA",
+      "byteLength": 72
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 48,
+      "target": 34962
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 48,
+      "byteLength": 24,
+      "target": 34963
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 4,
+      "type": "VEC3",
+      "min": [
+        -0.38,
+        -0.45,
+        -0.35
+      ],
+      "max": [
+        0.38,
+        0.45,
+        0.32
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5123,
+      "count": 12,
+      "type": "SCALAR"
+    }
+  ],
+  "materials": [
+    {
+      "name": "Utility Placeholder",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.95,
+          0.75,
+          0.2,
+          1.0
+        ],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 1.0
+      },
+      "doubleSided": true,
+      "extensions": {
+        "KHR_materials_unlit": {}
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "name": "PlaceholderMesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0
+          },
+          "indices": 1,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "Placeholder",
+      "mesh": 0
+    }
+  ],
+  "scenes": [
+    {
+      "name": "Scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "scene": 0
+}

--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -520,6 +520,13 @@ const FALLBACK_RARITY_BY_CATEGORY = {
   utility: 'uncommon',
 };
 
+const PLACEHOLDER_MODEL_BY_CATEGORY = {
+  primary: 'assets/models/primary/placeholder.gltf',
+  secondary: 'assets/models/secondary/placeholder.gltf',
+  melee: 'assets/models/melee/placeholder.gltf',
+  utility: 'assets/models/utility/placeholder.gltf',
+};
+
 const HEADSHOT_MULTIPLIER = RAW_GLOBALS.headshot_multiplier ?? 3;
 
 const slugify = (value) =>
@@ -1084,7 +1091,7 @@ const weapons = RAW_WEAPONS.map((weapon) => {
     category,
     rarity: legacy.rarity || FALLBACK_RARITY_BY_CATEGORY[category] || 'common',
     description: legacy.description || weapon.notes || 'Specification pending.',
-    modelPath: legacy.modelPath ?? null,
+    modelPath: legacy.modelPath ?? PLACEHOLDER_MODEL_BY_CATEGORY[category] ?? null,
     preview: legacy.preview || undefined,
     stats: buildStats(weapon, category),
     special: buildSpecial(weapon, legacy.special || {}, category),


### PR DESCRIPTION
## Summary
- add lightweight glTF placeholder models for each weapon category to avoid binary asset issues
- point sample weapon data at the new category placeholders so every weapon loads a preview model

## Testing
- not run (static data only)


------
https://chatgpt.com/codex/tasks/task_e_68ca3209e3fc832990fb3e46f5cb96e3