### PR TITLE
Fix animation playback and stabilize rig pose adjustments

### DIFF
--- a/src/core/ResourceLoader.js
+++ b/src/core/ResourceLoader.js
@@ -112,7 +112,7 @@ export class ResourceLoader {
     if (!this.skeletonUtilsPromise) {
       this.skeletonUtilsPromise = import(
         'https://esm.sh/three@0.160.0/examples/jsm/utils/SkeletonUtils.js'
-      );
+      ).then((module) => module?.SkeletonUtils ?? module?.default ?? module);
     }
     return this.skeletonUtilsPromise;
   }

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -109,6 +109,10 @@ export class SceneManager {
       this.orbitControls.update();
     }
 
+    if (this.rigController) {
+      this.rigController.prepareFrame();
+    }
+
     if (this.mixer) {
       this.mixer.update(delta);
     }


### PR DESCRIPTION
## Summary
- ensure GLB models and animations clone/retarget correctly by using the SkeletonUtils helpers from three.js
- prepare and reapply rig pose adjustments each frame so sliders apply absolute offsets instead of compounding rotations
- reset rig poses back to their rest orientation when clearing sliders to keep controls predictable

## Testing
- not run (web project)


------
https://chatgpt.com/codex/tasks/task_e_68ca6fa5f8908329b6b08723b9ebf20a