### PR TITLE
Add weapon tooltips and streamline bottle stats

### DIFF
--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -59,7 +59,7 @@ const RAW_WEAPONS = [
       range: '300cm',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: true,
     },
   },
   {
@@ -104,7 +104,7 @@ const RAW_WEAPONS = [
       range: '100cm',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: true,
     },
   },
 
@@ -150,7 +150,7 @@ const RAW_WEAPONS = [
       range: '100cm',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: true,
     },
   },
   {
@@ -167,7 +167,7 @@ const RAW_WEAPONS = [
       range: '100cm',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: true,
     },
   },
   {
@@ -184,7 +184,7 @@ const RAW_WEAPONS = [
       range: '10cm',
     },
     special: {
-      burnProfile: 'Ignites targets for 3 seconds dealing 10 damage per second.',
+      burnProfile: 'Fire',
     },
   },
 
@@ -274,7 +274,7 @@ const RAW_WEAPONS = [
       abilityCooldown: '10s',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: true,
     },
   },
   {
@@ -305,7 +305,7 @@ const RAW_WEAPONS = [
       info: 'Grenades Push Enemies & Self Back; Grenades Cannot be Cooked',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: true,
     },
   },
   {
@@ -357,7 +357,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Volatile gas bomb for area denial.',
     stats: {
-      damage: 'Gas (5/s for 5s)',
+      damage: 'Gas AOE',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -369,7 +369,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Ignites ground targets with lingering flames.',
     stats: {
-      damage: 'Fire (10/s for 3s)',
+      damage: 'Fire AOE',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -381,7 +381,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Crackling vial that paralyzes anything within.',
     stats: {
-      effect: 'Lightning (Paralyzes Enemy Units for 0.5s every 1s)',
+      effect: 'Field of Lightning',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -393,7 +393,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Chilling vial that strips traction from the ground.',
     stats: {
-      effect: 'Ice (All Units Have 50% Less Friction)',
+      effect: 'Sheet of Ice',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -405,10 +405,10 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Compressed gust that shoves everything outward.',
     stats: {
+      effect: 'Blast of Air',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
-      info: 'Create a Blast of Air that Pushes Enemies & Self Away',
     },
     special: {
       knockback: 'Knockback strength follows 100%/50%/25% falloff from the impact center.',

--- a/src/hud/components/WeaponDetailPanel.js
+++ b/src/hud/components/WeaponDetailPanel.js
@@ -1,4 +1,5 @@
 import { deriveStatsList } from '../../data/weaponSchema.js';
+import { applyTooltips } from '../../utils/tooltips.js';
 
 const RARITY_TITLES = {
   common: 'Common',
@@ -8,6 +9,8 @@ const RARITY_TITLES = {
   legendary: 'Legendary',
   mythic: 'Mythic',
 };
+
+const withTooltips = (content) => applyTooltips(content);
 
 const buildStatsMarkup = (weapon) => {
   if (!weapon) {
@@ -20,7 +23,11 @@ const buildStatsMarkup = (weapon) => {
   }
 
   const rows = stats
-    .map(({ label, value }) => `<dt>${label}</dt><dd>${value}</dd>`)
+    .map(({ label, value }) => {
+      const labelMarkup = withTooltips(label);
+      const valueMarkup = withTooltips(value);
+      return `<dt>${labelMarkup}</dt><dd>${valueMarkup}</dd>`;
+    })
     .join('');
 
   return `<dl class="stat-list">${rows}</dl>`;
@@ -36,7 +43,22 @@ const buildSpecialMarkup = (weapon, prettify) => {
   }
 
   const items = entries
-    .map(([key, value]) => `<li><span class="special-key">${prettify(key)}:</span> ${value}</li>`)
+    .map(([key, value]) => {
+      const label = prettify(key);
+      const labelMarkup = `<span class="special-key">${withTooltips(label)}</span>`;
+
+      const stringValue = typeof value === 'string' ? value.trim() : '';
+      const hasStandaloneValue =
+        value === true ||
+        (stringValue && stringValue.toLowerCase() === label.toLowerCase());
+
+      if (hasStandaloneValue) {
+        return `<li>${labelMarkup}</li>`;
+      }
+
+      const valueMarkup = withTooltips(stringValue || value);
+      return `<li>${labelMarkup}: ${valueMarkup}</li>`;
+    })
     .join('');
 
   return `

--- a/src/utils/tooltips.js
+++ b/src/utils/tooltips.js
@@ -1,0 +1,53 @@
+const TOOLTIP_DEFINITIONS = {
+  splash: 'Damage is highest at the point of impact, and falls off sharply the further away from the impact it is',
+  aoe: 'There is an Area of Effect (a defined zone or radius) applying whatever damage or effects.',
+  fire: 'Ignites targets for 3 seconds dealing 10 damage per second. Gas can be lit by fire.',
+  rpm: 'Rounds per Minute',
+  overheat:
+    "Weapons that have Overheat do not use Ammo, instead they are limited by a heat meter that rises with each shot fired and dissipates between shots. X/Y means that each shot costs X, and Y is the max of the heat meter. When a weapon overheats, it must wait until it's at 0/Y to fire again.",
+  gas: 'Gas deals 5 damage for 5 seconds. Gas can be lit by fire.',
+  lightning: 'Paralyzes Enemy Units for 0.5s every 1s',
+  ice: 'All Units Have 50% Less Friction',
+};
+
+const escapeForAttribute = (value) =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+const escapeForRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const TOOLTIP_PATTERN = new RegExp(
+  `\\b(${Object.keys(TOOLTIP_DEFINITIONS)
+    .map(escapeForRegex)
+    .join('|')})\\b`,
+  'gi'
+);
+
+const annotateWord = (word) => {
+  const tooltip = TOOLTIP_DEFINITIONS[word.toLowerCase()];
+  if (!tooltip) {
+    return word;
+  }
+
+  const escapedTooltip = escapeForAttribute(tooltip);
+  return `<span class="has-tooltip" tabindex="0" data-tooltip="${escapedTooltip}">${word}</span>`;
+};
+
+export const applyTooltips = (content) => {
+  if (content === null || content === undefined) {
+    return '';
+  }
+
+  const text = String(content);
+
+  if (!text.trim()) {
+    return text;
+  }
+
+  return text.replace(TOOLTIP_PATTERN, annotateWord);
+};
+

--- a/styles/main.css
+++ b/styles/main.css
@@ -527,6 +527,55 @@ dl dt {
   font-weight: 600;
 }
 
+.has-tooltip {
+  position: relative;
+  cursor: help;
+  text-decoration: underline dotted;
+}
+
+.has-tooltip::after,
+.has-tooltip::before {
+  position: absolute;
+  left: 50%;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 10;
+}
+
+.has-tooltip::after {
+  content: attr(data-tooltip);
+  bottom: 125%;
+  transform: translate(-50%, -0.4rem);
+  background: rgba(6, 19, 13, 0.94);
+  color: var(--color-text-primary);
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  box-shadow: 0 10px 25px rgba(6, 19, 13, 0.55);
+  max-width: 220px;
+  width: max-content;
+  text-align: center;
+  line-height: 1.4;
+  white-space: normal;
+}
+
+.has-tooltip::before {
+  content: '';
+  bottom: 115%;
+  transform: translate(-50%, 0);
+  border-width: 6px;
+  border-style: solid;
+  border-color: rgba(6, 19, 13, 0.94) transparent transparent transparent;
+}
+
+.has-tooltip:hover::after,
+.has-tooltip:hover::before,
+.has-tooltip:focus::after,
+.has-tooltip:focus::before {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 .panel-footer {
   font-size: 0.78rem;
   letter-spacing: 0.14em;


### PR DESCRIPTION
## Summary
- add a tooltip utility and integrate it into the weapon detail panel
- style tooltip hover/focus states to surface mechanic explanations
- simplify splash specials and update bottle damage/effect strings

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce1c68cd648329b0781a20fcb89969