### PR TITLE
Add overlay tooltips and refine equipment layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crtiz Armory Display</title>
+    <title>Critz Library</title>
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -125,8 +125,10 @@ export class WeaponDisplayApp {
             <span>Equipment Info</span>
             <span data-role="rarity-badge"></span>
           </div>
-          <div class="detail-content" data-role="detail-content">
-            <p class="description">Pick a tool to see its details.</p>
+          <div class="detail-content">
+            <div class="detail-scroll" data-role="detail-content">
+              <p class="description">Pick a tool to see its details.</p>
+            </div>
           </div>
           <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
         </section>

--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -172,7 +172,7 @@ const RAW_WEAPONS = [
       range: '10cm',
     },
     special: {
-      burnProfile: 'Ignites targets for 3 seconds dealing 10 damage per second.',
+      burnProfile: 'Fire',
     },
   },
 

--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -55,7 +55,8 @@ export class RigControlPanel {
       this.bus.on('stage:model-ready', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(false, `${payload?.name ?? 'Rig'} ready for tuning.`);
+          this.setLoading(false);
+          this.setStatus('ready', '');
         }
       }),
       this.bus.on('stage:model-missing', (payload) => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { WeaponDisplayApp } from './app/WeaponDisplayApp.js';
+import { initializeTooltipManager } from './utils/tooltipManager.js';
 
 const bootstrap = () => {
   const root = document.getElementById('app');
@@ -9,6 +10,7 @@ const bootstrap = () => {
 
   const app = new WeaponDisplayApp(root);
   app.init();
+  initializeTooltipManager();
 };
 
 document.addEventListener('DOMContentLoaded', bootstrap);

--- a/src/utils/keywordTooltips.js
+++ b/src/utils/keywordTooltips.js
@@ -16,6 +16,7 @@ const TOOLTIP_DEFINITIONS = [
     term: 'Fire',
     description:
       'Ignites targets for 3 seconds dealing 10 damage per second. Gas can be lit by fire.',
+    shouldSkip: ({ text, end }) => /^\s*mode\b/i.test(text.slice(end)),
   },
   {
     term: 'RPM',
@@ -57,14 +58,21 @@ export const applyKeywordTooltips = (input) => {
   const text = String(input);
   const matches = [];
 
-  TOOLTIP_DEFINITIONS.forEach(({ term, description }) => {
+  TOOLTIP_DEFINITIONS.forEach(({ term, description, shouldSkip }) => {
     const regex = new RegExp(`\\b${term}\\b`, 'gi');
     let match;
 
     while ((match = regex.exec(text)) !== null) {
+      const start = match.index;
+      const end = match.index + match[0].length;
+
+      if (typeof shouldSkip === 'function' && shouldSkip({ term, text, match, start, end })) {
+        continue;
+      }
+
       matches.push({
-        start: match.index,
-        end: match.index + match[0].length,
+        start,
+        end,
         replacement: buildTooltipMarkup(match[0], description),
       });
     }

--- a/src/utils/tooltipManager.js
+++ b/src/utils/tooltipManager.js
@@ -1,0 +1,204 @@
+const TOOLTIP_SELECTOR = '.tooltip[data-tooltip]';
+const VIEWPORT_MARGIN = 16;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const state = {
+  overlay: null,
+  activeTrigger: null,
+};
+
+let isInitialized = false;
+let pendingFrame = null;
+let decoder = null;
+
+const createOverlay = () => {
+  const root = document.createElement('div');
+  root.className = 'tooltip-overlay';
+  root.setAttribute('role', 'tooltip');
+  root.setAttribute('aria-hidden', 'true');
+  root.style.left = '0px';
+  root.style.top = '0px';
+
+  const bubble = document.createElement('div');
+  bubble.className = 'tooltip-overlay__bubble';
+  root.appendChild(bubble);
+
+  document.body.appendChild(root);
+  return { root, bubble };
+};
+
+const ensureOverlay = () => {
+  if (!state.overlay) {
+    state.overlay = createOverlay();
+  }
+  return state.overlay;
+};
+
+const decodeTooltip = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  if (typeof document === 'undefined') {
+    return value;
+  }
+
+  if (!decoder) {
+    decoder = document.createElement('div');
+  }
+
+  decoder.innerHTML = value;
+  return decoder.textContent || '';
+};
+
+const getDescription = (trigger) => {
+  if (!trigger) return '';
+  const raw = trigger.getAttribute('data-tooltip');
+  if (typeof raw !== 'string') {
+    return '';
+  }
+
+  return decodeTooltip(raw.trim());
+};
+
+const positionOverlay = (trigger) => {
+  if (!trigger || !state.overlay) {
+    return;
+  }
+
+  const { root, bubble } = state.overlay;
+  const rect = trigger.getBoundingClientRect();
+  const bubbleRect = bubble.getBoundingClientRect();
+  const viewportWidth = document.documentElement.clientWidth;
+  const viewportHeight = document.documentElement.clientHeight;
+  const bubbleWidth = bubbleRect.width;
+  const bubbleHeight = bubbleRect.height;
+
+  let centerX = rect.left + rect.width / 2;
+  const halfWidth = bubbleWidth / 2;
+  centerX = clamp(centerX, VIEWPORT_MARGIN + halfWidth, viewportWidth - VIEWPORT_MARGIN - halfWidth);
+
+  let placement = 'above';
+  let anchorY = rect.top;
+  const aboveSpace = rect.top;
+  const belowSpace = viewportHeight - rect.bottom;
+
+  if (aboveSpace < bubbleHeight + VIEWPORT_MARGIN && belowSpace > aboveSpace) {
+    placement = 'below';
+    anchorY = rect.bottom;
+  }
+
+  if (placement === 'below' && belowSpace < bubbleHeight + VIEWPORT_MARGIN) {
+    placement = 'above';
+    anchorY = rect.top;
+  }
+
+  root.style.left = `${Math.round(centerX)}px`;
+  root.style.top = `${Math.round(anchorY)}px`;
+  root.classList.toggle('is-below', placement === 'below');
+};
+
+const scheduleReposition = () => {
+  if (!state.activeTrigger) {
+    return;
+  }
+  if (pendingFrame) {
+    return;
+  }
+  pendingFrame = requestAnimationFrame(() => {
+    pendingFrame = null;
+    positionOverlay(state.activeTrigger);
+  });
+};
+
+const showTooltip = (trigger) => {
+  if (!trigger) {
+    return;
+  }
+
+  const description = getDescription(trigger);
+  if (!description) {
+    hideTooltip(trigger);
+    return;
+  }
+
+  const overlay = ensureOverlay();
+  overlay.bubble.textContent = description;
+  overlay.root.setAttribute('aria-hidden', 'false');
+  overlay.root.classList.add('is-active');
+  state.activeTrigger = trigger;
+  positionOverlay(trigger);
+  scheduleReposition();
+};
+
+const hideTooltip = (trigger) => {
+  if (state.activeTrigger && trigger && state.activeTrigger !== trigger) {
+    return;
+  }
+
+  if (!state.overlay) {
+    state.activeTrigger = null;
+    return;
+  }
+
+  if (pendingFrame) {
+    cancelAnimationFrame(pendingFrame);
+    pendingFrame = null;
+  }
+
+  state.overlay.root.classList.remove('is-active');
+  state.overlay.root.classList.remove('is-below');
+  state.overlay.root.setAttribute('aria-hidden', 'true');
+  state.activeTrigger = null;
+};
+
+const handlePointerEnter = (event) => {
+  const trigger = event.target.closest(TOOLTIP_SELECTOR);
+  if (trigger) {
+    showTooltip(trigger);
+  }
+};
+
+const handlePointerLeave = (event) => {
+  const trigger = event.target.closest(TOOLTIP_SELECTOR);
+  if (trigger) {
+    hideTooltip(trigger);
+  }
+};
+
+const handleFocusIn = (event) => {
+  const trigger = event.target.closest(TOOLTIP_SELECTOR);
+  if (trigger) {
+    showTooltip(trigger);
+  }
+};
+
+const handleFocusOut = (event) => {
+  const trigger = event.target.closest(TOOLTIP_SELECTOR);
+  if (trigger) {
+    hideTooltip(trigger);
+  }
+};
+
+const handleKeyDown = (event) => {
+  if (event.key === 'Escape' && state.activeTrigger) {
+    hideTooltip(state.activeTrigger);
+  }
+};
+
+export const initializeTooltipManager = () => {
+  if (isInitialized || typeof document === 'undefined') {
+    return;
+  }
+
+  isInitialized = true;
+  document.addEventListener('pointerenter', handlePointerEnter, true);
+  document.addEventListener('pointerleave', handlePointerLeave, true);
+  document.addEventListener('focusin', handleFocusIn, true);
+  document.addEventListener('focusout', handleFocusOut, true);
+  document.addEventListener('keydown', handleKeyDown, true);
+  document.addEventListener('scroll', scheduleReposition, true);
+  window.addEventListener('scroll', scheduleReposition, true);
+  window.addEventListener('resize', scheduleReposition, true);
+};

--- a/styles/main.css
+++ b/styles/main.css
@@ -73,7 +73,7 @@ body::after {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 200px 300px minmax(280px, 360px) minmax(520px, 1fr);
+  grid-template-columns: 200px 300px minmax(360px, 520px) minmax(420px, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1.5rem;
   padding: 2.25rem 2.75rem;
@@ -278,7 +278,7 @@ body::after {
   flex-direction: column;
   gap: 1.1rem;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   min-height: 0;
   box-shadow: var(--shadow-soft);
 }
@@ -396,6 +396,15 @@ dl dt {
 }
 
 .detail-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  position: relative;
+  overflow: visible;
+}
+
+.detail-scroll {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -529,16 +538,36 @@ dl dt {
 
 .tooltip {
   position: relative;
+  display: inline-flex;
+  align-items: baseline;
   cursor: help;
   color: var(--color-highlight);
   text-decoration: underline dotted rgba(240, 255, 150, 0.65);
 }
 
-.tooltip::after {
-  content: attr(data-tooltip);
-  position: absolute;
-  inset: auto auto 125% 50%;
-  transform: translateX(-50%) translateY(4px);
+.tooltip-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translate(-50%, calc(-100% - 12px));
+  pointer-events: none;
+  z-index: 100000;
+  opacity: 0;
+  transition: opacity 140ms ease-out, transform 140ms ease-out;
+}
+
+.tooltip-overlay.is-active {
+  opacity: 1;
+}
+
+.tooltip-overlay.is-below {
+  transform: translate(-50%, 12px);
+}
+
+.tooltip-overlay__bubble {
   min-width: 180px;
   max-width: 260px;
   padding: 0.5rem 0.65rem;
@@ -549,38 +578,38 @@ dl dt {
   font-size: 0.75rem;
   line-height: 1.45;
   letter-spacing: 0.02em;
-  white-space: normal;
   box-shadow: 0 10px 28px rgba(5, 15, 10, 0.55);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 140ms ease-out, transform 140ms ease-out;
-  z-index: 10;
+  white-space: normal;
+  text-align: left;
 }
 
-.tooltip::before {
+.tooltip-overlay::after {
   content: '';
   position: absolute;
-  inset: auto auto 115% 50%;
-  transform: translateX(-50%);
-  border-width: 6px;
+  left: 50%;
+  width: 0;
+  height: 0;
   border-style: solid;
-  border-color: rgba(9, 27, 19, 0.92) transparent transparent transparent;
   opacity: 0;
   transition: opacity 140ms ease-out;
-  pointer-events: none;
-  z-index: 10;
 }
 
-.tooltip:hover::after,
-.tooltip:focus-visible::after,
-.tooltip:hover::before,
-.tooltip:focus-visible::before {
+.tooltip-overlay.is-active::after {
   opacity: 1;
 }
 
-.tooltip:hover::after,
-.tooltip:focus-visible::after {
-  transform: translateX(-50%) translateY(0);
+.tooltip-overlay:not(.is-below)::after {
+  top: 100%;
+  transform: translate(-50%, 0);
+  border-width: 6px 6px 0 6px;
+  border-color: rgba(9, 27, 19, 0.92) transparent transparent transparent;
+}
+
+.tooltip-overlay.is-below::after {
+  top: 0;
+  transform: translate(-50%, -100%);
+  border-width: 0 6px 6px 6px;
+  border-color: transparent transparent rgba(9, 27, 19, 0.92) transparent;
 }
 
 .panel-footer {
@@ -591,23 +620,23 @@ dl dt {
 }
 
 .weapon-cards,
-.detail-content {
+.detail-scroll {
   scrollbar-width: thin;
   scrollbar-color: rgba(90, 169, 201, 0.55) transparent;
 }
 
 .weapon-cards::-webkit-scrollbar,
-.detail-content::-webkit-scrollbar {
+.detail-scroll::-webkit-scrollbar {
   width: 6px;
 }
 
 .weapon-cards::-webkit-scrollbar-track,
-.detail-content::-webkit-scrollbar-track {
+.detail-scroll::-webkit-scrollbar-track {
   background: transparent;
 }
 
 .weapon-cards::-webkit-scrollbar-thumb,
-.detail-content::-webkit-scrollbar-thumb {
+.detail-scroll::-webkit-scrollbar-thumb {
   background: linear-gradient(180deg, rgba(90, 169, 201, 0.65), rgba(124, 200, 111, 0.55));
   border-radius: 6px;
 }
@@ -669,7 +698,7 @@ dl dt {
   grid-row: 1 / span 2;
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  grid-template-columns: minmax(0, 58%) minmax(220px, 300px);
   grid-template-rows: minmax(0, 1fr);
   background: linear-gradient(155deg, rgba(26, 60, 40, 0.96), rgba(17, 48, 59, 0.92));
   border: 1px solid rgba(107, 182, 207, 0.35);
@@ -1025,7 +1054,7 @@ dl dt {
   }
 
   .app-shell {
-    grid-template-columns: 160px 320px minmax(280px, 1fr);
+    grid-template-columns: 160px 300px minmax(340px, 1fr);
     grid-template-rows: auto minmax(0, 1fr) minmax(280px, auto);
     padding: 2rem;
   }


### PR DESCRIPTION
## Summary
- Rename the document to "Critz Library" and rebalance the layout so the equipment info panel has more room while the stage and controls shrink.
- Implement a tooltip overlay manager with updated keyword definitions so Splash, AOE, Gas, Fire, RPM, Overheat, Lightning, and Ice tooltips appear above all UI layers without firing on "Fire Mode".
- Rely on the new Fire tooltip by trimming the flamethrower special entry and clear the rig status banner when a critter loads.

## Testing
- No tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce2812fc2483299391e69512492c48