### PR TITLE
Refresh Critz Library branding and simplify UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Critz Armory Display Application Plan
+# Critz Library Experience Plan
 
 ## Vision
-Create an immersive, fantasy-inspired armory interface that catalogs every weapon in Critz. The application should blend an arcane HUD with interactive 3D weapon previews powered by Three.js. It must support rapid iteration on weapon metadata, modular UI sections for Primary, Secondary, Melee, and Utility gear, and an extensible pipeline for importing new 3D assets.
+Create an immersive, fantasy-inspired library interface that catalogs every artifact in Critz. The application should blend an arcane HUD with interactive 3D previews powered by Three.js. It must support rapid iteration on item metadata, modular UI sections for Primary, Secondary, Melee, and Utility collections, and an extensible pipeline for importing new 3D assets.
 
 ## Technology Stack
 - **Core**: Vanilla JavaScript with ES modules
@@ -99,7 +99,7 @@ Weapons are modeled with a base schema plus category-specific extensions.
 The schema is intentionally flexible. The HUD reads the schema metadata to decide which stats to show. Optional fields (like `quiverCapacity`) are displayed only when present.
 
 ## UI Layout & Flow
-- **Top-left HUD**: Permanent "Crtiz" brand glyph and environment controls (fullscreen, sound toggle).
+- **Top-left HUD**: Permanent "Critz Library" marque and environment controls (fullscreen, sound toggle).
 - **Left rail**: Navigation tabs stacked vertically for category selection.
 - **Center stage**: Three.js canvas with weapon preview, orbit controls, and atmospheric VFX.
 - **Right panel**: Weapon list (top) and detail panel (bottom) with animated transitions.

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crtiz Armory Display</title>
+    <title>Critz Library</title>
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -116,7 +116,7 @@ export class WeaponDisplayApp {
   buildLayout() {
     this.root.innerHTML = `
       <div class="app-shell">
-        <div class="hud-brand">Crtiz Armory</div>
+        <div class="hud-brand">Critz Library</div>
         <nav class="hud-nav" aria-label="Interface options">
           <div class="nav-section nav-section--critters">
             <h2>Critters</h2>
@@ -129,21 +129,21 @@ export class WeaponDisplayApp {
         </nav>
         <section class="panel hud-panel hud-list" data-component="weapon-list">
           <div class="panel-header">
-            <span>Arsenal</span>
+            <span>Collection</span>
             <span data-role="list-context"></span>
           </div>
           <div class="weapon-cards" data-role="weapon-cards"></div>
-          <div class="panel-footer" data-role="list-footer">Choose a category to see its gear.</div>
+          <div class="panel-footer" data-role="list-footer">Choose a category to browse its entries.</div>
         </section>
         <section class="panel hud-panel hud-detail" data-component="weapon-detail">
           <div class="panel-header">
-            <span>Equipment Info</span>
+            <span>Item Details</span>
             <span data-role="rarity-badge"></span>
           </div>
           <div class="detail-content" data-role="detail-content">
-            <p class="description">Pick a tool to see its details.</p>
+            <p class="description">Pick an entry to see its details.</p>
           </div>
-          <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
+          <div class="panel-footer" data-role="detail-footer">Select an item to begin</div>
         </section>
         <section class="stage" data-component="stage">
           <div class="stage-toolbar" data-component="stage-toolbar">

--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -18,7 +18,7 @@ export class RigControlPanel {
 
     this.build();
     this.bindBusEvents();
-    this.renderEmpty('Select a critter to unlock pose sliders.');
+    this.renderEmpty('Choose a critter to enable rig controls.');
   }
 
   build() {
@@ -27,10 +27,7 @@ export class RigControlPanel {
     this.root.className = 'rig-panel';
     this.root.innerHTML = `
       <div class="rig-panel__header">
-        <div class="rig-panel__heading">
-          <span class="rig-panel__title">Pose Controls</span>
-          <p class="rig-panel__subtitle">Blend animations with direct rig offsets.</p>
-        </div>
+        <span class="rig-panel__title">Rig Controls</span>
         <span class="rig-panel__status" data-role="rig-status">Idle</span>
       </div>
       <div class="rig-panel__content" data-role="rig-content"></div>
@@ -50,30 +47,30 @@ export class RigControlPanel {
       this.bus.on('stage:model-loading', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(true, `Loading ${payload?.name ?? 'critter'} rig…`);
+          this.setLoading(true, `Preparing ${payload?.name ?? 'critter'}…`);
         }
       }),
       this.bus.on('stage:model-ready', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(false, `${payload?.name ?? 'Critter'} ready to pose.`);
+          this.setLoading(false, `${payload?.name ?? 'Critter'} linked.`);
         }
       }),
       this.bus.on('stage:model-missing', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = null;
           this.setLoading(false, `Rig unavailable for ${payload?.name ?? 'this critter'}.`);
-          this.renderEmpty('We could not find pose controls for this critter.');
+          this.renderEmpty('Rig controls unavailable for this critter.');
         }
       }),
       this.bus.on('stage:rig-controls-ready', (payload) => {
         const controls = payload?.controls ?? [];
         const values = payload?.values ?? {};
         this.renderControls(controls, values);
-        this.setStatus('ready', `${controls.length} control${controls.length === 1 ? '' : 's'} ready.`);
+        this.setStatus('ready', `${controls.length} adjustment${controls.length === 1 ? '' : 's'} ready.`);
       }),
       this.bus.on('stage:rig-controls-cleared', () => {
-        this.renderEmpty('Select a critter to unlock pose sliders.');
+        this.renderEmpty('Choose a critter to enable rig controls.');
       }),
       this.bus.on('stage:rig-pose-updated', (payload) => {
         if (!payload) return;
@@ -82,7 +79,7 @@ export class RigControlPanel {
       this.bus.on('stage:rig-pose-reset', (payload) => {
         const values = payload?.values ?? {};
         this.applyValues(values);
-        this.setStatus('ready', 'Pose sliders reset.');
+        this.setStatus('ready', 'Rig reset.');
       })
     );
   }
@@ -123,7 +120,7 @@ export class RigControlPanel {
   renderControls(controls, values) {
     this.clearControls({ keepContent: true });
     if (!controls || controls.length === 0) {
-      this.renderEmpty('This critter does not expose pose overrides yet.');
+      this.renderEmpty('This critter does not expose rig overrides yet.');
       return;
     }
 
@@ -147,7 +144,7 @@ export class RigControlPanel {
       this.controls.set(control.id, controlElements);
     });
 
-    this.setStatus('ready', `${controls.length} control${controls.length === 1 ? '' : 's'} ready.`);
+    this.setStatus('ready', `${controls.length} adjustment${controls.length === 1 ? '' : 's'} ready.`);
   }
 
   createGroup(name) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,20 +1,20 @@
 :root {
-  --color-bg: #0f1f17;
-  --color-bg-alt: #142e20;
-  --color-canopy: #1f3d2c;
-  --color-panel: rgba(26, 58, 41, 0.9);
-  --color-panel-border: rgba(169, 213, 179, 0.38);
-  --color-panel-highlight: rgba(116, 182, 139, 0.4);
-  --color-accent: #7cc86f;
-  --color-accent-soft: rgba(124, 200, 111, 0.2);
-  --color-earth: #b78044;
-  --color-water: #5aa9c9;
-  --color-highlight: #d3f36b;
-  --color-text-primary: #f3f8f0;
-  --color-text-secondary: rgba(243, 248, 240, 0.82);
+  --color-bg: #060a0c;
+  --color-bg-alt: #0f1519;
+  --color-canopy: #122225;
+  --color-panel: rgba(12, 19, 22, 0.78);
+  --color-panel-border: rgba(118, 206, 174, 0.28);
+  --color-panel-highlight: rgba(118, 206, 174, 0.22);
+  --color-accent: #6ee7bf;
+  --color-accent-soft: rgba(110, 231, 191, 0.16);
+  --color-earth: #8fbcd4;
+  --color-water: #7ad1ff;
+  --color-highlight: #f2ffe2;
+  --color-text-primary: #f4fbf7;
+  --color-text-secondary: rgba(244, 251, 247, 0.78);
   --font-display: 'Lilita One', cursive;
   --font-body: 'Nunito', sans-serif;
-  --shadow-soft: 0 24px 60px rgba(8, 22, 16, 0.55);
+  --shadow-soft: 0 24px 60px rgba(6, 12, 10, 0.55);
   --border-radius-lg: 20px;
 }
 
@@ -32,7 +32,7 @@ body {
   font-family: var(--font-body);
   letter-spacing: 0.01em;
   color: var(--color-text-primary);
-  background: linear-gradient(135deg, #0d1f17 0%, #143524 55%, #102330 100%);
+  background: radial-gradient(120% 120% at 50% 0%, #132226 0%, #060a0c 70%);
   overflow: hidden;
   position: relative;
 }
@@ -46,18 +46,17 @@ body::after {
 }
 
 body::before {
-  background: radial-gradient(circle at 18% 26%, rgba(124, 200, 111, 0.16), transparent 55%),
-    radial-gradient(circle at 78% 18%, rgba(90, 169, 201, 0.18), transparent 60%),
-    radial-gradient(circle at 48% 78%, rgba(179, 128, 68, 0.12), transparent 62%);
-  mix-blend-mode: screen;
-  opacity: 0.6;
+  background: radial-gradient(circle at 20% 20%, rgba(110, 231, 191, 0.18), transparent 60%),
+    radial-gradient(circle at 80% 25%, rgba(122, 209, 255, 0.16), transparent 65%),
+    radial-gradient(circle at 45% 80%, rgba(40, 96, 84, 0.22), transparent 70%);
+  opacity: 0.45;
 }
 
 body::after {
-  background: radial-gradient(circle at 14% 82%, rgba(16, 63, 42, 0.35), transparent 70%),
-    linear-gradient(120deg, rgba(12, 42, 31, 0.35), transparent 65%),
-    linear-gradient(300deg, rgba(21, 52, 67, 0.3), transparent 55%);
-  opacity: 0.55;
+  background: radial-gradient(circle at 18% 85%, rgba(22, 48, 44, 0.35), transparent 70%),
+    linear-gradient(120deg, rgba(14, 36, 32, 0.4), transparent 60%),
+    linear-gradient(300deg, rgba(21, 42, 55, 0.25), transparent 55%);
+  opacity: 0.35;
 }
 
 #app {
@@ -65,20 +64,28 @@ body::after {
   width: 100%;
   display: flex;
   align-items: stretch;
+  justify-content: center;
+  padding: 3rem;
   position: relative;
   z-index: 1;
 }
 
 .app-shell {
-  width: 100%;
+  width: min(1480px, 100%);
   height: 100%;
   display: grid;
-  grid-template-columns: 200px 300px minmax(280px, 360px) minmax(520px, 1fr);
+  grid-template-columns: 240px 320px minmax(300px, 360px) minmax(520px, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
-  gap: 1.5rem;
-  padding: 2.25rem 2.75rem;
+  gap: 1.75rem;
+  padding: 2.5rem;
   position: relative;
   align-items: stretch;
+  border-radius: 32px;
+  background: linear-gradient(135deg, rgba(12, 19, 22, 0.9), rgba(10, 19, 21, 0.8));
+  border: 1px solid rgba(118, 206, 174, 0.18);
+  box-shadow: 0 30px 120px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(26px);
+  overflow: hidden;
 }
 
 .app-shell > * {
@@ -88,49 +95,41 @@ body::after {
 .hud-brand {
   grid-column: 1 / span 3;
   grid-row: 1;
-  align-self: end;
+  align-self: start;
   display: flex;
   align-items: center;
-  gap: 0.85rem;
+  gap: 1.2rem;
   font-family: var(--font-display);
-  font-size: 1.75rem;
-  letter-spacing: 0.18em;
+  font-size: 2.15rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--color-highlight);
-  text-shadow: 0 0 18px rgba(124, 200, 111, 0.45);
+  text-shadow: 0 0 22px rgba(110, 231, 191, 0.3);
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(118, 206, 174, 0.18);
 }
 
-.hud-brand::before {
+.hud-brand::after {
   content: '';
-  width: 44px;
-  height: 44px;
-  border-radius: 14px;
-  border: 2px solid rgba(211, 243, 107, 0.6);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.25), rgba(90, 169, 201, 0.4));
-  box-shadow: 0 0 22px rgba(124, 200, 111, 0.35);
+  flex: 1 1 auto;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(110, 231, 191, 0.4), transparent 75%);
 }
 
 .hud-nav {
   grid-column: 1;
   grid-row: 2;
-  background: var(--color-panel);
+  background: rgba(12, 19, 22, 0.72);
   border: 1px solid var(--color-panel-border);
   border-radius: var(--border-radius-lg);
-  padding: 1.6rem 1.25rem;
+  padding: 1.75rem 1.35rem;
   display: flex;
   flex-direction: column;
-  gap: 1.35rem;
+  gap: 1.5rem;
   position: relative;
   overflow: hidden;
   box-shadow: var(--shadow-soft);
-}
-
-.hud-nav::before {
-  content: '';
-  position: absolute;
-  inset: -25% -40% 55% -40%;
-  background: radial-gradient(circle at 50% 38%, var(--color-panel-highlight), transparent 58%);
-  opacity: 0.4;
+  backdrop-filter: blur(22px);
 }
 
 .hud-nav h2 {
@@ -152,7 +151,7 @@ body::after {
 
 .nav-section + .nav-section {
   padding-top: 0.5rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid rgba(118, 206, 174, 0.12);
 }
 
 .critter-selector {
@@ -164,46 +163,29 @@ body::after {
   width: 100%;
   padding: 0.75rem 1rem;
   border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(53, 94, 70, 0.55);
+  border: 1px solid rgba(118, 206, 174, 0.2);
+  background: rgba(16, 26, 30, 0.6);
   color: var(--color-text-secondary);
   font-family: var(--font-display);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: all 0.2s ease;
-  position: relative;
-  overflow: hidden;
-}
-
-.critter-button::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
-  opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: all 0.18s ease;
 }
 
 .critter-button:hover,
 .critter-button:focus-visible {
-  border-color: rgba(124, 200, 111, 0.6);
+  border-color: rgba(110, 231, 191, 0.6);
   color: var(--color-text-primary);
   transform: translateY(-1px);
-  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+  box-shadow: 0 12px 26px rgba(5, 15, 13, 0.35);
   outline: none;
 }
 
-.critter-button:hover::after,
-.critter-button:focus-visible::after,
-.critter-button.active::after {
-  opacity: 1;
-}
-
 .critter-button.active {
-  border-color: rgba(211, 243, 107, 0.75);
+  border-color: rgba(110, 231, 191, 0.75);
   color: var(--color-text-primary);
-  box-shadow: 0 16px 32px rgba(21, 58, 37, 0.45);
+  box-shadow: 0 16px 32px rgba(4, 12, 10, 0.45);
 }
 
 .nav-tabs {
@@ -221,59 +203,40 @@ body::after {
 
 .nav-tabs button {
   width: 100%;
-  padding: 0.9rem 1rem;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(61, 102, 76, 0.35);
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(118, 206, 174, 0.2);
+  background: rgba(16, 26, 30, 0.62);
   color: var(--color-text-secondary);
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   font-family: var(--font-display);
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: all 0.2s ease;
-  position: relative;
-  overflow: hidden;
-}
-
-.nav-tabs button::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
-  opacity: 0;
-  transition: opacity 0.2s ease;
+  transition: all 0.18s ease;
 }
 
 .nav-tabs button:hover,
 .nav-tabs button:focus-visible {
-  border-color: rgba(124, 200, 111, 0.6);
+  border-color: rgba(110, 231, 191, 0.6);
   color: var(--color-text-primary);
   transform: translateY(-1px);
-  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+  box-shadow: 0 12px 26px rgba(5, 15, 12, 0.35);
   outline: none;
 }
 
-.nav-tabs button:hover::after,
-.nav-tabs button:focus-visible::after {
-  opacity: 1;
-}
-
 .nav-tabs button.active {
-  border-color: rgba(211, 243, 107, 0.75);
+  border-color: rgba(110, 231, 191, 0.65);
+  background: rgba(110, 231, 191, 0.16);
   color: var(--color-text-primary);
-  box-shadow: 0 14px 32px rgba(20, 52, 36, 0.45);
-}
-
-.nav-tabs button.active::after {
-  opacity: 1;
+  box-shadow: 0 14px 32px rgba(6, 18, 15, 0.45);
 }
 
 .panel {
-  background: linear-gradient(165deg, rgba(33, 71, 51, 0.92), rgba(23, 50, 35, 0.92));
+  background: rgba(12, 19, 22, 0.74);
   border: 1px solid var(--color-panel-border);
   border-radius: var(--border-radius-lg);
-  padding: 1.6rem 1.75rem;
+  padding: 1.75rem;
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
@@ -281,29 +244,7 @@ body::after {
   overflow: hidden;
   min-height: 0;
   box-shadow: var(--shadow-soft);
-}
-
-.panel::before {
-  content: '';
-  position: absolute;
-  inset: -20% -35% 65% -25%;
-  background: radial-gradient(circle at 32% 24%, rgba(124, 200, 111, 0.25), transparent 60%);
-  opacity: 0.55;
-  pointer-events: none;
-}
-
-.panel::after {
-  content: '';
-  position: absolute;
-  inset: 60% -30% -25% -20%;
-  background: radial-gradient(circle at 70% 80%, rgba(90, 169, 201, 0.18), transparent 60%);
-  opacity: 0.4;
-  pointer-events: none;
-}
-
-.panel > * {
-  position: relative;
-  z-index: 1;
+  backdrop-filter: blur(22px);
 }
 
 .hud-panel {
@@ -322,19 +263,21 @@ body::after {
 
 .panel-header {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   font-family: var(--font-display);
-  letter-spacing: 0.14em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: var(--color-highlight);
   gap: 1rem;
+  border-bottom: 1px solid rgba(118, 206, 174, 0.16);
+  padding-bottom: 0.75rem;
 }
 
 .panel-header [data-role='list-context'] {
-  font-size: 0.85rem;
-  letter-spacing: 0.16em;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--color-water);
 }
@@ -350,10 +293,10 @@ body::after {
 }
 
 .weapon-card {
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(118, 206, 174, 0.16);
   border-radius: 18px;
   padding: 1rem 1.2rem;
-  background: rgba(46, 88, 64, 0.4);
+  background: rgba(16, 26, 30, 0.55);
   color: var(--color-text-secondary);
   cursor: pointer;
   transition: all 0.18s ease;
@@ -361,18 +304,18 @@ body::after {
 
 .weapon-card:hover,
 .weapon-card:focus-visible {
-  border-color: rgba(124, 200, 111, 0.55);
-  box-shadow: 0 12px 26px rgba(16, 45, 31, 0.35);
-  background: rgba(46, 88, 64, 0.55);
+  border-color: rgba(110, 231, 191, 0.6);
+  box-shadow: 0 12px 26px rgba(5, 15, 13, 0.35);
+  background: rgba(16, 26, 30, 0.7);
   outline: none;
   color: var(--color-text-primary);
 }
 
 .weapon-card.active {
-  border-color: rgba(211, 243, 107, 0.75);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.38), rgba(90, 169, 201, 0.28));
+  border-color: rgba(110, 231, 191, 0.8);
+  background: rgba(110, 231, 191, 0.16);
   color: var(--color-text-primary);
-  box-shadow: 0 14px 30px rgba(17, 46, 33, 0.45);
+  box-shadow: 0 14px 30px rgba(4, 12, 10, 0.45);
 }
 
 .weapon-card h3 {
@@ -529,15 +472,17 @@ dl dt {
 
 .panel-footer {
   font-size: 0.78rem;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.65);
+  color: rgba(244, 251, 247, 0.6);
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(118, 206, 174, 0.12);
 }
 
 .weapon-cards,
 .detail-content {
   scrollbar-width: thin;
-  scrollbar-color: rgba(90, 169, 201, 0.55) transparent;
+  scrollbar-color: rgba(122, 209, 255, 0.45) transparent;
 }
 
 .weapon-cards::-webkit-scrollbar,
@@ -552,7 +497,7 @@ dl dt {
 
 .weapon-cards::-webkit-scrollbar-thumb,
 .detail-content::-webkit-scrollbar-thumb {
-  background: linear-gradient(180deg, rgba(90, 169, 201, 0.65), rgba(124, 200, 111, 0.55));
+  background: linear-gradient(180deg, rgba(122, 209, 255, 0.55), rgba(110, 231, 191, 0.45));
   border-radius: 6px;
 }
 
@@ -615,31 +560,13 @@ dl dt {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
   grid-template-rows: minmax(0, 1fr);
-  background: linear-gradient(160deg, rgba(24, 52, 36, 0.95), rgba(20, 47, 57, 0.92));
-  border: 1px solid rgba(90, 169, 201, 0.35);
-  border-radius: calc(var(--border-radius-lg) + 4px);
+  background: rgba(10, 16, 19, 0.85);
+  border: 1px solid rgba(118, 206, 174, 0.22);
+  border-radius: calc(var(--border-radius-lg) + 8px);
   overflow: hidden;
   box-shadow: var(--shadow-soft);
   min-height: 0;
-}
-
-.stage::before {
-  content: '';
-  position: absolute;
-  inset: -25% -18% 60% -18%;
-  background: radial-gradient(circle at 62% 35%, rgba(124, 200, 111, 0.28), transparent 62%);
-  opacity: 0.55;
-  pointer-events: none;
-}
-
-.stage::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 38% 72%, rgba(90, 169, 201, 0.22), transparent 70%),
-    radial-gradient(circle at 18% 28%, rgba(183, 128, 68, 0.18), transparent 58%);
-  opacity: 0.6;
-  pointer-events: none;
+  backdrop-filter: blur(24px);
 }
 
 .stage-toolbar {
@@ -647,11 +574,11 @@ dl dt {
   z-index: 1;
   grid-column: 2;
   grid-row: 1;
-  padding: 1.4rem 1.6rem 1.2rem;
+  padding: 1.6rem 1.6rem 1.4rem;
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
-  background: linear-gradient(180deg, rgba(13, 31, 23, 0.95), rgba(13, 31, 23, 0));
+  background: linear-gradient(180deg, rgba(12, 19, 22, 0.85), rgba(12, 19, 22, 0.35));
   overflow-y: auto;
 }
 
@@ -663,38 +590,14 @@ dl dt {
 
 .stage-tool-panel {
   pointer-events: auto;
-  background: linear-gradient(165deg, rgba(17, 40, 29, 0.85), rgba(14, 34, 28, 0.78));
-  border: 1px solid rgba(124, 200, 111, 0.25);
+  background: rgba(16, 26, 30, 0.7);
+  border: 1px solid rgba(118, 206, 174, 0.2);
   border-radius: 18px;
-  padding: 1.1rem 1.3rem;
-  box-shadow: 0 18px 36px rgba(9, 24, 17, 0.45);
+  padding: 1.2rem 1.35rem;
+  box-shadow: 0 18px 36px rgba(4, 12, 10, 0.45);
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
-  position: relative;
-}
-
-.stage-tool-panel::before {
-  content: '';
-  position: absolute;
-  inset: -18% -22% 65% -22%;
-  background: radial-gradient(circle at 32% 24%, rgba(124, 200, 111, 0.22), transparent 60%);
-  opacity: 0.45;
-  pointer-events: none;
-}
-
-.stage-tool-panel::after {
-  content: '';
-  position: absolute;
-  inset: 55% -18% -20% -18%;
-  background: radial-gradient(circle at 70% 80%, rgba(90, 169, 201, 0.18), transparent 60%);
-  opacity: 0.35;
-  pointer-events: none;
-}
-
-.stage-tool-panel > * {
-  position: relative;
-  z-index: 1;
 }
 
 .stage-tool-panel--rig {
@@ -714,30 +617,16 @@ dl dt {
 .rig-panel__header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.9rem;
-}
-
-.rig-panel__heading {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
 }
 
 .rig-panel__title {
   font-family: var(--font-display);
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  font-size: 0.85rem;
-  color: var(--color-highlight);
-}
-
-.rig-panel__subtitle {
-  margin: 0;
-  font-size: 0.72rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.62);
+  font-size: 0.9rem;
+  color: var(--color-highlight);
 }
 
 .rig-panel__status {
@@ -746,10 +635,10 @@ dl dt {
   justify-content: center;
   padding: 0.35rem 0.9rem;
   border-radius: 999px;
-  border: 1px solid rgba(124, 200, 111, 0.35);
-  background: rgba(14, 36, 26, 0.65);
+  border: 1px solid rgba(118, 206, 174, 0.32);
+  background: rgba(16, 26, 30, 0.65);
   font-size: 0.72rem;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--color-highlight);
   min-width: 0;
@@ -757,12 +646,12 @@ dl dt {
 }
 
 .rig-panel__status[data-state='loading'] {
-  border-color: rgba(90, 169, 201, 0.55);
+  border-color: rgba(122, 209, 255, 0.55);
   color: var(--color-water);
 }
 
 .rig-panel__status[data-state='idle'] {
-  color: rgba(243, 248, 240, 0.7);
+  color: rgba(244, 251, 247, 0.65);
 }
 
 .rig-panel__content {
@@ -773,10 +662,9 @@ dl dt {
 
 .rig-panel__empty {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: 0.85rem;
   letter-spacing: 0.05em;
-  color: rgba(243, 248, 240, 0.68);
-  font-style: italic;
+  color: rgba(244, 251, 247, 0.68);
 }
 
 .rig-group {
@@ -1229,6 +1117,10 @@ dl dt {
 }
 
 @media (max-width: 1100px) {
+  #app {
+    padding: 2.25rem;
+  }
+
   .app-shell {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto auto auto auto auto;
@@ -1301,6 +1193,10 @@ dl dt {
 }
 
 @media (max-width: 700px) {
+  #app {
+    padding: 1.25rem;
+  }
+
   .app-shell {
     padding: 1.5rem;
   }


### PR DESCRIPTION
## Summary
- Rebrand the experience to “Critz Library,” updating the document title, HUD header copy, and supporting documentation to remove the old Armory wording.
- Streamline rig control messaging to eliminate redundant pose text while keeping concise status updates.
- Restyle the navigation, panels, and stage shell with a cleaner glassy palette, lighter borders, and simplified buttons for a less cluttered UI.

## Testing
- Not run (UI updates only)


------
https://chatgpt.com/codex/tasks/task_e_68ca807cbb208329b358ce8495e49e4b