### PR TITLE
Implement hover tooltips and adjust layout for Critz Library

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crtiz Armory Display</title>
+    <title>Critz Library</title>
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -375,7 +375,7 @@ const RAW_WEAPONS = [
     category: 'utility',
     description: 'Chilling vial that strips traction from the ground.',
     stats: {
-      effect: 'Sheet of of Ice',
+      effect: 'Sheet of Ice',
       deploy: 'Throw',
       capacity: '2',
       range: '50cm',

--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -55,7 +55,7 @@ export class RigControlPanel {
       this.bus.on('stage:model-ready', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(false, `${payload?.name ?? 'Rig'} ready for tuning.`);
+          this.setLoading(false, 'Pose controls ready.');
         }
       }),
       this.bus.on('stage:model-missing', (payload) => {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { WeaponDisplayApp } from './app/WeaponDisplayApp.js';
+import { installTooltipHandlers } from './utils/tooltipManager.js';
 
 const bootstrap = () => {
   const root = document.getElementById('app');
@@ -9,6 +10,7 @@ const bootstrap = () => {
 
   const app = new WeaponDisplayApp(root);
   app.init();
+  installTooltipHandlers();
 };
 
 document.addEventListener('DOMContentLoaded', bootstrap);

--- a/src/utils/keywordTooltips.js
+++ b/src/utils/keywordTooltips.js
@@ -9,10 +9,6 @@ const TOOLTIP_DEFINITIONS = [
     description: 'There is an Area of Effect (a defined zone or radius) applying whatever damage or effects.',
   },
   {
-    term: 'Gas',
-    description: 'Gas deals 5 damage for 5 seconds. Gas can be lit by fire.',
-  },
-  {
     term: 'Fire',
     description:
       'Ignites targets for 3 seconds dealing 10 damage per second. Gas can be lit by fire.',
@@ -24,7 +20,11 @@ const TOOLTIP_DEFINITIONS = [
   {
     term: 'Overheat',
     description:
-      'Weapons that have Overheat do not use Ammo, instead they are limited by a heat meter that rises with each shot fired and dissipates between shots. X/Y means that each shot costs X, and Y is the max of the heat meter. When a weapon overheats, it must wait until it\'s at 0/Y to fire again.',
+      "Weapons that have Overheat do not use Ammo, instead they are limited by a heat meter that rises with each shot fired and dissipates between shots. X/Y means that each shot costs X, and Y is the max of the heat meter. When a weapon overheats, it must wait until it's at 0/Y to fire again.",
+  },
+  {
+    term: 'Gas',
+    description: 'Gas deals 5 damage for 5 seconds. Gas can be lit by fire.',
   },
   {
     term: 'Lightning',
@@ -46,7 +46,18 @@ const escapeAttribute = (value) =>
 
 const buildTooltipMarkup = (label, description) => {
   const escapedDescription = escapeAttribute(description);
-  return `<span class="tooltip" data-tooltip="${escapedDescription}" tabindex="0" aria-label="${escapedDescription}">${label}</span>`;
+  return `<span class="tooltip-trigger" data-tooltip="${escapedDescription}" tabindex="0">${label}</span>`;
+};
+
+const shouldSkipMatch = (term, text, start, end) => {
+  if (term.toLowerCase() === 'fire') {
+    const afterMatch = text.slice(end);
+    if (/^\s+mode\b/i.test(afterMatch)) {
+      return true;
+    }
+  }
+
+  return false;
 };
 
 export const applyKeywordTooltips = (input) => {
@@ -62,9 +73,16 @@ export const applyKeywordTooltips = (input) => {
     let match;
 
     while ((match = regex.exec(text)) !== null) {
+      const start = match.index;
+      const end = start + match[0].length;
+
+      if (shouldSkipMatch(term, text, start, end)) {
+        continue;
+      }
+
       matches.push({
-        start: match.index,
-        end: match.index + match[0].length,
+        start,
+        end,
         replacement: buildTooltipMarkup(match[0], description),
       });
     }

--- a/src/utils/tooltipManager.js
+++ b/src/utils/tooltipManager.js
@@ -1,0 +1,157 @@
+const TRIGGER_SELECTOR = '.tooltip-trigger[data-tooltip]';
+const OFFSET = 12;
+let tooltipElement = null;
+let activeTrigger = null;
+let rafId = null;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const ensureTooltipElement = () => {
+  if (!tooltipElement) {
+    tooltipElement = document.createElement('div');
+    tooltipElement.className = 'tooltip-bubble';
+    tooltipElement.setAttribute('role', 'tooltip');
+    tooltipElement.id = 'tooltip-bubble';
+    document.body.appendChild(tooltipElement);
+  }
+  return tooltipElement;
+};
+
+const schedulePositionUpdate = () => {
+  if (rafId !== null) {
+    cancelAnimationFrame(rafId);
+  }
+
+  rafId = requestAnimationFrame(() => {
+    rafId = null;
+    if (activeTrigger) {
+      positionTooltip(activeTrigger);
+    }
+  });
+};
+
+const hideTooltip = (target) => {
+  if (!tooltipElement || (target && target !== activeTrigger)) {
+    return;
+  }
+
+  tooltipElement.removeAttribute('data-visible');
+  tooltipElement.removeAttribute('data-position');
+  tooltipElement.textContent = '';
+  if (activeTrigger) {
+    activeTrigger.removeAttribute('aria-describedby');
+  }
+  activeTrigger = null;
+};
+
+const showTooltip = (target) => {
+  if (!target || typeof target.getAttribute !== 'function') {
+    return;
+  }
+
+  const description = target.getAttribute('data-tooltip');
+  if (!description) {
+    return;
+  }
+
+  if (activeTrigger && activeTrigger !== target) {
+    hideTooltip(activeTrigger);
+  }
+
+  const bubble = ensureTooltipElement();
+  bubble.textContent = description;
+  bubble.setAttribute('data-visible', 'true');
+  activeTrigger = target;
+  target.setAttribute('aria-describedby', bubble.id);
+  positionTooltip(target);
+};
+
+function positionTooltip(target) {
+  if (!tooltipElement) {
+    return;
+  }
+
+  const rect = target.getBoundingClientRect();
+  const bubbleRect = tooltipElement.getBoundingClientRect();
+
+  let top = rect.top - bubbleRect.height - OFFSET;
+  let position = 'above';
+
+  if (top < 8) {
+    top = rect.bottom + OFFSET;
+    position = 'below';
+  }
+
+  let left = rect.left + rect.width / 2 - bubbleRect.width / 2;
+  const maxLeft = window.innerWidth - bubbleRect.width - 8;
+  left = clamp(left, 8, Math.max(8, maxLeft));
+
+  tooltipElement.style.top = `${Math.round(top)}px`;
+  tooltipElement.style.left = `${Math.round(left)}px`;
+  tooltipElement.setAttribute('data-position', position);
+}
+
+const resolveTriggerFromEvent = (event) => {
+  const element = event.target;
+  if (!(element instanceof Element)) {
+    return null;
+  }
+  return element.closest(TRIGGER_SELECTOR);
+};
+
+const handlePointerEnter = (event) => {
+  const trigger = resolveTriggerFromEvent(event);
+  if (trigger) {
+    showTooltip(trigger);
+  }
+};
+
+const handlePointerLeave = (event) => {
+  const trigger = resolveTriggerFromEvent(event);
+  if (trigger) {
+    hideTooltip(trigger);
+  }
+};
+
+const handleFocusIn = (event) => {
+  const trigger = resolveTriggerFromEvent(event);
+  if (trigger) {
+    showTooltip(trigger);
+  }
+};
+
+const handleFocusOut = (event) => {
+  const trigger = resolveTriggerFromEvent(event);
+  if (trigger) {
+    hideTooltip(trigger);
+  }
+};
+
+const handleKeyDown = (event) => {
+  if (event.key === 'Escape') {
+    hideTooltip(activeTrigger);
+  }
+};
+
+export const installTooltipHandlers = () => {
+  document.addEventListener('pointerenter', handlePointerEnter, true);
+  document.addEventListener('pointerleave', handlePointerLeave, true);
+  document.addEventListener('focusin', handleFocusIn, true);
+  document.addEventListener('focusout', handleFocusOut, true);
+  document.addEventListener('keydown', handleKeyDown, true);
+  document.addEventListener('scroll', schedulePositionUpdate, true);
+  window.addEventListener('scroll', schedulePositionUpdate, true);
+  window.addEventListener('resize', schedulePositionUpdate, true);
+};
+
+export const uninstallTooltipHandlers = () => {
+  document.removeEventListener('pointerenter', handlePointerEnter, true);
+  document.removeEventListener('pointerleave', handlePointerLeave, true);
+  document.removeEventListener('focusin', handleFocusIn, true);
+  document.removeEventListener('focusout', handleFocusOut, true);
+  document.removeEventListener('keydown', handleKeyDown, true);
+  document.removeEventListener('scroll', schedulePositionUpdate, true);
+  window.removeEventListener('scroll', schedulePositionUpdate, true);
+  window.removeEventListener('resize', schedulePositionUpdate, true);
+  hideTooltip();
+};

--- a/styles/main.css
+++ b/styles/main.css
@@ -73,7 +73,7 @@ body::after {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 200px 300px minmax(280px, 360px) minmax(520px, 1fr);
+  grid-template-columns: 200px 300px minmax(360px, 520px) minmax(420px, 0.8fr);
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1.5rem;
   padding: 2.25rem 2.75rem;
@@ -527,60 +527,64 @@ dl dt {
   font-weight: 600;
 }
 
-.tooltip {
+.tooltip-trigger {
   position: relative;
   cursor: help;
   color: var(--color-highlight);
   text-decoration: underline dotted rgba(240, 255, 150, 0.65);
+  outline: none;
 }
 
-.tooltip::after {
-  content: attr(data-tooltip);
-  position: absolute;
-  inset: auto auto 125% 50%;
-  transform: translateX(-50%) translateY(4px);
+.tooltip-trigger:focus-visible {
+  text-decoration-thickness: 3px;
+  text-decoration-color: rgba(240, 255, 150, 0.9);
+}
+
+.tooltip-bubble {
+  position: fixed;
+  top: 0;
+  left: 0;
+  transform: translateY(4px);
   min-width: 180px;
-  max-width: 260px;
-  padding: 0.5rem 0.65rem;
-  border-radius: 8px;
-  background: rgba(9, 27, 19, 0.92);
-  border: 1px solid rgba(210, 243, 220, 0.35);
+  max-width: 280px;
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  background: rgba(9, 27, 19, 0.95);
+  border: 1px solid rgba(210, 243, 220, 0.4);
   color: var(--color-text-primary);
-  font-size: 0.75rem;
+  font-size: 0.78rem;
   line-height: 1.45;
   letter-spacing: 0.02em;
   white-space: normal;
-  box-shadow: 0 10px 28px rgba(5, 15, 10, 0.55);
+  box-shadow: 0 14px 32px rgba(5, 15, 10, 0.6);
   opacity: 0;
   pointer-events: none;
+  z-index: 9999;
   transition: opacity 140ms ease-out, transform 140ms ease-out;
-  z-index: 10;
 }
 
-.tooltip::before {
+.tooltip-bubble::after {
   content: '';
   position: absolute;
-  inset: auto auto 115% 50%;
+  left: 50%;
   transform: translateX(-50%);
   border-width: 6px;
   border-style: solid;
-  border-color: rgba(9, 27, 19, 0.92) transparent transparent transparent;
-  opacity: 0;
-  transition: opacity 140ms ease-out;
-  pointer-events: none;
-  z-index: 10;
 }
 
-.tooltip:hover::after,
-.tooltip:focus-visible::after,
-.tooltip:hover::before,
-.tooltip:focus-visible::before {
+.tooltip-bubble[data-visible='true'] {
   opacity: 1;
+  transform: translateY(0);
 }
 
-.tooltip:hover::after,
-.tooltip:focus-visible::after {
-  transform: translateX(-50%) translateY(0);
+.tooltip-bubble[data-position='above']::after {
+  bottom: -12px;
+  border-color: rgba(9, 27, 19, 0.95) transparent transparent transparent;
+}
+
+.tooltip-bubble[data-position='below']::after {
+  top: -12px;
+  border-color: transparent transparent rgba(9, 27, 19, 0.95) transparent;
 }
 
 .panel-footer {
@@ -669,7 +673,7 @@ dl dt {
   grid-row: 1 / span 2;
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  grid-template-columns: minmax(0, 0.9fr) minmax(220px, 300px);
   grid-template-rows: minmax(0, 1fr);
   background: linear-gradient(155deg, rgba(26, 60, 40, 0.96), rgba(17, 48, 59, 0.92));
   border: 1px solid rgba(107, 182, 207, 0.35);
@@ -1025,7 +1029,7 @@ dl dt {
   }
 
   .app-shell {
-    grid-template-columns: 160px 320px minmax(280px, 1fr);
+    grid-template-columns: 160px 320px minmax(320px, 1fr);
     grid-template-rows: auto minmax(0, 1fr) minmax(280px, auto);
     padding: 2rem;
   }


### PR DESCRIPTION
## Summary
- replace the document title with "Critz Library" and tweak the weapon data strings for the bottle utilities
- add rich keyword tooltips with a global tooltip manager so status terms like Splash, AOE, Gas, Fire, etc. show hover help without affecting "Fire Mode"
- restyle the tooltip bubble so it renders above the interface, enlarge the equipment detail panel, shrink the viewport area, and soften the rig status text

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce2812fc2483299391e69512492c48