### PR TITLE
Enable animation playback and stabilize rig pose controls

### DIFF
--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -483,8 +483,7 @@ export class SceneManager {
 
     this.mixer.stopAllAction();
 
-    const actionRoot = targetMesh ?? this.currentModel;
-    const action = this.mixer.clipAction(clip, actionRoot);
+    const action = this.mixer.clipAction(clip, this.currentModel);
     if (!action) {
       return;
     }
@@ -500,6 +499,7 @@ export class SceneManager {
 
     action.play();
     this.activeAction = action;
+    this.rigController?.applyPoseAdjustments?.();
     this.pendingAnimationId = null;
   }
 


### PR DESCRIPTION
## Summary
- ensure GLB animation clips are played on the critter root and reapply rig offsets after playback starts
- prevent pose overrides from accumulating by tracking and removing previous bone offsets before applying new ones
- present pose sliders in degrees so user inputs map cleanly to bounded rig rotations

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca6fa5f8908329b6b08723b9ebf20a