### PR TITLE
Add global tooltip overlay and refine equipment layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crtiz Armory Display</title>
+    <title>Critz Library</title>
     <link rel="stylesheet" href="styles/main.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -126,7 +126,9 @@ export class WeaponDisplayApp {
             <span data-role="rarity-badge"></span>
           </div>
           <div class="detail-content" data-role="detail-content">
-            <p class="description">Pick a tool to see its details.</p>
+            <div class="detail-scroll" data-role="detail-scroll">
+              <p class="description">Pick a tool to see its details.</p>
+            </div>
           </div>
           <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
         </section>

--- a/src/hud/components/RigControlPanel.js
+++ b/src/hud/components/RigControlPanel.js
@@ -55,7 +55,7 @@ export class RigControlPanel {
       this.bus.on('stage:model-ready', (payload) => {
         if (payload?.type === 'critter') {
           this.currentCritterName = payload?.name ?? null;
-          this.setLoading(false, `${payload?.name ?? 'Rig'} ready for tuning.`);
+          this.setLoading(false, '');
         }
       }),
       this.bus.on('stage:model-missing', (payload) => {
@@ -90,13 +90,15 @@ export class RigControlPanel {
     this.currentState = state;
     if (this.statusElement) {
       this.statusElement.dataset.state = state;
-      this.statusElement.textContent = message;
+      const hasMessage = typeof message === 'string' && message.trim().length > 0;
+      this.statusElement.textContent = hasMessage ? message : '';
+      this.statusElement.hidden = !hasMessage;
     }
   }
 
   setLoading(isLoading, message) {
     this.root?.classList.toggle('is-loading', Boolean(isLoading));
-    if (message) {
+    if (message !== undefined) {
       this.setStatus(isLoading ? 'loading' : 'ready', message);
     } else if (isLoading) {
       this.setStatus('loading', 'Loading rig…');

--- a/src/hud/components/WeaponDetailPanel.js
+++ b/src/hud/components/WeaponDetailPanel.js
@@ -55,6 +55,8 @@ export class WeaponDetailPanel {
   constructor({ panelElement, rarityBadge, footerElement }) {
     this.panelElement = panelElement;
     this.contentElement = panelElement.querySelector('[data-role="detail-content"]');
+    this.scrollElement =
+      panelElement.querySelector('[data-role="detail-scroll"]') || this.contentElement;
     this.rarityBadge = rarityBadge;
     this.footerElement = footerElement;
   }
@@ -84,12 +86,15 @@ export class WeaponDetailPanel {
     const statsMarkup = buildStatsMarkup(weapon, decorate);
     const specialMarkup = buildSpecialMarkup(weapon, (value) => this.prettify(value), decorate);
 
-    this.contentElement.innerHTML = `
-      <h3>${weapon.name}</h3>
-      <p class="description">${decorate(weapon.description)}</p>
-      ${statsMarkup}
-      ${specialMarkup}
-    `;
+    if (this.scrollElement) {
+      this.scrollElement.innerHTML = `
+        <h3>${weapon.name}</h3>
+        <p class="description">${decorate(weapon.description)}</p>
+        ${statsMarkup}
+        ${specialMarkup}
+      `;
+      this.scrollElement.scrollTop = 0;
+    }
 
     if (this.footerElement) {
       this.footerElement.textContent = `Catalog ID: ${weapon.id}`;
@@ -97,9 +102,10 @@ export class WeaponDetailPanel {
   }
 
   renderEmpty() {
-    if (this.contentElement) {
-      this.contentElement.innerHTML =
+    if (this.scrollElement) {
+      this.scrollElement.innerHTML =
         '<p class="description">Pick a tool to see its story and statistics.</p>';
+      this.scrollElement.scrollTop = 0;
     }
 
     if (this.rarityBadge) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { WeaponDisplayApp } from './app/WeaponDisplayApp.js';
+import { initializeKeywordTooltips } from './utils/keywordTooltips.js';
 
 const bootstrap = () => {
   const root = document.getElementById('app');
@@ -7,6 +8,7 @@ const bootstrap = () => {
     throw new Error('App root element not found. Ensure #app exists in index.html');
   }
 
+  initializeKeywordTooltips();
   const app = new WeaponDisplayApp(root);
   app.init();
 };

--- a/src/utils/keywordTooltips.js
+++ b/src/utils/keywordTooltips.js
@@ -49,6 +49,198 @@ const buildTooltipMarkup = (label, description) => {
   return `<span class="tooltip" data-tooltip="${escapedDescription}" tabindex="0" aria-label="${escapedDescription}">${label}</span>`;
 };
 
+const shouldSkipMatch = (term, text, startIndex, endIndex) => {
+  if (term.toLowerCase() === 'fire') {
+    const trailing = text.slice(endIndex);
+    if (/^\s*mode\b/i.test(trailing)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+let tooltipLayerElement = null;
+let activeTooltipTarget = null;
+let isTooltipSystemInitialized = false;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const ensureTooltipLayer = () => {
+  if (tooltipLayerElement && document.body.contains(tooltipLayerElement)) {
+    return;
+  }
+
+  tooltipLayerElement = document.createElement('div');
+  tooltipLayerElement.className = 'tooltip-layer';
+  tooltipLayerElement.dataset.visible = 'false';
+  tooltipLayerElement.dataset.placement = 'top';
+  tooltipLayerElement.setAttribute('role', 'tooltip');
+  tooltipLayerElement.setAttribute('aria-hidden', 'true');
+  tooltipLayerElement.style.left = '0px';
+  tooltipLayerElement.style.top = '0px';
+  document.body.appendChild(tooltipLayerElement);
+};
+
+const getTooltipText = (target) =>
+  target?.getAttribute('data-tooltip')?.trim() || target?.getAttribute('aria-label')?.trim() || '';
+
+const positionTooltipLayer = () => {
+  if (!tooltipLayerElement || !activeTooltipTarget) {
+    return;
+  }
+
+  if (!activeTooltipTarget.isConnected) {
+    activeTooltipTarget = null;
+    tooltipLayerElement.dataset.visible = 'false';
+    tooltipLayerElement.setAttribute('aria-hidden', 'true');
+    return;
+  }
+
+  const rect = activeTooltipTarget.getBoundingClientRect();
+
+  const viewportWidth = document.documentElement.clientWidth;
+  const viewportHeight = document.documentElement.clientHeight;
+
+  tooltipLayerElement.style.left = '0px';
+  tooltipLayerElement.style.top = '0px';
+
+  const layerRect = tooltipLayerElement.getBoundingClientRect();
+  const gap = 12;
+  const halfWidth = layerRect.width / 2;
+  const minLeft = gap + halfWidth;
+  const maxLeft = viewportWidth - gap - halfWidth;
+  const centerLeft = rect.left + rect.width / 2;
+  const clampedLeft = clamp(centerLeft, minLeft, maxLeft);
+
+  let top = rect.top - gap - layerRect.height;
+  let placement = 'top';
+
+  if (top < gap) {
+    top = Math.min(rect.bottom + gap, viewportHeight - gap - layerRect.height);
+    placement = 'bottom';
+  }
+
+  tooltipLayerElement.dataset.placement = placement;
+  tooltipLayerElement.style.left = `${Math.round(clampedLeft)}px`;
+  tooltipLayerElement.style.top = `${Math.round(top)}px`;
+};
+
+const showTooltipLayer = (target) => {
+  if (!target) {
+    return;
+  }
+
+  ensureTooltipLayer();
+  const tooltipText = getTooltipText(target);
+  if (!tooltipText) {
+    return;
+  }
+
+  activeTooltipTarget = target;
+  tooltipLayerElement.textContent = tooltipText;
+  tooltipLayerElement.dataset.visible = 'true';
+  tooltipLayerElement.setAttribute('aria-hidden', 'false');
+  positionTooltipLayer();
+};
+
+const hideTooltipLayer = (target) => {
+  if (!tooltipLayerElement) {
+    return;
+  }
+
+  if (target && target !== activeTooltipTarget) {
+    return;
+  }
+
+  activeTooltipTarget = null;
+  tooltipLayerElement.dataset.visible = 'false';
+  tooltipLayerElement.setAttribute('aria-hidden', 'true');
+};
+
+const handlePointerOver = (event) => {
+  const target = event.target?.closest?.('.tooltip');
+  if (!target) {
+    return;
+  }
+  showTooltipLayer(target);
+};
+
+const handlePointerOut = (event) => {
+  if (!activeTooltipTarget) {
+    return;
+  }
+
+  const origin = event.target?.closest?.('.tooltip');
+  if (!origin) {
+    return;
+  }
+
+  const related = event.relatedTarget instanceof Element ? event.relatedTarget.closest('.tooltip') : null;
+  if (related === origin) {
+    return;
+  }
+
+  hideTooltipLayer(origin);
+};
+
+const handleFocusIn = (event) => {
+  const target = event.target?.closest?.('.tooltip');
+  if (!target) {
+    return;
+  }
+  showTooltipLayer(target);
+};
+
+const handleFocusOut = (event) => {
+  if (!activeTooltipTarget) {
+    return;
+  }
+
+  const origin = event.target?.closest?.('.tooltip');
+  if (!origin) {
+    return;
+  }
+
+  if (event.relatedTarget instanceof Element && origin.contains(event.relatedTarget)) {
+    return;
+  }
+
+  hideTooltipLayer(origin);
+};
+
+const handleViewportChange = () => {
+  if (!activeTooltipTarget) {
+    return;
+  }
+  positionTooltipLayer();
+};
+
+export const initializeKeywordTooltips = () => {
+  if (isTooltipSystemInitialized) {
+    return;
+  }
+  isTooltipSystemInitialized = true;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener(
+      'DOMContentLoaded',
+      () => {
+        ensureTooltipLayer();
+      },
+      { once: true }
+    );
+  } else {
+    ensureTooltipLayer();
+  }
+
+  document.addEventListener('pointerover', handlePointerOver);
+  document.addEventListener('pointerout', handlePointerOut);
+  document.addEventListener('focusin', handleFocusIn);
+  document.addEventListener('focusout', handleFocusOut);
+  window.addEventListener('scroll', handleViewportChange, true);
+  window.addEventListener('resize', handleViewportChange);
+};
+
 export const applyKeywordTooltips = (input) => {
   if (input === null || input === undefined) {
     return '';
@@ -62,9 +254,14 @@ export const applyKeywordTooltips = (input) => {
     let match;
 
     while ((match = regex.exec(text)) !== null) {
+      const startIndex = match.index;
+      const endIndex = match.index + match[0].length;
+      if (shouldSkipMatch(term, text, startIndex, endIndex)) {
+        continue;
+      }
       matches.push({
-        start: match.index,
-        end: match.index + match[0].length,
+        start: startIndex,
+        end: endIndex,
         replacement: buildTooltipMarkup(match[0], description),
       });
     }

--- a/styles/main.css
+++ b/styles/main.css
@@ -73,7 +73,7 @@ body::after {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 200px 300px minmax(280px, 360px) minmax(520px, 1fr);
+  grid-template-columns: 200px 280px minmax(320px, 1.2fr) minmax(320px, 0.8fr);
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1.5rem;
   padding: 2.25rem 2.75rem;
@@ -278,7 +278,7 @@ body::after {
   flex-direction: column;
   gap: 1.1rem;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   min-height: 0;
   box-shadow: var(--shadow-soft);
 }
@@ -396,6 +396,13 @@ dl dt {
 }
 
 .detail-content {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  overflow: visible;
+}
+
+.detail-scroll {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -534,11 +541,10 @@ dl dt {
   text-decoration: underline dotted rgba(240, 255, 150, 0.65);
 }
 
-.tooltip::after {
-  content: attr(data-tooltip);
-  position: absolute;
-  inset: auto auto 125% 50%;
-  transform: translateX(-50%) translateY(4px);
+.tooltip-layer {
+  position: fixed;
+  left: 0;
+  top: 0;
   min-width: 180px;
   max-width: 260px;
   padding: 0.5rem 0.65rem;
@@ -553,34 +559,44 @@ dl dt {
   box-shadow: 0 10px 28px rgba(5, 15, 10, 0.55);
   opacity: 0;
   pointer-events: none;
+  transform: translate3d(-50%, 4px, 0);
   transition: opacity 140ms ease-out, transform 140ms ease-out;
-  z-index: 10;
+  z-index: 10000;
+  visibility: hidden;
 }
 
-.tooltip::before {
+.tooltip-layer[data-visible='true'] {
+  opacity: 1;
+  transform: translate3d(-50%, 0, 0);
+  visibility: visible;
+}
+
+.tooltip-layer[data-placement='bottom'] {
+  transform: translate3d(-50%, -4px, 0);
+}
+
+.tooltip-layer[data-placement='bottom'][data-visible='true'] {
+  transform: translate3d(-50%, 0, 0);
+}
+
+.tooltip-layer::after {
   content: '';
   position: absolute;
-  inset: auto auto 115% 50%;
-  transform: translateX(-50%);
+  left: 50%;
   border-width: 6px;
   border-style: solid;
-  border-color: rgba(9, 27, 19, 0.92) transparent transparent transparent;
-  opacity: 0;
-  transition: opacity 140ms ease-out;
+  transform: translateX(-50%);
   pointer-events: none;
-  z-index: 10;
 }
 
-.tooltip:hover::after,
-.tooltip:focus-visible::after,
-.tooltip:hover::before,
-.tooltip:focus-visible::before {
-  opacity: 1;
+.tooltip-layer[data-placement='top']::after {
+  top: 100%;
+  border-color: rgba(9, 27, 19, 0.92) transparent transparent transparent;
 }
 
-.tooltip:hover::after,
-.tooltip:focus-visible::after {
-  transform: translateX(-50%) translateY(0);
+.tooltip-layer[data-placement='bottom']::after {
+  bottom: 100%;
+  border-color: transparent transparent rgba(9, 27, 19, 0.92) transparent;
 }
 
 .panel-footer {
@@ -591,23 +607,23 @@ dl dt {
 }
 
 .weapon-cards,
-.detail-content {
+.detail-scroll {
   scrollbar-width: thin;
   scrollbar-color: rgba(90, 169, 201, 0.55) transparent;
 }
 
 .weapon-cards::-webkit-scrollbar,
-.detail-content::-webkit-scrollbar {
+.detail-scroll::-webkit-scrollbar {
   width: 6px;
 }
 
 .weapon-cards::-webkit-scrollbar-track,
-.detail-content::-webkit-scrollbar-track {
+.detail-scroll::-webkit-scrollbar-track {
   background: transparent;
 }
 
 .weapon-cards::-webkit-scrollbar-thumb,
-.detail-content::-webkit-scrollbar-thumb {
+.detail-scroll::-webkit-scrollbar-thumb {
   background: linear-gradient(180deg, rgba(90, 169, 201, 0.65), rgba(124, 200, 111, 0.55));
   border-radius: 6px;
 }
@@ -669,7 +685,7 @@ dl dt {
   grid-row: 1 / span 2;
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  grid-template-columns: minmax(0, 0.7fr) minmax(220px, 280px);
   grid-template-rows: minmax(0, 1fr);
   background: linear-gradient(155deg, rgba(26, 60, 40, 0.96), rgba(17, 48, 59, 0.92));
   border: 1px solid rgba(107, 182, 207, 0.35);


### PR DESCRIPTION
## Summary
- add a global tooltip manager so hover and focus tooltips render above all content and ignore "Fire Mode"
- restructure the equipment detail panel and layout to give the info column more space while reducing the stage footprint
- hide the rig panel ready message and rename the app to "Critz Library"

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce2812fc2483299391e69512492c48