### PR TITLE
Move area effect tags from fire mode to damage display

### DIFF
--- a/src/data/weaponSchema.js
+++ b/src/data/weaponSchema.js
@@ -80,6 +80,41 @@ export const deriveStatsList = (weapon) => {
     value !== null && value !== undefined && value !== ''
   );
 
+  const fireModeEntry = entries.find(([key]) => key === 'fireMode');
+  const damageEntry = entries.find(([key]) => key === 'damage');
+
+  if (fireModeEntry && typeof fireModeEntry[1] === 'string') {
+    const fireModeValue = fireModeEntry[1].trim();
+    const areaMatch = fireModeValue.match(/\b(Splash|AOE)\s*$/i);
+
+    if (areaMatch) {
+      const areaTag = areaMatch[1];
+      const baseFireMode = fireModeValue.replace(areaMatch[0], '').trim();
+
+      if (baseFireMode) {
+        fireModeEntry[1] = baseFireMode;
+      }
+
+      if (damageEntry && typeof damageEntry[1] === 'string') {
+        const damageValue = damageEntry[1].trim();
+        const hasAreaAlready = new RegExp(`\\b${areaTag}\\b`, 'i').test(damageValue);
+
+        if (!hasAreaAlready) {
+          const numericOnly = /^\d+(\.\d+)?$/.test(damageValue);
+          const endsWithDamage = /damage$/i.test(damageValue);
+
+          if (endsWithDamage) {
+            damageEntry[1] = damageValue.replace(/damage$/i, `${areaTag} damage`).trim();
+          } else if (numericOnly) {
+            damageEntry[1] = `${damageValue} ${areaTag} damage`;
+          } else {
+            damageEntry[1] = `${damageValue} ${areaTag}`;
+          }
+        }
+      }
+    }
+  }
+
   entries.sort((a, b) => {
     const indexA = DEFAULT_STATS_ORDER.indexOf(a[0]);
     const indexB = DEFAULT_STATS_ORDER.indexOf(b[0]);


### PR DESCRIPTION
## Summary
- shift Splash/AOE suffixes from fire mode stats to the damage stat when deriving weapon details
- keep fire mode labels clean while appending area tags to numeric and descriptive damage values appropriately

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cce6f845ac832986bc2b97c845cb62