### PR TITLE
Update weapon damage labels and simplify viewport overlay

### DIFF
--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -50,7 +50,7 @@ const RAW_WEAPONS = [
     category: 'primary',
     description: 'Heavy launcher delivering high splash damage.',
     stats: {
-      damage: '100',
+      damage: '100 Splash',
       fireMode: 'Manual',
       rpm: '50',
       ammo: '1/6',
@@ -175,7 +175,7 @@ const RAW_WEAPONS = [
     category: 'secondary',
     description: 'Close-range burner that drenches foes in flame.',
     stats: {
-      damage: 'Fire (10/s for 3s) AOE damage',
+      damage: 'Fire AOE',
       fireMode: 'Full-Auto',
       rpm: '1000',
       overheat: '2/100',

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -39,41 +39,16 @@ export class ViewportOverlay {
   build() {
     this.root = document.createElement('div');
     this.root.className = 'viewport-ui';
-    this.root.innerHTML = `
-      <div class="viewport-ui__top">
-        <div class="viewport-status" data-role="viewport-status" data-state="idle">
-          <span class="viewport-status__indicator" data-role="viewport-status-indicator"></span>
-          <span class="viewport-status__text" data-role="viewport-status-text"></span>
-        </div>
-      </div>
-      <div class="viewport-ui__bottom">
-        <div class="viewport-controls-panel">
-          <div class="viewport-controls" role="group" aria-label="Viewport controls">
-            <button type="button" class="viewport-button" data-action="focus">Focus Model</button>
-            <button type="button" class="viewport-button" data-action="reset">Reset View</button>
-            <button type="button" class="viewport-button" data-action="reset-pose">Reset Pose</button>
-            <button type="button" class="viewport-button" data-action="refresh">Refresh Critter</button>
-            <button
-              type="button"
-              class="viewport-button viewport-button--toggle"
-              data-action="autorotate"
-              aria-pressed="false"
-            >
-              Auto Orbit
-            </button>
-          </div>
-        </div>
-      </div>
-    `;
+    this.root.innerHTML = '';
 
     this.container.appendChild(this.root);
-    this.statusElement = this.root.querySelector('[data-role="viewport-status"]');
-    this.statusText = this.root.querySelector('[data-role="viewport-status-text"]');
-    this.autoRotateButton = this.root.querySelector('[data-action="autorotate"]');
-    this.focusButton = this.root.querySelector('[data-action="focus"]');
-    this.resetButton = this.root.querySelector('[data-action="reset"]');
-    this.resetPoseButton = this.root.querySelector('[data-action="reset-pose"]');
-    this.refreshButton = this.root.querySelector('[data-action="refresh"]');
+    this.statusElement = null;
+    this.statusText = null;
+    this.autoRotateButton = null;
+    this.focusButton = null;
+    this.resetButton = null;
+    this.resetPoseButton = null;
+    this.refreshButton = null;
   }
 
   bindControls() {


### PR DESCRIPTION
## Summary
- update the rocket launcher and flamethrower damage labels to match the requested wording
- strip the viewport overlay markup so the camera tips box and animation controls disappear

## Testing
- Not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68ccedbaf1808329981ce59d2375bf13