### PR TITLE
Add keyword tooltips and update bottle stats

### DIFF
--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -59,7 +59,7 @@ const RAW_WEAPONS = [
       range: '300cm',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: 'Splash',
     },
   },
   {
@@ -104,7 +104,7 @@ const RAW_WEAPONS = [
       range: '100cm',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: 'Splash',
     },
   },
 
@@ -150,7 +150,7 @@ const RAW_WEAPONS = [
       range: '100cm',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: 'Splash',
     },
   },
   {
@@ -167,7 +167,7 @@ const RAW_WEAPONS = [
       range: '100cm',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: 'Splash',
     },
   },
   {
@@ -274,7 +274,7 @@ const RAW_WEAPONS = [
       abilityCooldown: '10s',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: 'Splash',
     },
   },
   {
@@ -305,7 +305,7 @@ const RAW_WEAPONS = [
       info: 'Grenades Push Enemies & Self Back; Grenades Cannot be Cooked',
     },
     special: {
-      splash: 'Splash damage drops to 50% in the inner ring and 25% in the outer ring.',
+      splash: 'Splash',
     },
   },
   {
@@ -357,7 +357,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Volatile gas bomb for area denial.',
     stats: {
-      damage: 'Gas (5/s for 5s)',
+      damage: 'Gas AOE',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -369,7 +369,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Ignites ground targets with lingering flames.',
     stats: {
-      damage: 'Fire (10/s for 3s)',
+      damage: 'Fire AOE',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -381,7 +381,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Crackling vial that paralyzes anything within.',
     stats: {
-      effect: 'Lightning (Paralyzes Enemy Units for 0.5s every 1s)',
+      effect: 'Field of Lightning',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -393,7 +393,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Chilling vial that strips traction from the ground.',
     stats: {
-      effect: 'Ice (All Units Have 50% Less Friction)',
+      effect: 'Sheet of Ice',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',
@@ -405,6 +405,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Compressed gust that shoves everything outward.',
     stats: {
+      effect: 'Blast of Air',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',

--- a/styles/main.css
+++ b/styles/main.css
@@ -200,6 +200,65 @@ body::after {
   opacity: 1;
 }
 
+.tooltip-trigger {
+  position: relative;
+  cursor: help;
+  color: inherit;
+  border-bottom: 1px dotted rgba(247, 255, 245, 0.5);
+  outline: none;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.tooltip-trigger:hover,
+.tooltip-trigger:focus-visible {
+  color: var(--color-highlight);
+  border-bottom-color: rgba(240, 255, 150, 0.75);
+}
+
+.tooltip-trigger::after,
+.tooltip-trigger::before {
+  position: absolute;
+  left: 50%;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  z-index: 20;
+}
+
+.tooltip-trigger::after {
+  content: attr(data-tooltip);
+  bottom: calc(100% + 0.55rem);
+  transform: translate(-50%, 0.2rem);
+  background: rgba(6, 19, 13, 0.92);
+  color: var(--color-text-primary);
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.6rem;
+  box-shadow: 0 18px 32px rgba(5, 15, 10, 0.55);
+  font-size: 0.75rem;
+  line-height: 1.25;
+  max-width: 260px;
+  width: max-content;
+  text-align: center;
+  white-space: normal;
+}
+
+.tooltip-trigger::before {
+  content: '';
+  bottom: calc(100% + 0.25rem);
+  transform: translate(-50%, 0.2rem);
+  border-width: 6px 6px 0 6px;
+  border-style: solid;
+  border-color: rgba(6, 19, 13, 0.92) transparent transparent transparent;
+}
+
+.tooltip-trigger:hover::after,
+.tooltip-trigger:hover::before,
+.tooltip-trigger:focus-visible::after,
+.tooltip-trigger:focus-visible::before {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 .critter-button.active {
   border-color: rgba(211, 243, 107, 0.75);
   color: var(--color-text-primary);


### PR DESCRIPTION
## Summary
- replace verbose splash descriptions with concise values and adjust bottle damage/effect strings
- add tooltip keyword definitions and enhance the weapon detail panel to decorate matching terms
- style tooltip triggers for hover and focus states

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce1c68cd648329b0781a20fcb89969