### PR TITLE
Update pose control status text and splash weapon labels

### DIFF
--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -95,7 +95,7 @@ const RAW_WEAPONS = [
     category: 'primary',
     description: 'Channelled staff that spits arcane splash bolts.',
     stats: {
-      damage: '10 Splash damage',
+      damage: '10 Splash',
       fireMode: 'Full-Auto',
       rpm: '120',
       ammoOverheat: '10/100',
@@ -141,7 +141,7 @@ const RAW_WEAPONS = [
     category: 'secondary',
     description: 'Burst sidearm that saturates tight spaces.',
     stats: {
-      damage: '10 Splash damage',
+      damage: '10 Splash',
       fireMode: 'Semi-Auto',
       rpm: '300',
       ammo: '8/16',
@@ -158,7 +158,7 @@ const RAW_WEAPONS = [
     category: 'secondary',
     description: 'Full-auto wand that bathes targets in fae energy.',
     stats: {
-      damage: '15 Splash damage',
+      damage: '15 Splash',
       fireMode: 'Full-Auto',
       rpm: '120',
       overheat: '20/100',

--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -55,7 +55,7 @@ export class RigControlPanel {
       this.bus.on('stage:model-ready', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(false, `${payload?.name ?? 'Rig'} ready for tuning.`);
+          this.setLoading(false, 'Rig ready.');
         }
       }),
       this.bus.on('stage:model-missing', (payload) => {


### PR DESCRIPTION
## Summary
- replace the pose control ready status message with a neutral "Rig ready." text
- standardize splash weapon damage labels to omit the redundant "damage" suffix

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ce1611f4648329ba6089ea4e652267