### PR TITLE
Fix animation playback and rig pose accumulation

### DIFF
--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -481,7 +481,15 @@ export class SceneManager {
       return;
     }
 
+    if (animation.id && !clip.name) {
+      clip = clip.clone();
+      clip.name = animation.id;
+    }
+    clip.resetDuration();
+
     this.mixer.stopAllAction();
+    this.activeAction?.stop();
+    this.activeAction = null;
 
     const actionRoot = targetMesh ?? this.currentModel;
     const action = this.mixer.clipAction(clip, actionRoot);
@@ -492,6 +500,9 @@ export class SceneManager {
     action.reset();
     action.clampWhenFinished = true;
     action.enabled = true;
+    action.paused = false;
+    action.setEffectiveWeight(1);
+    action.setEffectiveTimeScale(1);
     if (animation.loop === 'once') {
       action.setLoop(THREE.LoopOnce, 1);
     } else {


### PR DESCRIPTION
## Summary
- prevent pose sliders from continuously compounding by tracking and removing the previous bone adjustment each frame
- reset and configure animation actions so GLB clips, including idle, reliably play when selected

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ca6fa5f8908329b6b08723b9ebf20a