### PR TITLE
Simplify HUD text and branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crtiz Armory Display</title>
+    <title>Critz Display</title>
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -116,7 +116,7 @@ export class WeaponDisplayApp {
   buildLayout() {
     this.root.innerHTML = `
       <div class="app-shell">
-        <div class="hud-brand">Crtiz Armory</div>
+        <div class="hud-brand">Critz</div>
         <nav class="hud-nav" aria-label="Interface options">
           <div class="nav-section nav-section--critters">
             <h2>Critters</h2>

--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -27,10 +27,6 @@ export class RigControlPanel {
     this.root.className = 'rig-panel';
     this.root.innerHTML = `
       <div class="rig-panel__header">
-        <div class="rig-panel__heading">
-          <span class="rig-panel__title">Pose Controls</span>
-          <p class="rig-panel__subtitle">Blend animations with direct rig offsets.</p>
-        </div>
         <span class="rig-panel__status" data-role="rig-status">Idle</span>
       </div>
       <div class="rig-panel__content" data-role="rig-content"></div>
@@ -56,7 +52,7 @@ export class RigControlPanel {
       this.bus.on('stage:model-ready', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(false, `${payload?.name ?? 'Critter'} ready to pose.`);
+          this.setLoading(false, 'Rig ready.');
         }
       }),
       this.bus.on('stage:model-missing', (payload) => {

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -135,7 +135,7 @@ export class ViewportOverlay {
       }),
       this.bus.on('stage:model-ready', (payload) => {
         const name = payload?.name ?? 'Model';
-        this.setStatus('ready', `${name} ready for inspection.`);
+        this.setStatus('ready', `${name} loaded.`);
         this.setLoading(false);
         this.setControlsAvailability({
           focus: true,

--- a/styles/main.css
+++ b/styles/main.css
@@ -713,8 +713,8 @@ dl dt {
 
 .rig-panel__header {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  justify-content: flex-end;
+  align-items: center;
   gap: 0.9rem;
 }
 


### PR DESCRIPTION
## Summary
- remove redundant rig panel heading copy and tighten status updates
- shorten viewport status messaging to avoid clutter
- replace "Crtiz Armory" branding with "Critz"

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca729b94608329b78bbdf7052d0f6a