### PR TITLE
Update weapon damage text and simplify viewport overlay

### DIFF
--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -50,7 +50,7 @@ const RAW_WEAPONS = [
     category: 'primary',
     description: 'Heavy launcher delivering high splash damage.',
     stats: {
-      damage: '100',
+      damage: '100 Splash',
       fireMode: 'Manual',
       rpm: '50',
       ammo: '1/6',
@@ -175,7 +175,7 @@ const RAW_WEAPONS = [
     category: 'secondary',
     description: 'Close-range burner that drenches foes in flame.',
     stats: {
-      damage: 'Fire (10/s for 3s) AOE damage',
+      damage: 'Fire AOE',
       fireMode: 'Full-Auto',
       rpm: '1000',
       overheat: '2/100',

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -40,12 +40,6 @@ export class ViewportOverlay {
     this.root = document.createElement('div');
     this.root.className = 'viewport-ui';
     this.root.innerHTML = `
-      <div class="viewport-ui__top">
-        <div class="viewport-status" data-role="viewport-status" data-state="idle">
-          <span class="viewport-status__indicator" data-role="viewport-status-indicator"></span>
-          <span class="viewport-status__text" data-role="viewport-status-text"></span>
-        </div>
-      </div>
       <div class="viewport-ui__bottom">
         <div class="viewport-controls-panel">
           <div class="viewport-controls" role="group" aria-label="Viewport controls">
@@ -67,8 +61,8 @@ export class ViewportOverlay {
     `;
 
     this.container.appendChild(this.root);
-    this.statusElement = this.root.querySelector('[data-role="viewport-status"]');
-    this.statusText = this.root.querySelector('[data-role="viewport-status-text"]');
+    this.statusElement = null;
+    this.statusText = null;
     this.autoRotateButton = this.root.querySelector('[data-action="autorotate"]');
     this.focusButton = this.root.querySelector('[data-action="focus"]');
     this.resetButton = this.root.querySelector('[data-action="reset"]');

--- a/styles/main.css
+++ b/styles/main.css
@@ -875,7 +875,7 @@ dl dt {
   inset: 0;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-end;
   padding: 1.5rem 1.75rem;
   pointer-events: none;
   z-index: 2;


### PR DESCRIPTION
## Summary
- update Rocket Launcher and Flamethrower damage strings to match the requested descriptions
- remove the viewport status banner so the camera tips box no longer appears and keep the control bar anchored to the bottom

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccedbaf1808329981ce59d2375bf13