### PR TITLE
Add placeholder weapon models

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Critz-Models/
         └── eventBus.js
 ```
 
-> **Note**: Until real assets are available, `.glb` placeholders sit under `assets/models/<category>/placeholder.glb`. The `ResourceLoader` is designed to swap to production CDN/local pipeline later.
+> **Note**: Until real assets are available, `.gltf` placeholders sit under `assets/models/<category>/placeholder.gltf`. The `ResourceLoader` is designed to swap to production CDN/local pipeline later.
 
 ## Core Modules
 ### `WeaponDisplayApp`

--- a/assets/models/melee/placeholder.gltf
+++ b/assets/models/melee/placeholder.gltf
@@ -1,0 +1,105 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "placeholder-generator"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "name": "melee-placeholder-scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "melee-placeholder-node",
+      "mesh": 0
+    }
+  ],
+  "materials": [
+    {
+      "name": "Melee Placeholder Material",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.835,
+          0.298,
+          0.341,
+          1.0
+        ],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 0.6
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "name": "Melee Placeholder Mesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "indices": 2,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 5,
+      "type": "VEC3",
+      "max": [
+        0.3,
+        1.1,
+        0.3
+      ],
+      "min": [
+        -0.3,
+        0.0,
+        -0.3
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 5,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5123,
+      "count": 18,
+      "type": "SCALAR"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 60
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 60,
+      "byteLength": 60
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 120,
+      "byteLength": 36,
+      "target": 34963
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 156,
+      "uri": "data:application/octet-stream;base64,mpmZvgAAAACamZm+mpmZPgAAAACamZm+mpmZPgAAAACamZk+mpmZvgAAAACamZk+AAAAAM3MjD8AAAAAFgusPm0/Yb8WC6w+uknxvirbPr+6SfE+Fgusvm0/Yb8WC6y+uknxPirbPr+6SfG+AAAAAAAAgL8AAAAAAAABAAIAAAACAAMAAAABAAQAAQACAAQAAgADAAQAAwAAAAQA"
+    }
+  ]
+}

--- a/assets/models/primary/placeholder.gltf
+++ b/assets/models/primary/placeholder.gltf
@@ -1,0 +1,105 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "placeholder-generator"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "name": "primary-placeholder-scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "primary-placeholder-node",
+      "mesh": 0
+    }
+  ],
+  "materials": [
+    {
+      "name": "Primary Placeholder Material",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.286,
+          0.514,
+          0.937,
+          1.0
+        ],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 0.6
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "name": "Primary Placeholder Mesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "indices": 2,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 5,
+      "type": "VEC3",
+      "max": [
+        0.3,
+        1.2,
+        0.3
+      ],
+      "min": [
+        -0.3,
+        0.0,
+        -0.3
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 5,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5123,
+      "count": 18,
+      "type": "SCALAR"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 60
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 60,
+      "byteLength": 60
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 120,
+      "byteLength": 36,
+      "target": 34963
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 156,
+      "uri": "data:application/octet-stream;base64,mpmZvgAAAACamZm+mpmZPgAAAACamZm+mpmZPgAAAACamZk+mpmZvgAAAACamZk+AAAAAJqZmT8AAAAAbfuuPuwcYL9t+64+16z1vnAJPL/XrPU+bfuuvuwcYL9t+66+16z1PnAJPL/XrPW+AAAAAAAAgL8AAAAAAAABAAIAAAACAAMAAAABAAQAAQACAAQAAgADAAQAAwAAAAQA"
+    }
+  ]
+}

--- a/assets/models/secondary/placeholder.gltf
+++ b/assets/models/secondary/placeholder.gltf
@@ -1,0 +1,105 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "placeholder-generator"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "name": "secondary-placeholder-scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "secondary-placeholder-node",
+      "mesh": 0
+    }
+  ],
+  "materials": [
+    {
+      "name": "Secondary Placeholder Material",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.223,
+          0.788,
+          0.572,
+          1.0
+        ],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 0.6
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "name": "Secondary Placeholder Mesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "indices": 2,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 5,
+      "type": "VEC3",
+      "max": [
+        0.3,
+        1.0,
+        0.3
+      ],
+      "min": [
+        -0.3,
+        0.0,
+        -0.3
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 5,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5123,
+      "count": 18,
+      "type": "SCALAR"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 60
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 60,
+      "byteLength": 60
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 120,
+      "byteLength": 36,
+      "target": 34963
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 156,
+      "uri": "data:application/octet-stream;base64,mpmZvgAAAACamZm+mpmZPgAAAACamZm+mpmZPgAAAACamZk+mpmZvgAAAACamZk+AAAAAAAAgD8AAAAA/ZCoPvGOYr/9kKg+xRjsvj0TQr/FGOw+/ZCovvGOYr/9kKi+xRjsPj0TQr/FGOy+AAAAAAAAgL8AAAAAAAABAAIAAAACAAMAAAABAAQAAQACAAQAAgADAAQAAwAAAAQA"
+    }
+  ]
+}

--- a/assets/models/utility/placeholder.gltf
+++ b/assets/models/utility/placeholder.gltf
@@ -1,0 +1,105 @@
+{
+  "asset": {
+    "version": "2.0",
+    "generator": "placeholder-generator"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "name": "utility-placeholder-scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "utility-placeholder-node",
+      "mesh": 0
+    }
+  ],
+  "materials": [
+    {
+      "name": "Utility Placeholder Material",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.937,
+          0.768,
+          0.341,
+          1.0
+        ],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 0.6
+      }
+    }
+  ],
+  "meshes": [
+    {
+      "name": "Utility Placeholder Mesh",
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0,
+            "NORMAL": 1
+          },
+          "indices": 2,
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 5,
+      "type": "VEC3",
+      "max": [
+        0.3,
+        0.9,
+        0.3
+      ],
+      "min": [
+        -0.3,
+        0.0,
+        -0.3
+      ]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 5,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5123,
+      "count": 18,
+      "type": "SCALAR"
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 60
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 60,
+      "byteLength": 60
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 120,
+      "byteLength": 36,
+      "target": 34963
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 156,
+      "uri": "data:application/octet-stream;base64,mpmZvgAAAACamZm+mpmZPgAAAACamZm+mpmZPgAAAACamZk+mpmZvgAAAACamZk+AAAAAGZmZj8AAAAAHWWkPvkVZL8dZaQ+EN/lvtDGRb8Q3+U+HWWkvvkVZL8dZaS+EN/lPtDGRb8Q3+W+AAAAAAAAgL8AAAAAAAABAAIAAAACAAMAAAABAAQAAQACAAQAAgADAAQAAwAAAAQA"
+    }
+  ]
+}

--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -1,5 +1,12 @@
 import { normalizeWeapon } from './weaponSchema.js';
 
+const PLACEHOLDER_MODEL_PATHS = {
+  primary: 'assets/models/primary/placeholder.gltf',
+  secondary: 'assets/models/secondary/placeholder.gltf',
+  melee: 'assets/models/melee/placeholder.gltf',
+  utility: 'assets/models/utility/placeholder.gltf',
+};
+
 const RAW_GLOBALS = {
   base_health: 100,
   base_speed: 100,
@@ -1084,7 +1091,7 @@ const weapons = RAW_WEAPONS.map((weapon) => {
     category,
     rarity: legacy.rarity || FALLBACK_RARITY_BY_CATEGORY[category] || 'common',
     description: legacy.description || weapon.notes || 'Specification pending.',
-    modelPath: legacy.modelPath ?? null,
+    modelPath: legacy.modelPath ?? PLACEHOLDER_MODEL_PATHS[category] ?? null,
     preview: legacy.preview || undefined,
     stats: buildStats(weapon, category),
     special: buildSpecial(weapon, legacy.special || {}, category),


### PR DESCRIPTION
## Summary
- add category-colored placeholder GLTF models for primary, secondary, melee, and utility weapons
- point sample weapon data at the new placeholder assets so previews render until real models arrive
- update documentation to reference the new placeholder asset format

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ca3209e3fc832990fb3e46f5cb96e3