### PR TITLE
Refine UI layout and simplify controls

### DIFF
--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -29,7 +29,6 @@ export class RigControlPanel {
       <div class="rig-panel__header">
         <div class="rig-panel__heading">
           <span class="rig-panel__title">Pose Controls</span>
-          <p class="rig-panel__subtitle">Blend animations with direct rig offsets.</p>
         </div>
         <span class="rig-panel__status" data-role="rig-status">Idle</span>
       </div>
@@ -56,7 +55,7 @@ export class RigControlPanel {
       this.bus.on('stage:model-ready', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(false, `${payload?.name ?? 'Critter'} ready to pose.`);
+          this.setLoading(false, 'Pose controls ready.');
         }
       }),
       this.bus.on('stage:model-missing', (payload) => {

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -47,14 +47,6 @@ export class ViewportOverlay {
         </div>
       </div>
       <div class="viewport-ui__bottom">
-        <div class="viewport-instructions">
-          <p class="viewport-instructions__title">Camera Tips</p>
-          <ul class="viewport-instructions__list" aria-label="Viewport camera controls">
-            <li><span>Drag</span> Orbit around</li>
-            <li><span>Right-drag</span> Pan the view</li>
-            <li><span>Scroll</span> Zoom in or out</li>
-          </ul>
-        </div>
         <div class="viewport-controls" role="group" aria-label="Viewport controls">
           <button type="button" class="viewport-button" data-action="focus">Focus Model</button>
           <button type="button" class="viewport-button" data-action="reset">Reset View</button>

--- a/src/hud/components/WeaponList.js
+++ b/src/hud/components/WeaponList.js
@@ -42,10 +42,11 @@ export class WeaponList {
     const count = this.weapons?.length ?? 0;
     if (count === 0) {
       this.footerElement.textContent = 'No gear catalogued yet.';
+      this.footerElement.classList.remove('is-hidden');
       return;
     }
-    const label = count === 1 ? 'choice' : 'choices';
-    this.footerElement.textContent = `${count} ${label} available`;
+    this.footerElement.textContent = '';
+    this.footerElement.classList.add('is-hidden');
   }
 
   createCard(weapon) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,20 +1,20 @@
 :root {
-  --color-bg: #0f1f17;
-  --color-bg-alt: #142e20;
-  --color-canopy: #1f3d2c;
-  --color-panel: rgba(26, 58, 41, 0.9);
-  --color-panel-border: rgba(169, 213, 179, 0.38);
-  --color-panel-highlight: rgba(116, 182, 139, 0.4);
-  --color-accent: #7cc86f;
-  --color-accent-soft: rgba(124, 200, 111, 0.2);
-  --color-earth: #b78044;
-  --color-water: #5aa9c9;
-  --color-highlight: #d3f36b;
-  --color-text-primary: #f3f8f0;
-  --color-text-secondary: rgba(243, 248, 240, 0.82);
+  --color-bg: #0a1610;
+  --color-bg-alt: #13281a;
+  --color-canopy: #1c3523;
+  --color-panel: rgba(18, 44, 29, 0.94);
+  --color-panel-border: rgba(162, 214, 143, 0.55);
+  --color-panel-highlight: rgba(196, 231, 186, 0.4);
+  --color-accent: #9ed36a;
+  --color-accent-soft: rgba(158, 211, 106, 0.22);
+  --color-earth: #c1843f;
+  --color-water: #6bb3c4;
+  --color-highlight: #f1f8d2;
+  --color-text-primary: #f4f7ed;
+  --color-text-secondary: rgba(244, 248, 232, 0.78);
   --font-display: 'Lilita One', cursive;
   --font-body: 'Nunito', sans-serif;
-  --shadow-soft: 0 24px 60px rgba(8, 22, 16, 0.55);
+  --shadow-soft: 0 28px 60px rgba(6, 16, 10, 0.72);
   --border-radius-lg: 20px;
 }
 
@@ -32,7 +32,7 @@ body {
   font-family: var(--font-body);
   letter-spacing: 0.01em;
   color: var(--color-text-primary);
-  background: linear-gradient(135deg, #0d1f17 0%, #143524 55%, #102330 100%);
+  background: linear-gradient(135deg, #0b1a11 0%, #173922 55%, #12343d 100%);
   overflow: hidden;
   position: relative;
 }
@@ -46,18 +46,18 @@ body::after {
 }
 
 body::before {
-  background: radial-gradient(circle at 18% 26%, rgba(124, 200, 111, 0.16), transparent 55%),
-    radial-gradient(circle at 78% 18%, rgba(90, 169, 201, 0.18), transparent 60%),
-    radial-gradient(circle at 48% 78%, rgba(179, 128, 68, 0.12), transparent 62%);
+  background: radial-gradient(circle at 18% 26%, rgba(158, 211, 106, 0.2), transparent 55%),
+    radial-gradient(circle at 78% 18%, rgba(107, 179, 196, 0.22), transparent 60%),
+    radial-gradient(circle at 48% 78%, rgba(193, 132, 63, 0.18), transparent 62%);
   mix-blend-mode: screen;
-  opacity: 0.6;
+  opacity: 0.65;
 }
 
 body::after {
-  background: radial-gradient(circle at 14% 82%, rgba(16, 63, 42, 0.35), transparent 70%),
-    linear-gradient(120deg, rgba(12, 42, 31, 0.35), transparent 65%),
-    linear-gradient(300deg, rgba(21, 52, 67, 0.3), transparent 55%);
-  opacity: 0.55;
+  background: radial-gradient(circle at 14% 82%, rgba(17, 58, 38, 0.38), transparent 70%),
+    linear-gradient(120deg, rgba(14, 45, 31, 0.42), transparent 65%),
+    linear-gradient(300deg, rgba(22, 56, 63, 0.35), transparent 55%);
+  opacity: 0.6;
 }
 
 #app {
@@ -96,8 +96,8 @@ body::after {
   font-size: 1.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--color-highlight);
-  text-shadow: 0 0 18px rgba(124, 200, 111, 0.45);
+  color: var(--color-accent);
+  text-shadow: 0 0 16px rgba(158, 211, 106, 0.45);
 }
 
 .hud-brand::before {
@@ -105,15 +105,15 @@ body::after {
   width: 44px;
   height: 44px;
   border-radius: 14px;
-  border: 2px solid rgba(211, 243, 107, 0.6);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.25), rgba(90, 169, 201, 0.4));
-  box-shadow: 0 0 22px rgba(124, 200, 111, 0.35);
+  border: 2px solid rgba(158, 211, 106, 0.65);
+  background: linear-gradient(135deg, rgba(158, 211, 106, 0.3), rgba(107, 179, 196, 0.45));
+  box-shadow: 0 0 20px rgba(158, 211, 106, 0.35);
 }
 
 .hud-nav {
   grid-column: 1;
   grid-row: 2;
-  background: var(--color-panel);
+  background: linear-gradient(165deg, rgba(20, 46, 30, 0.96), rgba(15, 34, 25, 0.9));
   border: 1px solid var(--color-panel-border);
   border-radius: var(--border-radius-lg);
   padding: 1.6rem 1.25rem;
@@ -130,7 +130,7 @@ body::after {
   position: absolute;
   inset: -25% -40% 55% -40%;
   background: radial-gradient(circle at 50% 38%, var(--color-panel-highlight), transparent 58%);
-  opacity: 0.4;
+  opacity: 0.5;
 }
 
 .hud-nav h2 {
@@ -164,8 +164,8 @@ body::after {
   width: 100%;
   padding: 0.75rem 1rem;
   border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(53, 94, 70, 0.55);
+  border: 1px solid rgba(158, 211, 106, 0.28);
+  background: rgba(37, 74, 52, 0.6);
   color: var(--color-text-secondary);
   font-family: var(--font-display);
   letter-spacing: 0.08em;
@@ -180,17 +180,17 @@ body::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
+  background: linear-gradient(135deg, rgba(158, 211, 106, 0.22), transparent 65%);
   opacity: 0;
   transition: opacity 0.2s ease;
 }
 
 .critter-button:hover,
 .critter-button:focus-visible {
-  border-color: rgba(124, 200, 111, 0.6);
+  border-color: rgba(158, 211, 106, 0.65);
   color: var(--color-text-primary);
   transform: translateY(-1px);
-  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+  box-shadow: 0 14px 28px rgba(16, 42, 30, 0.4);
   outline: none;
 }
 
@@ -201,7 +201,7 @@ body::after {
 }
 
 .critter-button.active {
-  border-color: rgba(211, 243, 107, 0.75);
+  border-color: rgba(158, 211, 106, 0.75);
   color: var(--color-text-primary);
   box-shadow: 0 16px 32px rgba(21, 58, 37, 0.45);
 }
@@ -223,8 +223,8 @@ body::after {
   width: 100%;
   padding: 0.9rem 1rem;
   border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(61, 102, 76, 0.35);
+  border: 1px solid rgba(158, 211, 106, 0.2);
+  background: rgba(32, 66, 46, 0.6);
   color: var(--color-text-secondary);
   font-size: 0.95rem;
   font-family: var(--font-display);
@@ -240,17 +240,17 @@ body::after {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.18), transparent 65%);
+  background: linear-gradient(135deg, rgba(158, 211, 106, 0.25), transparent 65%);
   opacity: 0;
   transition: opacity 0.2s ease;
 }
 
 .nav-tabs button:hover,
 .nav-tabs button:focus-visible {
-  border-color: rgba(124, 200, 111, 0.6);
+  border-color: rgba(158, 211, 106, 0.65);
   color: var(--color-text-primary);
   transform: translateY(-1px);
-  box-shadow: 0 12px 26px rgba(18, 49, 33, 0.35);
+  box-shadow: 0 14px 30px rgba(17, 43, 31, 0.38);
   outline: none;
 }
 
@@ -260,9 +260,9 @@ body::after {
 }
 
 .nav-tabs button.active {
-  border-color: rgba(211, 243, 107, 0.75);
+  border-color: rgba(158, 211, 106, 0.75);
   color: var(--color-text-primary);
-  box-shadow: 0 14px 32px rgba(20, 52, 36, 0.45);
+  box-shadow: 0 16px 34px rgba(18, 45, 32, 0.45);
 }
 
 .nav-tabs button.active::after {
@@ -270,7 +270,7 @@ body::after {
 }
 
 .panel {
-  background: linear-gradient(165deg, rgba(33, 71, 51, 0.92), rgba(23, 50, 35, 0.92));
+  background: linear-gradient(165deg, rgba(30, 66, 46, 0.95), rgba(20, 47, 34, 0.92));
   border: 1px solid var(--color-panel-border);
   border-radius: var(--border-radius-lg);
   padding: 1.6rem 1.75rem;
@@ -287,8 +287,8 @@ body::after {
   content: '';
   position: absolute;
   inset: -20% -35% 65% -25%;
-  background: radial-gradient(circle at 32% 24%, rgba(124, 200, 111, 0.25), transparent 60%);
-  opacity: 0.55;
+  background: radial-gradient(circle at 32% 24%, rgba(158, 211, 106, 0.28), transparent 60%);
+  opacity: 0.58;
   pointer-events: none;
 }
 
@@ -296,8 +296,8 @@ body::after {
   content: '';
   position: absolute;
   inset: 60% -30% -25% -20%;
-  background: radial-gradient(circle at 70% 80%, rgba(90, 169, 201, 0.18), transparent 60%);
-  opacity: 0.4;
+  background: radial-gradient(circle at 70% 80%, rgba(107, 179, 196, 0.22), transparent 60%);
+  opacity: 0.42;
   pointer-events: none;
 }
 
@@ -350,10 +350,10 @@ body::after {
 }
 
 .weapon-card {
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(158, 211, 106, 0.18);
   border-radius: 18px;
   padding: 1rem 1.2rem;
-  background: rgba(46, 88, 64, 0.4);
+  background: rgba(31, 63, 43, 0.6);
   color: var(--color-text-secondary);
   cursor: pointer;
   transition: all 0.18s ease;
@@ -361,18 +361,18 @@ body::after {
 
 .weapon-card:hover,
 .weapon-card:focus-visible {
-  border-color: rgba(124, 200, 111, 0.55);
-  box-shadow: 0 12px 26px rgba(16, 45, 31, 0.35);
-  background: rgba(46, 88, 64, 0.55);
+  border-color: rgba(158, 211, 106, 0.65);
+  box-shadow: 0 14px 28px rgba(15, 42, 30, 0.4);
+  background: rgba(34, 70, 47, 0.72);
   outline: none;
   color: var(--color-text-primary);
 }
 
 .weapon-card.active {
-  border-color: rgba(211, 243, 107, 0.75);
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.38), rgba(90, 169, 201, 0.28));
+  border-color: rgba(158, 211, 106, 0.85);
+  background: linear-gradient(135deg, rgba(158, 211, 106, 0.38), rgba(107, 179, 196, 0.3));
   color: var(--color-text-primary);
-  box-shadow: 0 14px 30px rgba(17, 46, 33, 0.45);
+  box-shadow: 0 16px 34px rgba(16, 44, 32, 0.46);
 }
 
 .weapon-card h3 {
@@ -534,6 +534,10 @@ dl dt {
   color: rgba(243, 248, 240, 0.65);
 }
 
+.panel-footer.is-hidden {
+  display: none;
+}
+
 .weapon-cards,
 .detail-content {
   scrollbar-width: thin;
@@ -615,8 +619,8 @@ dl dt {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
   grid-template-rows: minmax(0, 1fr);
-  background: linear-gradient(160deg, rgba(24, 52, 36, 0.95), rgba(20, 47, 57, 0.92));
-  border: 1px solid rgba(90, 169, 201, 0.35);
+  background: linear-gradient(160deg, rgba(20, 48, 32, 0.96), rgba(18, 44, 50, 0.93));
+  border: 1px solid rgba(126, 194, 156, 0.45);
   border-radius: calc(var(--border-radius-lg) + 4px);
   overflow: hidden;
   box-shadow: var(--shadow-soft);
@@ -627,8 +631,8 @@ dl dt {
   content: '';
   position: absolute;
   inset: -25% -18% 60% -18%;
-  background: radial-gradient(circle at 62% 35%, rgba(124, 200, 111, 0.28), transparent 62%);
-  opacity: 0.55;
+  background: radial-gradient(circle at 62% 35%, rgba(158, 211, 106, 0.32), transparent 62%);
+  opacity: 0.58;
   pointer-events: none;
 }
 
@@ -636,9 +640,9 @@ dl dt {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 38% 72%, rgba(90, 169, 201, 0.22), transparent 70%),
-    radial-gradient(circle at 18% 28%, rgba(183, 128, 68, 0.18), transparent 58%);
-  opacity: 0.6;
+  background: radial-gradient(circle at 38% 72%, rgba(107, 179, 196, 0.24), transparent 70%),
+    radial-gradient(circle at 18% 28%, rgba(193, 132, 63, 0.2), transparent 58%);
+  opacity: 0.62;
   pointer-events: none;
 }
 
@@ -651,9 +655,10 @@ dl dt {
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
-  background: linear-gradient(180deg, rgba(13, 31, 23, 0.95), rgba(13, 31, 23, 0));
+  background: linear-gradient(180deg, rgba(12, 32, 23, 0.94), rgba(12, 32, 23, 0));
   overflow-y: auto;
 }
+
 
 .stage-tool-grid {
   display: grid;
@@ -663,11 +668,11 @@ dl dt {
 
 .stage-tool-panel {
   pointer-events: auto;
-  background: linear-gradient(165deg, rgba(17, 40, 29, 0.85), rgba(14, 34, 28, 0.78));
-  border: 1px solid rgba(124, 200, 111, 0.25);
+  background: linear-gradient(165deg, rgba(23, 56, 38, 0.9), rgba(18, 44, 33, 0.82));
+  border: 1px solid rgba(158, 211, 106, 0.3);
   border-radius: 18px;
   padding: 1.1rem 1.3rem;
-  box-shadow: 0 18px 36px rgba(9, 24, 17, 0.45);
+  box-shadow: 0 18px 36px rgba(8, 22, 15, 0.5);
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
@@ -678,8 +683,8 @@ dl dt {
   content: '';
   position: absolute;
   inset: -18% -22% 65% -22%;
-  background: radial-gradient(circle at 32% 24%, rgba(124, 200, 111, 0.22), transparent 60%);
-  opacity: 0.45;
+  background: radial-gradient(circle at 32% 24%, rgba(158, 211, 106, 0.28), transparent 60%);
+  opacity: 0.5;
   pointer-events: none;
 }
 
@@ -687,14 +692,9 @@ dl dt {
   content: '';
   position: absolute;
   inset: 55% -18% -20% -18%;
-  background: radial-gradient(circle at 70% 80%, rgba(90, 169, 201, 0.18), transparent 60%);
-  opacity: 0.35;
+  background: radial-gradient(circle at 70% 80%, rgba(107, 179, 196, 0.2), transparent 60%);
+  opacity: 0.4;
   pointer-events: none;
-}
-
-.stage-tool-panel > * {
-  position: relative;
-  z-index: 1;
 }
 
 .stage-tool-panel--rig {
@@ -732,37 +732,29 @@ dl dt {
   color: var(--color-highlight);
 }
 
-.rig-panel__subtitle {
-  margin: 0;
-  font-size: 0.72rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.62);
-}
-
 .rig-panel__status {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0.35rem 0.9rem;
   border-radius: 999px;
-  border: 1px solid rgba(124, 200, 111, 0.35);
-  background: rgba(14, 36, 26, 0.65);
+  border: 1px solid rgba(158, 211, 106, 0.4);
+  background: rgba(16, 38, 26, 0.7);
   font-size: 0.72rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--color-highlight);
+  color: var(--color-accent);
   min-width: 0;
   white-space: nowrap;
 }
 
 .rig-panel__status[data-state='loading'] {
-  border-color: rgba(90, 169, 201, 0.55);
+  border-color: rgba(107, 179, 196, 0.55);
   color: var(--color-water);
 }
 
 .rig-panel__status[data-state='idle'] {
-  color: rgba(243, 248, 240, 0.7);
+  color: rgba(244, 248, 232, 0.7);
 }
 
 .rig-panel__content {
@@ -893,7 +885,7 @@ dl dt {
   pointer-events: none;
   z-index: 2;
   color: var(--color-text-primary);
-  background: linear-gradient(180deg, rgba(12, 32, 23, 0.28), rgba(12, 32, 23, 0));
+  background: linear-gradient(180deg, rgba(10, 28, 20, 0.38), rgba(10, 28, 20, 0));
   backdrop-filter: blur(1px);
 }
 
@@ -906,6 +898,11 @@ dl dt {
   pointer-events: none;
 }
 
+.viewport-ui__bottom {
+  justify-content: flex-end;
+  align-items: flex-end;
+}
+
 .viewport-status {
   pointer-events: auto;
   display: inline-flex;
@@ -913,14 +910,14 @@ dl dt {
   gap: 0.75rem;
   padding: 0.75rem 1.15rem;
   border-radius: 16px;
-  border: 1px solid rgba(124, 200, 111, 0.32);
-  background: linear-gradient(135deg, rgba(20, 52, 37, 0.82), rgba(18, 47, 58, 0.65));
-  box-shadow: 0 16px 32px rgba(8, 20, 14, 0.45);
+  border: 1px solid rgba(158, 211, 106, 0.4);
+  background: linear-gradient(135deg, rgba(18, 44, 31, 0.85), rgba(18, 44, 50, 0.68));
+  box-shadow: 0 16px 34px rgba(8, 22, 14, 0.48);
   transition: border-color 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
 }
 
 .viewport-status.is-pulsing {
-  box-shadow: 0 0 0 0 rgba(124, 200, 111, 0.45), 0 16px 42px rgba(8, 20, 14, 0.5);
+  box-shadow: 0 0 0 0 rgba(158, 211, 106, 0.45), 0 16px 42px rgba(8, 22, 14, 0.5);
   animation: viewport-status-pulse 0.9s ease;
 }
 
@@ -928,8 +925,8 @@ dl dt {
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  border: 2px solid rgba(124, 200, 111, 0.35);
-  border-top-color: rgba(124, 200, 111, 0.95);
+  border: 2px solid rgba(158, 211, 106, 0.35);
+  border-top-color: rgba(158, 211, 106, 0.95);
   opacity: 0.2;
   transform: scale(0.85);
   transition: opacity 0.2s ease, transform 0.2s ease, border-color 0.3s ease,
@@ -948,74 +945,29 @@ dl dt {
 }
 
 .viewport-status[data-state='ready'] {
-  border-color: rgba(124, 200, 111, 0.6);
-  background: linear-gradient(135deg, rgba(22, 56, 40, 0.9), rgba(30, 70, 52, 0.75));
+  border-color: rgba(158, 211, 106, 0.65);
+  background: linear-gradient(135deg, rgba(22, 58, 40, 0.92), rgba(32, 74, 52, 0.78));
 }
 
 .viewport-status[data-state='ready'] .viewport-status__indicator {
   opacity: 1;
   animation: none;
   border: none;
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.95), rgba(211, 243, 107, 0.95));
-  box-shadow: 0 0 10px rgba(211, 243, 107, 0.6);
+  background: linear-gradient(135deg, rgba(158, 211, 106, 0.95), rgba(241, 248, 210, 0.95));
+  box-shadow: 0 0 10px rgba(241, 248, 210, 0.55);
 }
 
 .viewport-status[data-state='empty'] {
-  border-color: rgba(229, 132, 96, 0.6);
-  background: linear-gradient(135deg, rgba(52, 26, 22, 0.82), rgba(52, 34, 27, 0.68));
+  border-color: rgba(193, 132, 63, 0.65);
+  background: linear-gradient(135deg, rgba(60, 32, 20, 0.82), rgba(54, 38, 24, 0.7));
 }
 
 .viewport-status[data-state='empty'] .viewport-status__indicator {
   opacity: 1;
   animation: none;
   border: none;
-  background: linear-gradient(135deg, rgba(229, 132, 96, 0.9), rgba(255, 196, 132, 0.9));
-  box-shadow: 0 0 10px rgba(229, 132, 96, 0.6);
-}
-
-.viewport-instructions {
-  pointer-events: auto;
-  padding: 1rem 1.25rem;
-  border-radius: 18px;
-  border: 1px solid rgba(124, 200, 111, 0.28);
-  background: linear-gradient(160deg, rgba(16, 40, 29, 0.82), rgba(16, 37, 47, 0.78));
-  box-shadow: 0 18px 30px rgba(8, 20, 14, 0.35);
-  max-width: 240px;
-}
-
-.viewport-instructions__title {
-  margin: 0 0 0.65rem;
-  font-family: var(--font-display);
-  font-size: 0.95rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--color-highlight);
-}
-
-.viewport-instructions__list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.4rem;
-  font-size: 0.82rem;
-  letter-spacing: 0.05em;
-  color: rgba(243, 248, 240, 0.82);
-}
-
-.viewport-instructions__list span {
-  display: inline-block;
-  min-width: 88px;
-  padding: 0.15rem 0.45rem;
-  border-radius: 999px;
-  margin-right: 0.4rem;
-  background: rgba(124, 200, 111, 0.2);
-  border: 1px solid rgba(124, 200, 111, 0.45);
-  color: var(--color-highlight);
-  font-family: var(--font-display);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.72rem;
+  background: linear-gradient(135deg, rgba(193, 132, 63, 0.9), rgba(240, 188, 120, 0.9));
+  box-shadow: 0 0 10px rgba(240, 188, 120, 0.55);
 }
 
 .viewport-controls {
@@ -1028,10 +980,10 @@ dl dt {
 }
 
 .viewport-button {
-  border: 1px solid rgba(124, 200, 111, 0.35);
+  border: 1px solid rgba(158, 211, 106, 0.35);
   border-radius: 999px;
   padding: 0.55rem 1.35rem;
-  background: rgba(12, 31, 23, 0.68);
+  background: rgba(15, 36, 26, 0.7);
   color: var(--color-text-primary);
   font-family: var(--font-display);
   letter-spacing: 0.14em;
@@ -1045,8 +997,8 @@ dl dt {
 .viewport-button:hover,
 .viewport-button:focus-visible {
   transform: translateY(-1px);
-  border-color: rgba(124, 200, 111, 0.65);
-  box-shadow: 0 16px 32px rgba(10, 28, 20, 0.45);
+  border-color: rgba(158, 211, 106, 0.65);
+  box-shadow: 0 16px 32px rgba(10, 30, 21, 0.45);
   outline: none;
 }
 
@@ -1056,8 +1008,8 @@ dl dt {
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
-  border-color: rgba(124, 200, 111, 0.18);
-  background: rgba(12, 31, 23, 0.45);
+  border-color: rgba(158, 211, 106, 0.18);
+  background: rgba(15, 36, 26, 0.45);
 }
 
 .viewport-button.is-disabled:hover,
@@ -1066,19 +1018,19 @@ dl dt {
 .viewport-button:disabled:focus-visible {
   transform: none;
   box-shadow: none;
-  border-color: rgba(124, 200, 111, 0.18);
+  border-color: rgba(158, 211, 106, 0.18);
 }
 
 .viewport-button--toggle.is-active {
-  background: linear-gradient(135deg, rgba(124, 200, 111, 0.95), rgba(211, 243, 107, 0.95));
+  background: linear-gradient(135deg, rgba(158, 211, 106, 0.95), rgba(241, 248, 210, 0.95));
   color: #0c1c14;
-  border-color: rgba(124, 200, 111, 0.85);
+  border-color: rgba(158, 211, 106, 0.85);
   box-shadow: 0 18px 32px rgba(14, 36, 26, 0.55);
 }
 
 .viewport-button--toggle.is-active:hover,
 .viewport-button--toggle.is-active:focus-visible {
-  border-color: rgba(124, 200, 111, 0.9);
+  border-color: rgba(158, 211, 106, 0.9);
 }
 
 @keyframes viewport-status-spin {
@@ -1092,81 +1044,14 @@ dl dt {
 
 @keyframes viewport-status-pulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(124, 200, 111, 0.55);
+    box-shadow: 0 0 0 0 rgba(158, 211, 106, 0.55);
   }
   70% {
-    box-shadow: 0 0 0 12px rgba(124, 200, 111, 0);
+    box-shadow: 0 0 0 12px rgba(158, 211, 106, 0);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(124, 200, 111, 0);
+    box-shadow: 0 0 0 0 rgba(158, 211, 106, 0);
   }
-}
-
-.animation-selector {
-  display: grid;
-  gap: 0.6rem;
-}
-
-.animation-selector__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.95rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.9);
-}
-
-.animation-selector__label {
-  font-family: var(--font-display);
-  color: var(--color-highlight);
-}
-
-.animation-selector__name {
-  font-family: var(--font-display);
-  color: var(--color-text-primary);
-}
-
-.animation-selector__control {
-  display: grid;
-  gap: 0.35rem;
-  font-size: 0.85rem;
-  color: var(--color-text-secondary);
-}
-
-.animation-selector__control span {
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-weight: 600;
-}
-
-.animation-selector__control select {
-  appearance: none;
-  padding: 0.75rem 0.9rem;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(33, 70, 51, 0.65);
-  color: var(--color-text-primary);
-  font-family: var(--font-display);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.animation-selector__control select:focus-visible {
-  border-color: rgba(124, 200, 111, 0.7);
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(124, 200, 111, 0.25);
-}
-
-.animation-selector__hint {
-  margin: 0;
-  font-size: 0.75rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(243, 248, 240, 0.6);
-}
 }
 
 @media (max-width: 1400px) {
@@ -1217,10 +1102,6 @@ dl dt {
 
   .viewport-ui {
     padding: 1.25rem 1.4rem;
-  }
-
-  .viewport-instructions {
-    max-width: none;
   }
 
   .viewport-controls {
@@ -1290,11 +1171,6 @@ dl dt {
     padding: 1.1rem 1.3rem;
   }
 
-  .viewport-ui__bottom {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
   .viewport-controls {
     justify-content: flex-start;
   }
@@ -1321,7 +1197,4 @@ dl dt {
     padding: 1rem 1.1rem;
   }
 
-  .viewport-instructions__list span {
-    min-width: auto;
-  }
 }


### PR DESCRIPTION
## Summary
- remove the animation selector panel and automatically load each critter's default animation
- streamline the rig control header messaging and hide redundant list footer text
- refresh the HUD, stage, and viewport styling with a higher-contrast natural palette

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cce40d18508329bbfe2ea22edc8392