### PR TITLE
Add tooltips for ammo and overheat stats

### DIFF
--- a/src/data/sampleWeapons.js
+++ b/src/data/sampleWeapons.js
@@ -95,7 +95,7 @@ const RAW_WEAPONS = [
       damage: '10 Splash damage',
       fireMode: 'Full-Auto',
       rpm: '120',
-      ammoOverheat: '10/100',
+      overheat: '10/100',
       cooldown: '2s',
       drawSpeed: '0.5s',
       range: '100cm',

--- a/src/hud/components/WeaponDetailPanel.js
+++ b/src/hud/components/WeaponDetailPanel.js
@@ -10,6 +10,84 @@ const RARITY_TITLES = {
   mythic: 'Mythic',
 };
 
+const escapeAttribute = (value) =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+const wrapWithTooltip = (content, description) => {
+  if (!description) {
+    return content;
+  }
+
+  const escapedDescription = escapeAttribute(description);
+  return `<span class="tooltip" data-tooltip="${escapedDescription}" tabindex="0" aria-label="${escapedDescription}">${content}</span>`;
+};
+
+const parseDualValue = (rawValue) => {
+  if (typeof rawValue !== 'string') {
+    return null;
+  }
+
+  const parts = rawValue
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  return parts;
+};
+
+const pluralize = (value, singular, plural) => {
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && Math.abs(numeric) === 1) {
+    return singular;
+  }
+  return plural;
+};
+
+const createAmmoTooltip = (rawValue) => {
+  const parts = parseDualValue(rawValue);
+  if (!parts) {
+    return null;
+  }
+
+  const [magazine, reserve] = parts;
+  const magazineLabel = pluralize(magazine, 'Round per Magazine', 'Rounds per Magazine');
+  return `${magazine} ${magazineLabel}; ${reserve} Extra Ammo`;
+};
+
+const createOverheatTooltip = (rawValue) => {
+  const parts = parseDualValue(rawValue);
+  if (!parts) {
+    return null;
+  }
+
+  const [cost, max] = parts;
+  return `Cost per Shot: ${cost} Heat; Max Heat: ${max}`;
+};
+
+const STAT_TOOLTIP_BUILDERS = {
+  ammo: createAmmoTooltip,
+  overheat: createOverheatTooltip,
+  ammoOverheat: createOverheatTooltip,
+};
+
+const getStatTooltip = (key, rawValue) => {
+  const builder = STAT_TOOLTIP_BUILDERS[key];
+  if (typeof builder !== 'function') {
+    return null;
+  }
+
+  return builder(rawValue);
+};
+
 const buildStatsMarkup = (weapon, decorate = (value) => value) => {
   if (!weapon) {
     return '';
@@ -21,7 +99,14 @@ const buildStatsMarkup = (weapon, decorate = (value) => value) => {
   }
 
   const rows = stats
-    .map(({ label, value }) => `<dt>${decorate(label)}</dt><dd>${decorate(value)}</dd>`)
+    .map(({ key, label, value }) => {
+      const decoratedLabel = decorate(label);
+      const decoratedValue = decorate(value);
+      const tooltip = getStatTooltip(key, value);
+      const finalValue = tooltip ? wrapWithTooltip(decoratedValue, tooltip) : decoratedValue;
+
+      return `<dt>${decoratedLabel}</dt><dd>${finalValue}</dd>`;
+    })
     .join('');
 
   return `<dl class="stat-list">${rows}</dl>`;


### PR DESCRIPTION
## Summary
- add contextual tooltips to ammo and overheat stat values so players can understand each portion of the X/Y display
- update the wizard staff data to use the overheat stat exclusively so it no longer shows ammo

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0cb0a25bc832994636235a2ab245f