### PR TITLE
Add hover tooltips for weapon keywords

### DIFF
--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -58,9 +58,6 @@ const RAW_WEAPONS = [
       drawSpeed: '0.5s',
       range: '300cm',
     },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
-    },
   },
   {
     name: 'Bow',
@@ -102,9 +99,6 @@ const RAW_WEAPONS = [
       cooldown: '2s',
       drawSpeed: '0.5s',
       range: '100cm',
-    },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
     },
   },
 
@@ -149,9 +143,6 @@ const RAW_WEAPONS = [
       drawSpeed: '0.2s',
       range: '100cm',
     },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
-    },
   },
   {
     name: 'Fey Wand',
@@ -165,9 +156,6 @@ const RAW_WEAPONS = [
       cooldown: '3s',
       drawSpeed: '0.1s',
       range: '100cm',
-    },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
     },
   },
   {
@@ -273,9 +261,6 @@ const RAW_WEAPONS = [
       ability: 'Ground Pound: Swing the Warhammer at the Ground',
       abilityCooldown: '10s',
     },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
-    },
   },
   {
     name: 'Bo Staff',
@@ -303,9 +288,6 @@ const RAW_WEAPONS = [
       capacity: '2',
       range: '50cm',
       info: 'Grenades Push Enemies & Self Back; Grenades Cannot be Cooked',
-    },
-    special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
     },
   },
   {
@@ -357,7 +339,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Volatile gas bomb for area denial.',
     stats: {
-      damage: 'Gas (5/s for 5s)',
+      damage: 'Gas AOE',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -369,7 +351,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Ignites ground targets with lingering flames.',
     stats: {
-      damage: 'Fire (10/s for 3s)',
+      damage: 'Fire AOE',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -381,7 +363,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Crackling vial that paralyzes anything within.',
     stats: {
-      effect: 'Lightning (Paralyzes Enemy Units for 0.5s every 1s)',
+      effect: 'Field of Lightning',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -393,7 +375,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Chilling vial that strips traction from the ground.',
     stats: {
-      effect: 'Ice (All Units Have 50% Less Friction)',
+      effect: 'Sheet of Ice',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -405,6 +387,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Compressed gust that shoves everything outward.',
     stats: {
+      effect: 'Blast of Air',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',

--- a/styles/main.css
+++ b/styles/main.css
@@ -420,6 +420,21 @@ dl dt {
   color: var(--color-text-secondary);
 }
 
+.has-tooltip {
+  cursor: help;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: rgba(247, 255, 244, 0.65);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+}
+
+.has-tooltip:hover,
+.has-tooltip:focus-visible {
+  text-decoration-color: var(--color-highlight);
+  text-decoration-style: solid;
+}
+
 .stat-grid {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add shared tooltip handling for recurring weapon keywords and apply it to descriptions, stats, and specials
- style tooltip text to communicate hover affordance
- simplify bottle stats text and drop redundant splash special entries now covered by tooltips

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce1c68cd648329b0781a20fcb89969