### PR TITLE
Fix GLTF model loading and cloning

### DIFF
--- a/src/core/ResourceLoader.js
+++ b/src/core/ResourceLoader.js
@@ -15,7 +15,10 @@ export class ResourceLoader {
     const cached = this.cache.get(path);
     if (cached) {
       if (cached.type === 'model') {
-
+        const clone = await this._cloneScene(cached.scene);
+        if (clone) {
+          return clone;
+        }
       }
 
       if (cached.type === 'placeholder') {
@@ -29,6 +32,10 @@ export class ResourceLoader {
       const scene = gltf.scene || gltf.scenes?.[0];
       if (scene) {
         this.cache.set(path, { type: 'model', scene });
+        const clone = await this._cloneScene(scene);
+        if (clone) {
+          return clone;
+        }
       }
     } catch (error) {
       console.warn(`Failed to load model at ${path}. Using fallback geometry instead.`, error);
@@ -109,9 +116,9 @@ export class ResourceLoader {
     }
 
     try {
-      const module = await this._getSkeletonUtils();
-      if (module?.clone) {
-        return module.clone(scene);
+      const cloneFn = await this._getCloneFunction();
+      if (typeof cloneFn === 'function') {
+        return cloneFn(scene);
       }
     } catch (error) {
       console.warn('Failed to clone model using SkeletonUtils. Falling back to basic clone.', error);


### PR DESCRIPTION
## Summary
- return proper cloned scenes when loading critter GLB models
- cache successful GLB loads and reuse SkeletonUtils.clone for skinned meshes
- preserve graceful fallback placeholders when a model cannot be loaded

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ca38092e5c8329bb58d6c1916abc71