### PR TITLE
Add assault rifle placeholder model and stage switching

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -191,6 +191,12 @@ export class WeaponDisplayApp {
       }
       this.activeWeapon = weapon;
       this.sceneManager.applyRarityGlow(weapon.rarity);
+      this.sceneManager?.loadWeapon?.(weapon);
+      this.activeCritter = null;
+      if (this.animationSelector) {
+        this.animationSelector.setCritterName('--');
+        this.animationSelector.setAnimations([]);
+      }
     });
 
     this.eventBus.on('critter:selected', (critterId) => {
@@ -200,6 +206,7 @@ export class WeaponDisplayApp {
       }
 
       this.activeCritter = critter;
+      this.activeWeapon = null;
       this.animationSelector.setCritterName(critter.name);
       this.animationSelector.setAnimations(critter.animations, critter.defaultAnimationId);
 


### PR DESCRIPTION
## Summary
- render a handmade blaster-style placeholder model whenever the assault rifle is selected
- update the scene manager to build the futuristic rifle geometry and clear critter animation UI when swapping between critters and weapons

## Testing
- Not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca730573948329bb36d59736353645