### PR TITLE
Update Critz library presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crtiz Armory Display</title>
+    <title>Critz Library Display</title>
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -116,20 +116,19 @@ export class WeaponDisplayApp {
   buildLayout() {
     this.root.innerHTML = `
       <div class="app-shell">
-        <div class="hud-brand">Crtiz Armory</div>
+        <div class="hud-brand">Critz Library</div>
         <nav class="hud-nav" aria-label="Interface options">
           <div class="nav-section nav-section--critters">
             <h2>Critters</h2>
             <div data-component="critter-selector"></div>
           </div>
           <div class="nav-section nav-section--categories">
-            <h2>Categories</h2>
+            <h2>Arsenal</h2>
             <ul class="nav-tabs" data-component="nav-tabs"></ul>
           </div>
         </nav>
         <section class="panel hud-panel hud-list" data-component="weapon-list">
           <div class="panel-header">
-            <span>Arsenal</span>
             <span data-role="list-context"></span>
           </div>
           <div class="weapon-cards" data-role="weapon-cards"></div>

--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -4,7 +4,7 @@ const RAW_GLOBALS = {
   base_health: 100,
   base_speed: 100,
   base_stamina: 100,
-  headshot_multiplier: 3.0,
+  headshot_multiplier: 2.0,
   units: {
     distance: 'cm',
     time: 's',
@@ -476,8 +476,6 @@ const FALLBACK_RARITY_BY_CATEGORY = {
   utility: 'uncommon',
 };
 
-const HEADSHOT_MULTIPLIER = RAW_GLOBALS.headshot_multiplier ?? 3;
-
 const slugify = (value) =>
   value
     .toLowerCase()
@@ -821,17 +819,8 @@ const getLegacyDetails = (name) => {
 };
 
 const buildStats = (weapon, category) => {
-  const headshotDamage =
-    weapon.headshot_allowed && weapon.damage_body !== null && weapon.damage_body !== undefined
-      ? weapon.damage_body * HEADSHOT_MULTIPLIER
-      : null;
-
   const baseStats = {
     damage: weapon.damage_body !== null && weapon.damage_body !== undefined ? `${formatNumber(weapon.damage_body)} body` : null,
-    headshotDamage:
-      headshotDamage !== null
-        ? `${formatNumber(headshotDamage)} head (×${formatNumber(HEADSHOT_MULTIPLIER)})`
-        : null,
     fireRate: formatRate(weapon.rps),
     reloadSpeed: formatSeconds(weapon.reload_s),
     magazineSize:
@@ -956,16 +945,6 @@ const buildSpecial = (weapon, legacySpecial = {}, category) => {
 
   if (weapon.fire_mode) {
     special.fireMode = prettify(weapon.fire_mode);
-  }
-
-  if (weapon.headshot_allowed !== undefined) {
-    special.headshotRule = weapon.headshot_allowed
-      ? `Headshots enabled (×${formatNumber(HEADSHOT_MULTIPLIER)})`
-      : 'Headshots disabled';
-  }
-
-  if (weapon.headshot_allowed && weapon.damage_body !== null && weapon.damage_body !== undefined) {
-    special.headshotDamage = `${formatNumber(weapon.damage_body * HEADSHOT_MULTIPLIER)} damage on headshots`;
   }
 
   if (weapon.stamina_pool !== undefined && weapon.stamina_pool !== null) {

--- a/src/data/weaponSchema.js
+++ b/src/data/weaponSchema.js
@@ -4,7 +4,6 @@ export const RARITIES = ['common', 'uncommon', 'rare', 'epic', 'legendary', 'myt
 
 export const STAT_LABELS = {
   damage: 'Damage',
-  headshotDamage: 'Headshot Damage',
   splashDamage: 'Splash Damage',
   dotDamage: 'Damage over Time',
   dps: 'Damage per Second',
@@ -52,7 +51,6 @@ export const STAT_LABELS = {
 
 export const DEFAULT_STATS_ORDER = [
   'damage',
-  'headshotDamage',
   'splashDamage',
   'dotDamage',
   'dps',

--- a/src/hud/HUDController.js
+++ b/src/hud/HUDController.js
@@ -4,10 +4,10 @@ import { WeaponDetailPanel } from './components/WeaponDetailPanel.js';
 import { WEAPON_CATEGORIES } from '../data/weaponSchema.js';
 
 const CATEGORY_LABELS = {
-  primary: 'Primary',
-  secondary: 'Secondary',
-  melee: 'Melee',
-  utility: 'Utility',
+  primary: 'Primary Weapons',
+  secondary: 'Secondary Weapons',
+  melee: 'Melee Weapons',
+  utility: 'Utilities',
 };
 
 export class HUDController {

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -135,7 +135,8 @@ export class ViewportOverlay {
       }),
       this.bus.on('stage:model-ready', (payload) => {
         const name = payload?.name ?? 'Model';
-        this.setStatus('ready', `${name} ready for inspection.`);
+        const message = name;
+        this.setStatus('ready', message);
         this.setLoading(false);
         this.setControlsAvailability({
           focus: true,

--- a/src/hud/components/WeaponDetailPanel.js
+++ b/src/hud/components/WeaponDetailPanel.js
@@ -80,7 +80,7 @@ function collectStatBarData(weapon) {
       hasValue,
       fill,
     };
-  });
+  }).filter((stat) => stat.hasValue);
 }
 
 function createStatBarMarkup(stat) {
@@ -128,13 +128,13 @@ function parseStatValue(raw) {
 
 function formatDisplayValue(raw) {
   if (raw === null || raw === undefined || raw === '') {
-    return 'N/A';
+    return '';
   }
 
   if (typeof raw === 'number') {
     return Number.isFinite(raw)
       ? Number(raw).toLocaleString(undefined, { maximumFractionDigits: 2 })
-      : 'N/A';
+      : '';
   }
 
   return String(raw);

--- a/src/hud/components/WeaponList.js
+++ b/src/hud/components/WeaponList.js
@@ -1,5 +1,3 @@
-import { deriveStatsList } from '../../data/weaponSchema.js';
-
 export class WeaponList {
   constructor({ panelElement, footerElement, onSelect }) {
     this.panelElement = panelElement;
@@ -59,20 +57,6 @@ export class WeaponList {
     const title = document.createElement('h3');
     title.textContent = weapon.name;
     card.appendChild(title);
-
-    const stats = deriveStatsList(weapon).slice(0, 4);
-    if (stats.length > 0) {
-      const statList = document.createElement('dl');
-      stats.forEach(({ label, value }) => {
-        const dt = document.createElement('dt');
-        dt.textContent = label;
-        const dd = document.createElement('dd');
-        dd.textContent = value;
-        statList.appendChild(dt);
-        statList.appendChild(dd);
-      });
-      card.appendChild(statList);
-    }
 
     card.addEventListener('click', () => this.handleSelection(weapon.id));
     card.addEventListener('keyup', (event) => {


### PR DESCRIPTION
## Summary
- rename the HUD branding to Critz Library and update navigation labels to match the new terminology
- simplify weapon selection cards and filter stat displays so only populated stats appear
- apply the new 2x headshot multiplier and remove headshot-specific outputs from the weapon data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cca6ea921c83299f9e809b59f66cc7