### PR TITLE
Recenter viewport with collapsible rig controls

### DIFF
--- a/src/core/RigController.js
+++ b/src/core/RigController.js
@@ -1,0 +1,581 @@
+import * as THREE from 'https://esm.sh/three@0.160.0';
+
+const GROUP_ORDER = ['Face', 'Body', 'Arms', 'Legs', 'Tail'];
+
+const CONTROL_DEFINITIONS = [
+  {
+    id: 'mouthOpen',
+    label: 'Mouth Open',
+    group: 'Face',
+    order: 0,
+    morph: {
+      keywords: ['mouth_open', 'jaw_open', 'mouth', 'jaw'],
+      prefer: ['mouth_open', 'jaw_open'],
+      min: 0,
+      max: 1,
+      step: 0.01,
+      defaultValue: 0,
+    },
+    bone: {
+      axis: 'x',
+      keywords: ['jaw', 'mouth'],
+      prefer: ['jaw'],
+      min: -0.2,
+      max: 0.9,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'headPitch',
+    label: 'Head Pitch',
+    group: 'Face',
+    order: 1,
+    bone: {
+      axis: 'x',
+      keywords: ['head'],
+      min: -0.7,
+      max: 0.7,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'headYaw',
+    label: 'Head Turn',
+    group: 'Face',
+    order: 2,
+    bone: {
+      axis: 'y',
+      keywords: ['head'],
+      min: -0.9,
+      max: 0.9,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'headRoll',
+    label: 'Head Roll',
+    group: 'Face',
+    order: 3,
+    bone: {
+      axis: 'z',
+      keywords: ['head'],
+      min: -0.7,
+      max: 0.7,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'torsoLean',
+    label: 'Body Lean',
+    group: 'Body',
+    order: 0,
+    bone: {
+      axis: 'x',
+      keywords: ['spine', 'chest', 'torso'],
+      prefer: ['spine2', 'spine_02', 'chest'],
+      min: -0.6,
+      max: 0.6,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'torsoTwist',
+    label: 'Body Twist',
+    group: 'Body',
+    order: 1,
+    bone: {
+      axis: 'y',
+      keywords: ['spine', 'chest', 'torso'],
+      prefer: ['spine2', 'spine_02', 'chest'],
+      min: -0.8,
+      max: 0.8,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'tailCurl',
+    label: 'Tail Curl',
+    group: 'Tail',
+    order: 0,
+    bone: {
+      axis: 'x',
+      keywords: ['tail'],
+      min: -0.9,
+      max: 0.9,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'tailSwing',
+    label: 'Tail Swing',
+    group: 'Tail',
+    order: 1,
+    bone: {
+      axis: 'y',
+      keywords: ['tail'],
+      min: -0.9,
+      max: 0.9,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'armLiftL',
+    label: 'Left Arm Lift',
+    group: 'Arms',
+    order: 0,
+    bone: {
+      axis: 'z',
+      keywords: ['arm', 'shoulder', 'front'],
+      prefer: ['upperarm', 'frontleg', 'shoulder'],
+      side: 'left',
+      min: -1.4,
+      max: 1.4,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'armLiftR',
+    label: 'Right Arm Lift',
+    group: 'Arms',
+    order: 1,
+    bone: {
+      axis: 'z',
+      keywords: ['arm', 'shoulder', 'front'],
+      prefer: ['upperarm', 'frontleg', 'shoulder'],
+      side: 'right',
+      min: -1.4,
+      max: 1.4,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'legLiftL',
+    label: 'Left Leg Lift',
+    group: 'Legs',
+    order: 0,
+    bone: {
+      axis: 'z',
+      keywords: ['leg', 'thigh', 'hind', 'knee'],
+      prefer: ['thigh', 'hindleg'],
+      side: 'left',
+      min: -1.2,
+      max: 1.2,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+  {
+    id: 'legLiftR',
+    label: 'Right Leg Lift',
+    group: 'Legs',
+    order: 1,
+    bone: {
+      axis: 'z',
+      keywords: ['leg', 'thigh', 'hind', 'knee'],
+      prefer: ['thigh', 'hindleg'],
+      side: 'right',
+      min: -1.2,
+      max: 1.2,
+      step: 0.01,
+      defaultValue: 0,
+    },
+  },
+];
+
+const EPSILON = 1e-4;
+
+const AXIS_VECTORS = {
+  x: new THREE.Vector3(1, 0, 0),
+  y: new THREE.Vector3(0, 1, 0),
+  z: new THREE.Vector3(0, 0, 1),
+};
+
+const clamp = (value, min, max) => {
+  if (Number.isNaN(value)) {
+    return min;
+  }
+  if (typeof min === 'number' && value < min) {
+    return min;
+  }
+  if (typeof max === 'number' && value > max) {
+    return max;
+  }
+  return value;
+};
+
+export class RigController {
+  constructor(model) {
+    this.model = model;
+    this.skinnedMeshes = [];
+    this.bones = [];
+    this.morphTargets = [];
+    this.usedMorphTargets = new Set();
+
+    this.controlsById = new Map();
+    this.morphControls = [];
+    this.boneEntries = new Map();
+    this.orderedControls = [];
+    this.tempQuaternion = new THREE.Quaternion();
+
+    if (model) {
+      this._collectRigData();
+      this._buildControls();
+    }
+  }
+
+  getControls() {
+    return this.orderedControls.map((control) => ({
+      id: control.id,
+      label: control.label,
+      group: control.group,
+      type: control.type,
+      min: control.min,
+      max: control.max,
+      step: control.step,
+      defaultValue: control.defaultValue,
+    }));
+  }
+
+  getPoseValues() {
+    const values = {};
+    this.orderedControls.forEach((control) => {
+      values[control.id] = control.value;
+    });
+    return values;
+  }
+
+  setPoseValue(id, rawValue) {
+    const control = this.controlsById.get(id);
+    if (!control) {
+      return null;
+    }
+
+    const value = clamp(Number(rawValue), control.min, control.max);
+    if (Math.abs(value - control.value) < EPSILON) {
+      return null;
+    }
+
+    control.value = value;
+
+    if (control.type === 'morph') {
+      this._applyMorphControl(control, value);
+    }
+
+    return control.value;
+  }
+
+  resetPose() {
+    this.orderedControls.forEach((control) => {
+      const next = clamp(control.defaultValue ?? 0, control.min, control.max);
+      control.value = next;
+      if (control.type === 'morph') {
+        this._applyMorphControl(control, next);
+      }
+    });
+    return { values: this.getPoseValues() };
+  }
+
+  applyPoseAdjustments() {
+    if (!this.model) {
+      return;
+    }
+
+    this.boneEntries.forEach((entry) => {
+      entry.baseQuaternion.copy(entry.bone.quaternion);
+    });
+
+    this.boneEntries.forEach((entry) => {
+      const { bone, controls, baseQuaternion } = entry;
+      bone.quaternion.copy(baseQuaternion);
+      controls.forEach((control) => {
+        if (Math.abs(control.value) < EPSILON) {
+          return;
+        }
+        this.tempQuaternion.setFromAxisAngle(control.axisVector, control.value);
+        bone.quaternion.multiply(this.tempQuaternion);
+      });
+      bone.updateMatrixWorld(true);
+    });
+
+    this.morphControls.forEach((control) => {
+      this._applyMorphControl(control, control.value);
+    });
+  }
+
+  dispose() {
+    this.controlsById.clear();
+    this.morphControls.length = 0;
+    this.boneEntries.clear();
+    this.orderedControls.length = 0;
+    this.skinnedMeshes.length = 0;
+    this.bones.length = 0;
+    this.morphTargets.length = 0;
+    this.usedMorphTargets.clear();
+    this.model = null;
+  }
+
+  _collectRigData() {
+    this.model.traverse((child) => {
+      if (child.isSkinnedMesh) {
+        this.skinnedMeshes.push(child);
+        this._collectBonesFromSkeleton(child.skeleton);
+        this._collectMorphTargetsFromMesh(child);
+      }
+    });
+  }
+
+  _collectBonesFromSkeleton(skeleton) {
+    if (!skeleton?.bones) {
+      return;
+    }
+
+    skeleton.bones.forEach((bone) => {
+      if (!bone || !bone.name) {
+        return;
+      }
+      if (this.bones.some((entry) => entry.bone === bone)) {
+        return;
+      }
+      const depth = this._computeBoneDepth(bone);
+      this.bones.push({
+        bone,
+        name: bone.name,
+        nameLower: bone.name.toLowerCase(),
+        depth,
+      });
+    });
+  }
+
+  _collectMorphTargetsFromMesh(mesh) {
+    const dictionary = mesh.morphTargetDictionary;
+    const influences = mesh.morphTargetInfluences;
+    if (!dictionary || !influences) {
+      return;
+    }
+
+    Object.entries(dictionary).forEach(([name, index]) => {
+      if (typeof index !== 'number') {
+        return;
+      }
+      this.morphTargets.push({
+        mesh,
+        index,
+        name,
+        nameLower: name.toLowerCase(),
+      });
+    });
+  }
+
+  _buildControls() {
+    CONTROL_DEFINITIONS.forEach((definition, index) => {
+      const control = this._createControl(definition, index);
+      if (control) {
+        this.controlsById.set(control.id, control);
+        this.orderedControls.push(control);
+        if (control.type === 'morph') {
+          this.morphControls.push(control);
+        } else if (control.type === 'bone') {
+          this._registerBoneControl(control);
+        }
+      }
+    });
+
+    const groupRank = new Map(GROUP_ORDER.map((group, rank) => [group, rank]));
+    this.orderedControls.sort((a, b) => {
+      const groupA = groupRank.get(a.group) ?? GROUP_ORDER.length;
+      const groupB = groupRank.get(b.group) ?? GROUP_ORDER.length;
+      if (groupA !== groupB) {
+        return groupA - groupB;
+      }
+      if (a.order !== b.order) {
+        return (a.order ?? 0) - (b.order ?? 0);
+      }
+      return a.label.localeCompare(b.label);
+    });
+
+    if (this.orderedControls.length > 0) {
+      this.applyPoseAdjustments();
+    }
+  }
+
+  _createControl(definition, definitionIndex) {
+    if (!definition) {
+      return null;
+    }
+
+    if (definition.morph) {
+      const morphTarget = this._findMorphTarget(definition.morph);
+      if (morphTarget) {
+        const { min = 0, max = 1, step = 0.01, defaultValue = 0 } = definition.morph;
+        return {
+          id: definition.id,
+          label: definition.label,
+          group: definition.group,
+          order: definition.order ?? definitionIndex,
+          type: 'morph',
+          min,
+          max,
+          step,
+          defaultValue,
+          value: defaultValue,
+          mesh: morphTarget.mesh,
+          morphIndex: morphTarget.index,
+        };
+      }
+    }
+
+    if (definition.bone) {
+      const boneTarget = this._findBone(definition.bone);
+      if (boneTarget) {
+        const { min = -Math.PI, max = Math.PI, step = 0.01, defaultValue = 0 } = definition.bone;
+        return {
+          id: definition.id,
+          label: definition.label,
+          group: definition.group,
+          order: definition.order ?? definitionIndex,
+          type: 'bone',
+          min,
+          max,
+          step,
+          defaultValue,
+          value: defaultValue,
+          axis: definition.bone.axis,
+          axisVector: AXIS_VECTORS[definition.bone.axis]?.clone() ?? AXIS_VECTORS.x.clone(),
+          bone: boneTarget,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  _registerBoneControl(control) {
+    const bone = control.bone;
+    if (!bone) {
+      return;
+    }
+
+    let entry = this.boneEntries.get(bone);
+    if (!entry) {
+      entry = {
+        bone,
+        controls: [],
+        baseQuaternion: new THREE.Quaternion(),
+      };
+      this.boneEntries.set(bone, entry);
+    }
+    entry.controls.push(control);
+  }
+
+  _findMorphTarget(config) {
+    const { keywords = [], prefer = [] } = config;
+    if (this.morphTargets.length === 0) {
+      return null;
+    }
+
+    const matches = this.morphTargets.filter((target) => {
+      if (this.usedMorphTargets.has(this._morphKey(target))) {
+        return false;
+      }
+      if (!keywords.length) {
+        return true;
+      }
+      return keywords.some((keyword) => target.nameLower.includes(keyword));
+    });
+
+    if (!matches.length) {
+      return null;
+    }
+
+    const preferred = matches.find((target) =>
+      prefer.some((keyword) => target.nameLower.includes(keyword))
+    );
+    const result = preferred ?? matches[0];
+    this.usedMorphTargets.add(this._morphKey(result));
+    return result;
+  }
+
+  _findBone(config) {
+    const { keywords = [], prefer = [], side } = config;
+    const candidates = this.bones.filter((entry) => {
+      if (!keywords.length) {
+        return true;
+      }
+      return keywords.some((keyword) => entry.nameLower.includes(keyword));
+    });
+
+    const filtered = side ? candidates.filter((entry) => this._matchesSide(entry.nameLower, side)) : candidates;
+    if (!filtered.length) {
+      return null;
+    }
+
+    const preferred = prefer.length
+      ? filtered.filter((entry) => prefer.some((keyword) => entry.nameLower.includes(keyword)))
+      : filtered;
+
+    const pool = preferred.length ? preferred : filtered;
+    pool.sort((a, b) => {
+      if (a.depth !== b.depth) {
+        return a.depth - b.depth;
+      }
+      return a.name.localeCompare(b.name);
+    });
+    return pool[0]?.bone ?? null;
+  }
+
+  _matchesSide(name, side) {
+    const normalized = name.toLowerCase();
+    const tokens = normalized.split(/[^a-z0-9]+/).filter(Boolean);
+    if (side === 'left') {
+      return (
+        tokens.includes('left') ||
+        tokens.includes('l') ||
+        normalized.includes('_l') ||
+        normalized.includes('.l') ||
+        normalized.endsWith('l')
+      );
+    }
+    if (side === 'right') {
+      return (
+        tokens.includes('right') ||
+        tokens.includes('r') ||
+        normalized.includes('_r') ||
+        normalized.includes('.r') ||
+        normalized.endsWith('r')
+      );
+    }
+    return true;
+  }
+
+  _computeBoneDepth(bone) {
+    let depth = 0;
+    let current = bone;
+    while (current && current.isBone) {
+      depth += 1;
+      current = current.parent;
+    }
+    return depth;
+  }
+
+  _applyMorphControl(control, value) {
+    const influences = control.mesh?.morphTargetInfluences;
+    if (!influences || typeof control.morphIndex !== 'number') {
+      return;
+    }
+    influences[control.morphIndex] = value;
+  }
+
+  _morphKey(target) {
+    return `${target.mesh.uuid}:${target.index}`;
+  }
+}

--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -1,0 +1,268 @@
+export class RigControlPanel {
+  constructor({ container, bus }) {
+    this.container = container;
+    this.bus = bus;
+    this.root = null;
+    this.contentElement = null;
+    this.statusElement = null;
+    this.currentState = 'idle';
+    this.controls = new Map();
+    this.subscriptions = [];
+    this.currentCritterName = null;
+  }
+
+  init() {
+    if (!this.container) {
+      return;
+    }
+
+    this.build();
+    this.bindBusEvents();
+    this.renderEmpty('Select a critter to unlock pose sliders.');
+  }
+
+  build() {
+    this.container.innerHTML = '';
+    this.root = document.createElement('div');
+    this.root.className = 'rig-panel';
+    this.root.innerHTML = `
+      <div class="rig-panel__header">
+        <div class="rig-panel__heading">
+          <span class="rig-panel__title">Pose Controls</span>
+          <p class="rig-panel__subtitle">Blend animations with direct rig offsets.</p>
+        </div>
+        <span class="rig-panel__status" data-role="rig-status">Idle</span>
+      </div>
+      <div class="rig-panel__content" data-role="rig-content"></div>
+    `;
+
+    this.container.appendChild(this.root);
+    this.contentElement = this.root.querySelector('[data-role="rig-content"]');
+    this.statusElement = this.root.querySelector('[data-role="rig-status"]');
+  }
+
+  bindBusEvents() {
+    if (!this.bus) {
+      return;
+    }
+
+    this.subscriptions.push(
+      this.bus.on('stage:model-loading', (payload) => {
+        if (payload?.type === 'critter') {
+          this.currentCritterName = payload?.name ?? null;
+          this.setLoading(true, `Loading ${payload?.name ?? 'critter'} rig…`);
+        }
+      }),
+      this.bus.on('stage:model-ready', (payload) => {
+        if (payload?.type === 'critter') {
+          this.currentCritterName = payload?.name ?? null;
+          this.setLoading(false, `${payload?.name ?? 'Critter'} ready to pose.`);
+        }
+      }),
+      this.bus.on('stage:model-missing', (payload) => {
+        if (payload?.type === 'critter') {
+          this.currentCritterName = null;
+          this.setLoading(false, `Rig unavailable for ${payload?.name ?? 'this critter'}.`);
+          this.renderEmpty('We could not find pose controls for this critter.');
+        }
+      }),
+      this.bus.on('stage:rig-controls-ready', (payload) => {
+        const controls = payload?.controls ?? [];
+        const values = payload?.values ?? {};
+        this.renderControls(controls, values);
+        this.setStatus('ready', `${controls.length} control${controls.length === 1 ? '' : 's'} ready.`);
+      }),
+      this.bus.on('stage:rig-controls-cleared', () => {
+        this.renderEmpty('Select a critter to unlock pose sliders.');
+      }),
+      this.bus.on('stage:rig-pose-updated', (payload) => {
+        if (!payload) return;
+        this.updateControlValue(payload.id, payload.value);
+      }),
+      this.bus.on('stage:rig-pose-reset', (payload) => {
+        const values = payload?.values ?? {};
+        this.applyValues(values);
+        this.setStatus('ready', 'Pose sliders reset.');
+      })
+    );
+  }
+
+  setStatus(state, message) {
+    this.currentState = state;
+    if (this.statusElement) {
+      this.statusElement.dataset.state = state;
+      this.statusElement.textContent = message;
+    }
+  }
+
+  setLoading(isLoading, message) {
+    this.root?.classList.toggle('is-loading', Boolean(isLoading));
+    if (message) {
+      this.setStatus(isLoading ? 'loading' : 'ready', message);
+    } else if (isLoading) {
+      this.setStatus('loading', 'Loading rig…');
+    }
+
+    this.controls.forEach((control) => {
+      control.input.disabled = Boolean(isLoading);
+    });
+  }
+
+  renderEmpty(message) {
+    this.clearControls({ keepContent: true });
+    if (this.contentElement) {
+      this.contentElement.innerHTML = '';
+      const empty = document.createElement('p');
+      empty.className = 'rig-panel__empty';
+      empty.textContent = message;
+      this.contentElement.appendChild(empty);
+    }
+    this.setStatus('idle', message);
+  }
+
+  renderControls(controls, values) {
+    this.clearControls({ keepContent: true });
+    if (!controls || controls.length === 0) {
+      this.renderEmpty('This critter does not expose pose overrides yet.');
+      return;
+    }
+
+    if (this.contentElement) {
+      this.contentElement.innerHTML = '';
+    }
+
+    const groups = new Map();
+
+    controls.forEach((control) => {
+      const groupName = control.group || 'General';
+      let group = groups.get(groupName);
+      if (!group) {
+        group = this.createGroup(groupName);
+        groups.set(groupName, group);
+        this.contentElement?.appendChild(group.container);
+      }
+      const value = typeof values[control.id] === 'number' ? values[control.id] : control.defaultValue ?? 0;
+      const controlElements = this.createControlElement(control, value);
+      group.controls.appendChild(controlElements.wrapper);
+      this.controls.set(control.id, controlElements);
+    });
+
+    this.setStatus('ready', `${controls.length} control${controls.length === 1 ? '' : 's'} ready.`);
+  }
+
+  createGroup(name) {
+    const container = document.createElement('section');
+    container.className = 'rig-group';
+
+    const title = document.createElement('h3');
+    title.className = 'rig-group__title';
+    title.textContent = name;
+
+    const controls = document.createElement('div');
+    controls.className = 'rig-group__controls';
+
+    container.appendChild(title);
+    container.appendChild(controls);
+
+    return { container, controls };
+  }
+
+  createControlElement(control, value) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'rig-control';
+    wrapper.dataset.id = control.id;
+
+    const labelRow = document.createElement('div');
+    labelRow.className = 'rig-control__label';
+
+    const name = document.createElement('span');
+    name.className = 'rig-control__name';
+    name.textContent = control.label;
+
+    const valueDisplay = document.createElement('span');
+    valueDisplay.className = 'rig-control__value';
+    valueDisplay.textContent = this.formatValue(control.type, value);
+
+    labelRow.appendChild(name);
+    labelRow.appendChild(valueDisplay);
+
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.className = 'rig-control__slider';
+    slider.min = typeof control.min === 'number' ? control.min : 0;
+    slider.max = typeof control.max === 'number' ? control.max : 1;
+    slider.step = typeof control.step === 'number' ? control.step : 0.01;
+    slider.value = value;
+
+    const handleInput = (event) => {
+      const nextValue = parseFloat(event.target.value);
+      valueDisplay.textContent = this.formatValue(control.type, nextValue);
+      this.bus?.emit?.('rig:pose-changed', { id: control.id, value: nextValue });
+    };
+
+    slider.addEventListener('input', handleInput);
+
+    wrapper.appendChild(labelRow);
+    wrapper.appendChild(slider);
+
+    return {
+      wrapper,
+      input: slider,
+      valueElement: valueDisplay,
+      type: control.type,
+      handleInput,
+    };
+  }
+
+  updateControlValue(id, value) {
+    const entry = this.controls.get(id);
+    if (!entry || typeof value !== 'number') {
+      return;
+    }
+
+    entry.input.value = value;
+    entry.valueElement.textContent = this.formatValue(entry.type, value);
+  }
+
+  applyValues(values) {
+    if (!values) {
+      return;
+    }
+
+    Object.entries(values).forEach(([id, value]) => {
+      this.updateControlValue(id, value);
+    });
+  }
+
+  clearControls({ keepContent = false } = {}) {
+    this.controls.forEach((entry) => {
+      entry.input.removeEventListener('input', entry.handleInput);
+    });
+    this.controls.clear();
+
+    if (!keepContent && this.contentElement) {
+      this.contentElement.innerHTML = '';
+    }
+  }
+
+  formatValue(type, value) {
+    if (type === 'bone') {
+      const degrees = value * (180 / Math.PI);
+      const rounded = Math.round(degrees);
+      const prefix = rounded > 0 ? '+' : '';
+      return `${prefix}${rounded}\u00B0`;
+    }
+    const percent = Math.round(value * 100);
+    return `${percent}%`;
+  }
+
+  destroy() {
+    this.clearControls();
+    this.subscriptions.forEach((off) => off?.());
+    this.subscriptions = [];
+    this.container = null;
+    this.root = null;
+    this.contentElement = null;
+    this.statusElement = null;
+  }
+}

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -8,11 +8,14 @@ export class ViewportOverlay {
     this.autoRotateButton = null;
     this.focusButton = null;
     this.resetButton = null;
+    this.resetPoseButton = null;
+    this.refreshButton = null;
     this.autoRotateEnabled = false;
     this.state = 'idle';
     this.unsubscribe = [];
     this.pulseTimeout = null;
     this.isLoading = false;
+    this.hasRigControls = false;
   }
 
   init() {
@@ -24,6 +27,13 @@ export class ViewportOverlay {
     this.bindControls();
     this.bindBusEvents();
     this.setStatus('idle', 'Select a critter to preview.');
+    this.setControlsAvailability({
+      focus: false,
+      reset: false,
+      autorotate: false,
+      resetPose: false,
+      refresh: false,
+    });
   }
 
   build() {
@@ -48,6 +58,8 @@ export class ViewportOverlay {
         <div class="viewport-controls" role="group" aria-label="Viewport controls">
           <button type="button" class="viewport-button" data-action="focus">Focus Model</button>
           <button type="button" class="viewport-button" data-action="reset">Reset View</button>
+          <button type="button" class="viewport-button" data-action="reset-pose">Reset Pose</button>
+          <button type="button" class="viewport-button" data-action="refresh">Refresh Critter</button>
           <button
             type="button"
             class="viewport-button viewport-button--toggle"
@@ -66,6 +78,8 @@ export class ViewportOverlay {
     this.autoRotateButton = this.root.querySelector('[data-action="autorotate"]');
     this.focusButton = this.root.querySelector('[data-action="focus"]');
     this.resetButton = this.root.querySelector('[data-action="reset"]');
+    this.resetPoseButton = this.root.querySelector('[data-action="reset-pose"]');
+    this.refreshButton = this.root.querySelector('[data-action="refresh"]');
   }
 
   bindControls() {
@@ -82,6 +96,20 @@ export class ViewportOverlay {
     if (this.resetButton) {
       this.resetButton.addEventListener('click', () => {
         this.bus.emit('stage:reset-requested');
+        this.flashStatus();
+      });
+    }
+
+    if (this.resetPoseButton) {
+      this.resetPoseButton.addEventListener('click', () => {
+        this.bus.emit('rig:reset-requested');
+        this.flashStatus();
+      });
+    }
+
+    if (this.refreshButton) {
+      this.refreshButton.addEventListener('click', () => {
+        this.bus.emit('rig:refresh-requested');
         this.flashStatus();
       });
     }
@@ -109,14 +137,26 @@ export class ViewportOverlay {
         const name = payload?.name ?? 'Model';
         this.setStatus('ready', `${name} ready for inspection.`);
         this.setLoading(false);
-        this.setControlsAvailability({ focus: true, reset: true, autorotate: true });
+        this.setControlsAvailability({
+          focus: true,
+          reset: true,
+          autorotate: true,
+          resetPose: this.hasRigControls,
+          refresh: this.hasRigControls,
+        });
         this.flashStatus();
       }),
       this.bus.on('stage:model-missing', (payload) => {
         const name = payload?.name ?? 'model';
         this.setStatus('empty', `We couldn't load the ${name}.`);
         this.setLoading(false);
-        this.setControlsAvailability({ focus: false, reset: true, autorotate: false });
+        this.setControlsAvailability({
+          focus: false,
+          reset: true,
+          autorotate: false,
+          resetPose: false,
+          refresh: false,
+        });
       }),
       this.bus.on('stage:focus-achieved', () => {
         this.flashStatus();
@@ -127,6 +167,15 @@ export class ViewportOverlay {
       this.bus.on('stage:auto-rotate-changed', (payload) => {
         this.autoRotateEnabled = Boolean(payload?.enabled);
         this.updateAutoRotateButton();
+      }),
+      this.bus.on('stage:rig-controls-ready', (payload) => {
+        const controls = payload?.controls ?? [];
+        this.hasRigControls = controls.length > 0;
+        this.setControlsAvailability({ resetPose: this.hasRigControls, refresh: this.hasRigControls });
+      }),
+      this.bus.on('stage:rig-controls-cleared', () => {
+        this.hasRigControls = false;
+        this.setControlsAvailability({ resetPose: false, refresh: false });
       })
     );
   }
@@ -173,13 +222,17 @@ export class ViewportOverlay {
       focus: !isLoading,
       reset: !isLoading,
       autorotate: !isLoading,
+      resetPose: !isLoading && this.hasRigControls,
+      refresh: !isLoading && this.hasRigControls,
     });
   }
 
-  setControlsAvailability({ focus, reset, autorotate }) {
+  setControlsAvailability({ focus, reset, autorotate, resetPose, refresh }) {
     this.updateButtonState(this.focusButton, focus);
     this.updateButtonState(this.resetButton, reset);
     this.updateButtonState(this.autoRotateButton, autorotate);
+    this.updateButtonState(this.resetPoseButton, resetPose);
+    this.updateButtonState(this.refreshButton, refresh);
   }
 
   updateButtonState(button, isEnabled) {
@@ -204,6 +257,14 @@ export class ViewportOverlay {
     if (this.resetButton) {
       this.resetButton.replaceWith(this.resetButton.cloneNode(true));
       this.resetButton = null;
+    }
+    if (this.resetPoseButton) {
+      this.resetPoseButton.replaceWith(this.resetPoseButton.cloneNode(true));
+      this.resetPoseButton = null;
+    }
+    if (this.refreshButton) {
+      this.refreshButton.replaceWith(this.refreshButton.cloneNode(true));
+      this.refreshButton = null;
     }
     if (this.root?.parentNode) {
       this.root.parentNode.removeChild(this.root);

--- a/styles/main.css
+++ b/styles/main.css
@@ -73,7 +73,7 @@ body::after {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 180px 320px minmax(320px, 1fr) minmax(240px, 28vw);
+  grid-template-columns: minmax(160px, 18vw) minmax(280px, 22vw) minmax(280px, 22vw) minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1.5rem;
   padding: 2.25rem 2.75rem;
@@ -613,8 +613,8 @@ dl dt {
   grid-row: 1 / span 2;
   position: relative;
   display: flex;
-  flex-direction: column;
-  background: linear-gradient(160deg, rgba(24, 52, 36, 0.95), rgba(20, 47, 57, 0.92));
+  align-items: stretch;
+  background: linear-gradient(160deg, rgba(24, 52, 36, 0.92), rgba(20, 47, 57, 0.9));
   border: 1px solid rgba(90, 169, 201, 0.35);
   border-radius: calc(var(--border-radius-lg) + 4px);
   overflow: hidden;
@@ -626,8 +626,8 @@ dl dt {
   content: '';
   position: absolute;
   inset: -25% -18% 60% -18%;
-  background: radial-gradient(circle at 62% 35%, rgba(124, 200, 111, 0.28), transparent 62%);
-  opacity: 0.55;
+  background: radial-gradient(circle at 62% 35%, rgba(124, 200, 111, 0.24), transparent 62%);
+  opacity: 0.5;
   pointer-events: none;
 }
 
@@ -635,20 +635,292 @@ dl dt {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 38% 72%, rgba(90, 169, 201, 0.22), transparent 70%),
-    radial-gradient(circle at 18% 28%, rgba(183, 128, 68, 0.18), transparent 58%);
-  opacity: 0.6;
+  background: radial-gradient(circle at 38% 72%, rgba(90, 169, 201, 0.16), transparent 70%),
+    radial-gradient(circle at 18% 28%, rgba(183, 128, 68, 0.14), transparent 58%);
+  opacity: 0.55;
   pointer-events: none;
 }
 
-.stage-toolbar {
-  position: relative;
-  z-index: 1;
-  padding: 1.4rem 1.6rem 1.2rem;
+.stage-controls {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 1.1rem;
-  background: linear-gradient(180deg, rgba(13, 31, 23, 0.95), rgba(13, 31, 23, 0));
+  align-items: flex-end;
+  gap: 0.9rem;
+  width: clamp(220px, 24vw, 360px);
+  max-height: calc(100% - 3rem);
+  pointer-events: none;
+  z-index: 3;
+}
+
+.stage-controls > * {
+  pointer-events: auto;
+}
+
+.stage-controls__toggle {
+  border: 1px solid rgba(124, 200, 111, 0.4);
+  border-radius: 999px;
+  padding: 0.45rem 1.15rem;
+  background: rgba(13, 31, 23, 0.72);
+  color: var(--color-text-primary);
+  font-family: var(--font-display);
+  font-size: 0.65rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+  box-shadow: 0 12px 24px rgba(8, 22, 16, 0.35);
+  z-index: 4;
+}
+
+.stage-controls__toggle:hover,
+.stage-controls__toggle:focus-visible {
+  outline: none;
+  border-color: rgba(124, 200, 111, 0.65);
+  background: rgba(18, 42, 30, 0.82);
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(8, 22, 16, 0.45);
+}
+
+.stage-controls.is-collapsed .stage-controls__toggle {
+  background: rgba(12, 28, 21, 0.82);
+}
+
+.stage-toolbar {
+  width: 100%;
+  padding: 1.1rem 1.35rem 1.2rem;
+  background: linear-gradient(165deg, rgba(16, 38, 28, 0.9), rgba(14, 34, 28, 0.78));
+  border: 1px solid rgba(124, 200, 111, 0.3);
+  border-radius: 18px;
+  box-shadow: 0 20px 42px rgba(8, 22, 16, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 100%;
+  overflow-y: auto;
+  transition: transform 0.28s ease, opacity 0.28s ease;
+  backdrop-filter: blur(6px);
+}
+
+.stage-controls.is-collapsed .stage-toolbar {
+  transform: translateX(calc(100% + 1.25rem));
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.stage-tool-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.stage-tool-panel {
+  pointer-events: auto;
+  background: linear-gradient(165deg, rgba(17, 40, 29, 0.85), rgba(14, 34, 28, 0.78));
+  border: 1px solid rgba(124, 200, 111, 0.25);
+  border-radius: 18px;
+  padding: 1.1rem 1.3rem;
+  box-shadow: 0 18px 36px rgba(9, 24, 17, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  position: relative;
+}
+
+.stage-tool-panel::before {
+  content: '';
+  position: absolute;
+  inset: -18% -22% 65% -22%;
+  background: radial-gradient(circle at 32% 24%, rgba(124, 200, 111, 0.22), transparent 60%);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.stage-tool-panel::after {
+  content: '';
+  position: absolute;
+  inset: 55% -18% -20% -18%;
+  background: radial-gradient(circle at 70% 80%, rgba(90, 169, 201, 0.18), transparent 60%);
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.stage-tool-panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.stage-tool-panel--rig {
+  gap: 0.75rem;
+}
+
+.rig-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.rig-panel.is-loading {
+  opacity: 0.78;
+}
+
+.rig-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.9rem;
+}
+
+.rig-panel__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.rig-panel__title {
+  font-family: var(--font-display);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  color: var(--color-highlight);
+}
+
+.rig-panel__subtitle {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.62);
+}
+
+.rig-panel__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(124, 200, 111, 0.35);
+  background: rgba(14, 36, 26, 0.65);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.rig-panel__status[data-state='loading'] {
+  border-color: rgba(90, 169, 201, 0.55);
+  color: var(--color-water);
+}
+
+.rig-panel__status[data-state='idle'] {
+  color: rgba(243, 248, 240, 0.7);
+}
+
+.rig-panel__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.rig-panel__empty {
+  margin: 0;
+  font-size: 0.82rem;
+  letter-spacing: 0.05em;
+  color: rgba(243, 248, 240, 0.68);
+  font-style: italic;
+}
+
+.rig-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.rig-group__title {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+}
+
+.rig-group__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.rig-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.rig-control__label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
+}
+
+.rig-control__name {
+  font-weight: 600;
+}
+
+.rig-control__value {
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.6);
+}
+
+.rig-control__slider {
+  appearance: none;
+  width: 100%;
+  height: 7px;
+  border-radius: 999px;
+  background: rgba(124, 200, 111, 0.18);
+  border: 1px solid rgba(124, 200, 111, 0.32);
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.rig-control__slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.95), rgba(90, 169, 201, 0.95));
+  border: 2px solid rgba(243, 248, 240, 0.9);
+  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.25);
+}
+
+.rig-control__slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(124, 200, 111, 0.95), rgba(90, 169, 201, 0.95));
+  border: 2px solid rgba(243, 248, 240, 0.9);
+  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.25);
+}
+
+.rig-control__slider:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.3);
+  border-color: rgba(124, 200, 111, 0.55);
+}
+
+.rig-control__slider:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .stage-viewport {
@@ -671,11 +943,11 @@ dl dt {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 1.5rem 1.75rem;
+  padding: 1.25rem 1.4rem;
   pointer-events: none;
   z-index: 2;
   color: var(--color-text-primary);
-  background: linear-gradient(180deg, rgba(12, 32, 23, 0.28), rgba(12, 32, 23, 0));
+  background: linear-gradient(180deg, rgba(12, 32, 23, 0.16), rgba(12, 32, 23, 0));
   backdrop-filter: blur(1px);
 }
 
@@ -684,8 +956,14 @@ dl dt {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 1.5rem;
+  gap: 1.25rem;
   pointer-events: none;
+}
+
+.viewport-ui__bottom {
+  align-items: flex-end;
+  flex-wrap: wrap;
+  row-gap: 0.85rem;
 }
 
 .viewport-status {
@@ -757,12 +1035,12 @@ dl dt {
 
 .viewport-instructions {
   pointer-events: auto;
-  padding: 1rem 1.25rem;
-  border-radius: 18px;
-  border: 1px solid rgba(124, 200, 111, 0.28);
-  background: linear-gradient(160deg, rgba(16, 40, 29, 0.82), rgba(16, 37, 47, 0.78));
-  box-shadow: 0 18px 30px rgba(8, 20, 14, 0.35);
-  max-width: 240px;
+  padding: 0.85rem 1.05rem;
+  border-radius: 16px;
+  border: 1px solid rgba(124, 200, 111, 0.22);
+  background: linear-gradient(160deg, rgba(15, 36, 26, 0.68), rgba(13, 33, 26, 0.55));
+  box-shadow: 0 16px 28px rgba(8, 20, 14, 0.35);
+  max-width: 260px;
 }
 
 .viewport-instructions__title {
@@ -805,19 +1083,24 @@ dl dt {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.6rem;
   margin-left: auto;
+  padding: 0.6rem 0.75rem;
+  border-radius: 18px;
+  background: rgba(12, 30, 23, 0.55);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 12px 28px rgba(8, 20, 14, 0.35);
 }
 
 .viewport-button {
   border: 1px solid rgba(124, 200, 111, 0.35);
   border-radius: 999px;
-  padding: 0.55rem 1.35rem;
+  padding: 0.5rem 1.1rem;
   background: rgba(12, 31, 23, 0.68);
   color: var(--color-text-primary);
   font-family: var(--font-display);
   letter-spacing: 0.14em;
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   text-transform: uppercase;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
@@ -983,16 +1266,27 @@ dl dt {
     border-radius: var(--border-radius-lg);
   }
 
+  .stage-controls {
+    top: 1rem;
+    right: 1rem;
+    width: min(340px, 70vw);
+  }
+
+  .stage-controls__toggle {
+    font-size: 0.64rem;
+  }
+
   .viewport-ui {
     padding: 1.25rem 1.4rem;
   }
 
   .viewport-instructions {
-    max-width: none;
+    display: none;
   }
 
   .viewport-controls {
     justify-content: flex-start;
+    width: 100%;
   }
 }
 
@@ -1052,6 +1346,17 @@ dl dt {
     height: 320px;
   }
 
+  .stage-controls {
+    top: 0.85rem;
+    right: 0.85rem;
+    width: min(320px, 85vw);
+  }
+
+  .stage-controls__toggle {
+    font-size: 0.62rem;
+    padding: 0.4rem 1rem;
+  }
+
   .viewport-ui {
     padding: 1.1rem 1.3rem;
   }
@@ -1059,6 +1364,10 @@ dl dt {
   .viewport-ui__bottom {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .viewport-instructions {
+    display: none;
   }
 
   .viewport-controls {
@@ -1081,6 +1390,17 @@ dl dt {
 
   .stage {
     height: 260px;
+  }
+
+  .stage-controls {
+    top: 0.75rem;
+    right: 0.75rem;
+    width: min(280px, 88vw);
+  }
+
+  .stage-controls__toggle {
+    font-size: 0.6rem;
+    padding: 0.38rem 0.85rem;
   }
 
   .viewport-ui {


### PR DESCRIPTION
## Summary
- rework the stage layout so the viewport fills the column and the animation/rig tools live in a toggleable controls pod
- collapse the controls by default and wire a dedicated toggle that manages aria state for the floating toolbar
- refresh the viewport overlay styling and responsive rules to reduce on-screen clutter while keeping quick actions accessible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca5f00cb848329aa732a48dd0e2b79