### PR TITLE
Add keyword tooltips for stats and adjust bottle copy

### DIFF
--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -58,9 +58,6 @@ const RAW_WEAPONS = [
       drawSpeed: '0.5s',
       range: '300cm',
     },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
-    },
   },
   {
     name: 'Bow',
@@ -102,9 +99,6 @@ const RAW_WEAPONS = [
       cooldown: '2s',
       drawSpeed: '0.5s',
       range: '100cm',
-    },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
     },
   },
 
@@ -149,9 +143,6 @@ const RAW_WEAPONS = [
       drawSpeed: '0.2s',
       range: '100cm',
     },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
-    },
   },
   {
     name: 'Fey Wand',
@@ -165,9 +156,6 @@ const RAW_WEAPONS = [
       cooldown: '3s',
       drawSpeed: '0.1s',
       range: '100cm',
-    },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
     },
   },
   {
@@ -273,9 +261,6 @@ const RAW_WEAPONS = [
       ability: 'Ground Pound: Swing the Warhammer at the Ground',
       abilityCooldown: '10s',
     },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
-    },
   },
   {
     name: 'Bo Staff',
@@ -303,9 +288,6 @@ const RAW_WEAPONS = [
       capacity: '2',
       range: '50cm',
       info: 'Grenades Push Enemies & Self Back; Grenades Cannot be Cooked',
-    },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
     },
   },
   {
@@ -357,7 +339,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Volatile gas bomb for area denial.',
     stats: {
-      damage: 'Gas (5/s for 5s)',
+      damage: 'Gas AOE',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -369,7 +351,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Ignites ground targets with lingering flames.',
     stats: {
-      damage: 'Fire (10/s for 3s)',
+      damage: 'Fire AOE',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -381,7 +363,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Crackling vial that paralyzes anything within.',
     stats: {
-      effect: 'Lightning (Paralyzes Enemy Units for 0.5s every 1s)',
+      effect: 'Field of Lightning',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -393,7 +375,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Chilling vial that strips traction from the ground.',
     stats: {
-      effect: 'Ice (All Units Have 50% Less Friction)',
+      effect: 'Sheet of of Ice',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -405,6 +387,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Compressed gust that shoves everything outward.',
     stats: {
+      effect: 'Blast of Air',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',

--- a/src/hud/components/WeaponDetailPanel.js
+++ b/src/hud/components/WeaponDetailPanel.js
@@ -1,4 +1,5 @@
 import { deriveStatsList } from '../../data/weaponSchema.js';
+import { applyKeywordTooltips } from '../../utils/keywordTooltips.js';
 
 const RARITY_TITLES = {
   common: 'Common',
@@ -9,7 +10,7 @@ const RARITY_TITLES = {
   mythic: 'Mythic',
 };
 
-const buildStatsMarkup = (weapon) => {
+const buildStatsMarkup = (weapon, decorate = (value) => value) => {
   if (!weapon) {
     return '';
   }
@@ -20,13 +21,13 @@ const buildStatsMarkup = (weapon) => {
   }
 
   const rows = stats
-    .map(({ label, value }) => `<dt>${label}</dt><dd>${value}</dd>`)
+    .map(({ label, value }) => `<dt>${decorate(label)}</dt><dd>${decorate(value)}</dd>`)
     .join('');
 
   return `<dl class="stat-list">${rows}</dl>`;
 };
 
-const buildSpecialMarkup = (weapon, prettify) => {
+const buildSpecialMarkup = (weapon, prettify, decorate = (value) => value) => {
   const entries = Object.entries(weapon.special || {}).filter(([, value]) =>
     value !== null && value !== undefined && value !== ''
   );
@@ -36,7 +37,10 @@ const buildSpecialMarkup = (weapon, prettify) => {
   }
 
   const items = entries
-    .map(([key, value]) => `<li><span class="special-key">${prettify(key)}:</span> ${value}</li>`)
+    .map(
+      ([key, value]) =>
+        `<li><span class="special-key">${decorate(prettify(key))}:</span> ${decorate(value)}</li>`
+    )
     .join('');
 
   return `
@@ -76,12 +80,13 @@ export class WeaponDetailPanel {
   }
 
   renderContent(weapon) {
-    const statsMarkup = buildStatsMarkup(weapon);
-    const specialMarkup = buildSpecialMarkup(weapon, (value) => this.prettify(value));
+    const decorate = (value) => applyKeywordTooltips(value);
+    const statsMarkup = buildStatsMarkup(weapon, decorate);
+    const specialMarkup = buildSpecialMarkup(weapon, (value) => this.prettify(value), decorate);
 
     this.contentElement.innerHTML = `
       <h3>${weapon.name}</h3>
-      <p class="description">${weapon.description}</p>
+      <p class="description">${decorate(weapon.description)}</p>
       ${statsMarkup}
       ${specialMarkup}
     `;

--- a/src/utils/keywordTooltips.js
+++ b/src/utils/keywordTooltips.js
@@ -1,0 +1,105 @@
+const TOOLTIP_DEFINITIONS = [
+  {
+    term: 'Splash',
+    description:
+      'Damage is highest at the point of impact, and falls off sharply the further away from the impact it is',
+  },
+  {
+    term: 'AOE',
+    description: 'There is an Area of Effect (a defined zone or radius) applying whatever damage or effects.',
+  },
+  {
+    term: 'Gas',
+    description: 'Gas deals 5 damage for 5 seconds. Gas can be lit by fire.',
+  },
+  {
+    term: 'Fire',
+    description:
+      'Ignites targets for 3 seconds dealing 10 damage per second. Gas can be lit by fire.',
+  },
+  {
+    term: 'RPM',
+    description: 'Rounds per Minute',
+  },
+  {
+    term: 'Overheat',
+    description:
+      'Weapons that have Overheat do not use Ammo, instead they are limited by a heat meter that rises with each shot fired and dissipates between shots. X/Y means that each shot costs X, and Y is the max of the heat meter. When a weapon overheats, it must wait until it\'s at 0/Y to fire again.',
+  },
+  {
+    term: 'Lightning',
+    description: 'Paralyzes Enemy Units for 0.5s every 1s',
+  },
+  {
+    term: 'Ice',
+    description: 'All Units Have 50% Less Friction',
+  },
+];
+
+const escapeAttribute = (value) =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+const buildTooltipMarkup = (label, description) => {
+  const escapedDescription = escapeAttribute(description);
+  return `<span class="tooltip" data-tooltip="${escapedDescription}" tabindex="0" aria-label="${escapedDescription}">${label}</span>`;
+};
+
+export const applyKeywordTooltips = (input) => {
+  if (input === null || input === undefined) {
+    return '';
+  }
+
+  const text = String(input);
+  const matches = [];
+
+  TOOLTIP_DEFINITIONS.forEach(({ term, description }) => {
+    const regex = new RegExp(`\\b${term}\\b`, 'gi');
+    let match;
+
+    while ((match = regex.exec(text)) !== null) {
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        replacement: buildTooltipMarkup(match[0], description),
+      });
+    }
+  });
+
+  if (!matches.length) {
+    return text;
+  }
+
+  matches.sort((a, b) => {
+    if (a.start === b.start) {
+      return b.end - a.end;
+    }
+    return a.start - b.start;
+  });
+
+  const filtered = [];
+  let lastEnd = -1;
+
+  matches.forEach((match) => {
+    if (match.start >= lastEnd) {
+      filtered.push(match);
+      lastEnd = match.end;
+    }
+  });
+
+  let cursor = 0;
+  let result = '';
+
+  filtered.forEach((match) => {
+    result += text.slice(cursor, match.start);
+    result += match.replacement;
+    cursor = match.end;
+  });
+
+  result += text.slice(cursor);
+  return result;
+};

--- a/styles/main.css
+++ b/styles/main.css
@@ -527,6 +527,62 @@ dl dt {
   font-weight: 600;
 }
 
+.tooltip {
+  position: relative;
+  cursor: help;
+  color: var(--color-highlight);
+  text-decoration: underline dotted rgba(240, 255, 150, 0.65);
+}
+
+.tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  inset: auto auto 125% 50%;
+  transform: translateX(-50%) translateY(4px);
+  min-width: 180px;
+  max-width: 260px;
+  padding: 0.5rem 0.65rem;
+  border-radius: 8px;
+  background: rgba(9, 27, 19, 0.92);
+  border: 1px solid rgba(210, 243, 220, 0.35);
+  color: var(--color-text-primary);
+  font-size: 0.75rem;
+  line-height: 1.45;
+  letter-spacing: 0.02em;
+  white-space: normal;
+  box-shadow: 0 10px 28px rgba(5, 15, 10, 0.55);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 140ms ease-out, transform 140ms ease-out;
+  z-index: 10;
+}
+
+.tooltip::before {
+  content: '';
+  position: absolute;
+  inset: auto auto 115% 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: rgba(9, 27, 19, 0.92) transparent transparent transparent;
+  opacity: 0;
+  transition: opacity 140ms ease-out;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.tooltip:hover::after,
+.tooltip:focus-visible::after,
+.tooltip:hover::before,
+.tooltip:focus-visible::before {
+  opacity: 1;
+}
+
+.tooltip:hover::after,
+.tooltip:focus-visible::after {
+  transform: translateX(-50%) translateY(0);
+}
+
 .panel-footer {
   font-size: 0.78rem;
   letter-spacing: 0.14em;


### PR DESCRIPTION
## Summary
- add a tooltip utility to decorate weapon stats, special properties, and descriptions with keyword explanations
- remove redundant splash special entries and update bottle damage/effect text per the new copy
- style the tooltip hover states to match the HUD theme

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce1c68cd648329b0781a20fcb89969