### PR TITLE
Clean up UI labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crtiz Armory Display</title>
+    <title>Critz Display</title>
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -116,7 +116,7 @@ export class WeaponDisplayApp {
   buildLayout() {
     this.root.innerHTML = `
       <div class="app-shell">
-        <div class="hud-brand">Crtiz Armory</div>
+        <div class="hud-brand">Critz</div>
         <nav class="hud-nav" aria-label="Interface options">
           <div class="nav-section nav-section--critters">
             <h2>Critters</h2>

--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -27,10 +27,6 @@ export class RigControlPanel {
     this.root.className = 'rig-panel';
     this.root.innerHTML = `
       <div class="rig-panel__header">
-        <div class="rig-panel__heading">
-          <span class="rig-panel__title">Pose Controls</span>
-          <p class="rig-panel__subtitle">Blend animations with direct rig offsets.</p>
-        </div>
         <span class="rig-panel__status" data-role="rig-status">Idle</span>
       </div>
       <div class="rig-panel__content" data-role="rig-content"></div>
@@ -56,7 +52,7 @@ export class RigControlPanel {
       this.bus.on('stage:model-ready', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(false, `${payload?.name ?? 'Critter'} ready to pose.`);
+          this.setLoading(false, `${payload?.name ?? 'Critter'} rig loaded.`);
         }
       }),
       this.bus.on('stage:model-missing', (payload) => {

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -135,7 +135,7 @@ export class ViewportOverlay {
       }),
       this.bus.on('stage:model-ready', (payload) => {
         const name = payload?.name ?? 'Model';
-        this.setStatus('ready', `${name} ready for inspection.`);
+        this.setStatus('ready', `${name} loaded.`);
         this.setLoading(false);
         this.setControlsAvailability({
           focus: true,

--- a/styles/main.css
+++ b/styles/main.css
@@ -713,31 +713,8 @@ dl dt {
 
 .rig-panel__header {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.9rem;
-}
-
-.rig-panel__heading {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.rig-panel__title {
-  font-family: var(--font-display);
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-size: 0.85rem;
-  color: var(--color-highlight);
-}
-
-.rig-panel__subtitle {
-  margin: 0;
-  font-size: 0.72rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.62);
+  justify-content: flex-end;
+  align-items: center;
 }
 
 .rig-panel__status {


### PR DESCRIPTION
## Summary
- remove extra copy from the rig controls header and loading status
- tone down the viewport ready message so inspection text is gone
- update the brand text to display "Critz" across the interface

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca729b94608329b78bbdf7052d0f6a