### PR TITLE
Add global tooltips and adjust layout per design updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crtiz Armory Display</title>
+    <title>Critz Library</title>
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -6,6 +6,7 @@ import { critters } from '../data/critters.js';
 import { CritterSelector } from '../hud/components/CritterSelector.js';
 import { ViewportOverlay } from '../hud/components/ViewportOverlay.js';
 import { RigControlPanel } from '../hud/components/RigControlPanel.js';
+import { installTooltipLayer } from '../utils/tooltipManager.js';
 
 export class WeaponDisplayApp {
   constructor(rootElement) {
@@ -31,6 +32,7 @@ export class WeaponDisplayApp {
 
   init() {
     const layout = this.buildLayout();
+    installTooltipLayer();
     this.indexWeapons();
     this.indexCritters();
     this.registerEventHandlers();

--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -55,7 +55,8 @@ export class RigControlPanel {
       this.bus.on('stage:model-ready', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(false, `${payload?.name ?? 'Rig'} ready for tuning.`);
+          this.setLoading(false);
+          this.setStatus('ready', '');
         }
       }),
       this.bus.on('stage:model-missing', (payload) => {

--- a/src/hud/components/WeaponDetailPanel.js
+++ b/src/hud/components/WeaponDetailPanel.js
@@ -1,5 +1,5 @@
 import { deriveStatsList } from '../../data/weaponSchema.js';
-import { applyKeywordTooltips } from '../../utils/keywordTooltips.js';
+import { applyKeywordTooltips, hasKeywordTooltip } from '../../utils/keywordTooltips.js';
 
 const RARITY_TITLES = {
   common: 'Common',
@@ -27,6 +27,22 @@ const buildStatsMarkup = (weapon, decorate = (value) => value) => {
   return `<dl class="stat-list">${rows}</dl>`;
 };
 
+const shouldDisplaySpecialValue = (label, value) => {
+  if (hasKeywordTooltip(label)) {
+    return false;
+  }
+
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === 'string' && value.trim() === '') {
+    return false;
+  }
+
+  return true;
+};
+
 const buildSpecialMarkup = (weapon, prettify, decorate = (value) => value) => {
   const entries = Object.entries(weapon.special || {}).filter(([, value]) =>
     value !== null && value !== undefined && value !== ''
@@ -38,8 +54,14 @@ const buildSpecialMarkup = (weapon, prettify, decorate = (value) => value) => {
 
   const items = entries
     .map(
-      ([key, value]) =>
-        `<li><span class="special-key">${decorate(prettify(key))}:</span> ${decorate(value)}</li>`
+      ([key, value]) => {
+        const label = prettify(key);
+        const decoratedLabel = decorate(label);
+        if (!shouldDisplaySpecialValue(label, value)) {
+          return `<li><span class="special-key">${decoratedLabel}</span></li>`;
+        }
+        return `<li><span class="special-key">${decoratedLabel}:</span> ${decorate(value)}</li>`;
+      }
     )
     .join('');
 

--- a/src/utils/keywordTooltips.js
+++ b/src/utils/keywordTooltips.js
@@ -36,6 +36,8 @@ const TOOLTIP_DEFINITIONS = [
   },
 ];
 
+const TOOLTIP_TERMS = new Set(TOOLTIP_DEFINITIONS.map(({ term }) => term.toLowerCase()));
+
 const escapeAttribute = (value) =>
   String(value)
     .replace(/&/g, '&amp;')
@@ -47,6 +49,16 @@ const escapeAttribute = (value) =>
 const buildTooltipMarkup = (label, description) => {
   const escapedDescription = escapeAttribute(description);
   return `<span class="tooltip" data-tooltip="${escapedDescription}" tabindex="0" aria-label="${escapedDescription}">${label}</span>`;
+};
+
+const shouldSkipMatch = (term, text, _start, end) => {
+  if (term.toLowerCase() === 'fire') {
+    const tail = text.slice(end, end + 5).toLowerCase();
+    if (tail.startsWith(' mode')) {
+      return true;
+    }
+  }
+  return false;
 };
 
 export const applyKeywordTooltips = (input) => {
@@ -62,6 +74,9 @@ export const applyKeywordTooltips = (input) => {
     let match;
 
     while ((match = regex.exec(text)) !== null) {
+      if (shouldSkipMatch(term, text, match.index, match.index + match[0].length)) {
+        continue;
+      }
       matches.push({
         start: match.index,
         end: match.index + match[0].length,
@@ -102,4 +117,11 @@ export const applyKeywordTooltips = (input) => {
 
   result += text.slice(cursor);
   return result;
+};
+
+export const hasKeywordTooltip = (term) => {
+  if (!term && term !== 0) {
+    return false;
+  }
+  return TOOLTIP_TERMS.has(String(term).toLowerCase());
 };

--- a/src/utils/tooltipManager.js
+++ b/src/utils/tooltipManager.js
@@ -1,0 +1,170 @@
+const TOOLTIP_MARGIN = 12;
+let tooltipRoot = null;
+let tooltipBubble = null;
+let tooltipArrow = null;
+let installed = false;
+let activeTarget = null;
+
+const ensureTooltipRoot = () => {
+  if (tooltipRoot) {
+    return;
+  }
+
+  tooltipRoot = document.createElement('div');
+  tooltipRoot.className = 'tooltip-layer';
+  tooltipRoot.setAttribute('role', 'tooltip');
+  tooltipRoot.hidden = true;
+
+  tooltipBubble = document.createElement('div');
+  tooltipBubble.className = 'tooltip-layer__bubble';
+
+  tooltipArrow = document.createElement('div');
+  tooltipArrow.className = 'tooltip-layer__arrow';
+
+  tooltipRoot.appendChild(tooltipBubble);
+  tooltipRoot.appendChild(tooltipArrow);
+  document.body.appendChild(tooltipRoot);
+};
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const positionTooltip = (target) => {
+  if (!tooltipRoot || !tooltipBubble || !tooltipArrow) {
+    return;
+  }
+
+  const description = target.getAttribute('data-tooltip');
+  if (!description) {
+    return;
+  }
+
+  tooltipBubble.textContent = description;
+  tooltipRoot.hidden = false;
+  tooltipRoot.classList.add('is-visible');
+
+  requestAnimationFrame(() => {
+    if (!tooltipRoot || tooltipRoot.hidden) {
+      return;
+    }
+
+    const targetRect = target.getBoundingClientRect();
+    const bubbleRect = tooltipBubble.getBoundingClientRect();
+    const viewportWidth = document.documentElement.clientWidth;
+    const viewportHeight = document.documentElement.clientHeight;
+
+    let top = targetRect.top - bubbleRect.height - TOOLTIP_MARGIN;
+    let placement = 'top';
+
+    if (top < TOOLTIP_MARGIN) {
+      top = targetRect.bottom + TOOLTIP_MARGIN;
+      placement = 'bottom';
+    }
+
+    top = clamp(top, TOOLTIP_MARGIN, viewportHeight - bubbleRect.height - TOOLTIP_MARGIN);
+
+    const idealCenter = targetRect.left + targetRect.width / 2;
+    let left = idealCenter - bubbleRect.width / 2;
+    left = clamp(left, TOOLTIP_MARGIN, viewportWidth - bubbleRect.width - TOOLTIP_MARGIN);
+
+    const arrowOffset = clamp(
+      idealCenter - left,
+      TOOLTIP_MARGIN,
+      bubbleRect.width - TOOLTIP_MARGIN
+    );
+
+    tooltipRoot.style.transform = `translate(${Math.round(left)}px, ${Math.round(top)}px)`;
+    tooltipRoot.dataset.placement = placement;
+    tooltipRoot.style.setProperty('--tooltip-arrow-offset', `${Math.round(arrowOffset)}px`);
+  });
+};
+
+const hideTooltip = () => {
+  if (!tooltipRoot) {
+    return;
+  }
+
+  tooltipRoot.classList.remove('is-visible');
+  tooltipRoot.hidden = true;
+  tooltipRoot.removeAttribute('data-placement');
+  activeTarget = null;
+};
+
+const handlePointerEnter = (event) => {
+  const target = event.target?.closest?.('[data-tooltip]');
+  if (!target || target === activeTarget) {
+    return;
+  }
+
+  activeTarget = target;
+  ensureTooltipRoot();
+  positionTooltip(target);
+};
+
+const handlePointerLeave = (event) => {
+  if (!activeTarget) {
+    return;
+  }
+
+  const target = event.target?.closest?.('[data-tooltip]');
+  if (!target || target !== activeTarget) {
+    return;
+  }
+
+  hideTooltip();
+};
+
+const handleFocusIn = (event) => {
+  const target = event.target?.closest?.('[data-tooltip]');
+  if (!target) {
+    return;
+  }
+
+  activeTarget = target;
+  ensureTooltipRoot();
+  positionTooltip(target);
+};
+
+const handleFocusOut = (event) => {
+  if (!activeTarget) {
+    return;
+  }
+
+  if (event.target === activeTarget) {
+    hideTooltip();
+  }
+};
+
+const handleScroll = () => {
+  if (activeTarget) {
+    hideTooltip();
+  }
+};
+
+const handleKeyDown = (event) => {
+  if (event.key === 'Escape') {
+    hideTooltip();
+  }
+};
+
+export const installTooltipLayer = () => {
+  if (installed) {
+    return;
+  }
+
+  installed = true;
+
+  document.addEventListener('pointerenter', handlePointerEnter, true);
+  document.addEventListener('pointerleave', handlePointerLeave, true);
+  document.addEventListener('focusin', handleFocusIn, true);
+  document.addEventListener('focusout', handleFocusOut, true);
+  window.addEventListener('scroll', handleScroll, true);
+  window.addEventListener('resize', handleScroll, true);
+  window.addEventListener('keydown', handleKeyDown, true);
+};
+
+export const forceTooltipReposition = () => {
+  if (!activeTarget) {
+    return;
+  }
+  positionTooltip(activeTarget);
+};

--- a/styles/main.css
+++ b/styles/main.css
@@ -73,7 +73,7 @@ body::after {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 200px 300px minmax(280px, 360px) minmax(520px, 1fr);
+  grid-template-columns: 200px 280px minmax(360px, 480px) minmax(380px, 0.95fr);
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1.5rem;
   padding: 2.25rem 2.75rem;
@@ -308,6 +308,7 @@ body::after {
 
 .hud-panel {
   min-height: 0;
+  overflow: visible;
 }
 
 .hud-list {
@@ -528,59 +529,62 @@ dl dt {
 }
 
 .tooltip {
-  position: relative;
   cursor: help;
   color: var(--color-highlight);
   text-decoration: underline dotted rgba(240, 255, 150, 0.65);
+  position: relative;
 }
 
-.tooltip::after {
-  content: attr(data-tooltip);
-  position: absolute;
-  inset: auto auto 125% 50%;
-  transform: translateX(-50%) translateY(4px);
-  min-width: 180px;
-  max-width: 260px;
-  padding: 0.5rem 0.65rem;
-  border-radius: 8px;
-  background: rgba(9, 27, 19, 0.92);
-  border: 1px solid rgba(210, 243, 220, 0.35);
-  color: var(--color-text-primary);
-  font-size: 0.75rem;
-  line-height: 1.45;
-  letter-spacing: 0.02em;
-  white-space: normal;
-  box-shadow: 0 10px 28px rgba(5, 15, 10, 0.55);
-  opacity: 0;
+.tooltip-layer {
+  position: fixed;
+  inset: 0;
+  width: max-content;
+  max-width: min(280px, calc(100vw - 24px));
+  transform: translate(-9999px, -9999px);
   pointer-events: none;
+  z-index: 9999;
   transition: opacity 140ms ease-out, transform 140ms ease-out;
-  z-index: 10;
-}
-
-.tooltip::before {
-  content: '';
-  position: absolute;
-  inset: auto auto 115% 50%;
-  transform: translateX(-50%);
-  border-width: 6px;
-  border-style: solid;
-  border-color: rgba(9, 27, 19, 0.92) transparent transparent transparent;
   opacity: 0;
-  transition: opacity 140ms ease-out;
-  pointer-events: none;
-  z-index: 10;
 }
 
-.tooltip:hover::after,
-.tooltip:focus-visible::after,
-.tooltip:hover::before,
-.tooltip:focus-visible::before {
+.tooltip-layer.is-visible {
   opacity: 1;
 }
 
-.tooltip:hover::after,
-.tooltip:focus-visible::after {
-  transform: translateX(-50%) translateY(0);
+.tooltip-layer__bubble {
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  background: rgba(9, 27, 19, 0.96);
+  border: 1px solid rgba(210, 243, 220, 0.4);
+  color: var(--color-text-primary);
+  font-size: 0.78rem;
+  line-height: 1.45;
+  letter-spacing: 0.02em;
+  box-shadow: 0 16px 32px rgba(5, 15, 10, 0.6);
+  white-space: normal;
+}
+
+.tooltip-layer__arrow {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: rgba(9, 27, 19, 0.96);
+  border-left: 1px solid rgba(210, 243, 220, 0.4);
+  border-top: 1px solid rgba(210, 243, 220, 0.4);
+  transform: translate(calc(var(--tooltip-arrow-offset, 0px) - 6px), 0) rotate(45deg);
+  top: 100%;
+  box-shadow: 0 12px 22px rgba(5, 15, 10, 0.45);
+}
+
+.tooltip-layer[data-placement='bottom'] .tooltip-layer__arrow {
+  top: auto;
+  bottom: 100%;
+  transform: translate(calc(var(--tooltip-arrow-offset, 0px) - 6px), 0) rotate(45deg);
+  border-left: none;
+  border-top: none;
+  border-right: 1px solid rgba(210, 243, 220, 0.4);
+  border-bottom: 1px solid rgba(210, 243, 220, 0.4);
+  box-shadow: 0 -12px 22px rgba(5, 15, 10, 0.45);
 }
 
 .panel-footer {
@@ -669,7 +673,7 @@ dl dt {
   grid-row: 1 / span 2;
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 280px);
   grid-template-rows: minmax(0, 1fr);
   background: linear-gradient(155deg, rgba(26, 60, 40, 0.96), rgba(17, 48, 59, 0.92));
   border: 1px solid rgba(107, 182, 207, 0.35);
@@ -703,7 +707,7 @@ dl dt {
   z-index: 1;
   grid-column: 2;
   grid-row: 1;
-  padding: 1.6rem 1.75rem 1.4rem;
+  padding: 1.25rem 1.35rem 1.1rem;
   display: flex;
   flex-direction: column;
   gap: 1.1rem;


### PR DESCRIPTION
## Summary
- rename the document title and update the HUD layout to give the equipment panel more space while shrinking the stage tools
- replace the pseudo-element tooltip approach with a global tooltip layer so keyword popovers sit above every surface and skip the Fire Mode label
- trim special property text when a tooltip exists and suppress the rig panel's "ready for tuning" status message

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce2812fc2483299391e69512492c48