### PR TITLE
Improve critter viewport clarity and lighting

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -7,6 +7,13 @@ import { CritterSelector } from '../hud/components/CritterSelector.js';
 import { ViewportOverlay } from '../hud/components/ViewportOverlay.js';
 import { RigControlPanel } from '../hud/components/RigControlPanel.js';
 
+const RARITY_ORDER = {
+  common: 0,
+  rare: 1,
+  legendary: 2,
+  mythic: 3,
+};
+
 export class WeaponDisplayApp {
   constructor(rootElement) {
     this.root = rootElement;
@@ -66,7 +73,7 @@ export class WeaponDisplayApp {
 
     if (defaultWeapon) {
       this.activeWeapon = defaultWeapon;
-      this.sceneManager.applyRarityGlow(defaultWeapon.rarity);
+      this.sceneManager.applyRarityGlow();
     }
 
     this.critterSelector = new CritterSelector({
@@ -92,6 +99,7 @@ export class WeaponDisplayApp {
           this.sceneManager.playAnimation(activeAnimation);
         }
       });
+      this.emitCritterStats(defaultCritter);
     } else {
       this.activeAnimationId = null;
     }
@@ -133,15 +141,15 @@ export class WeaponDisplayApp {
           <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
         </section>
         <section class="stage" data-component="stage">
-          <div class="stage-toolbar" data-component="stage-toolbar">
-            <div class="stage-tool-panel stage-tool-panel--rig" data-component="rig-controls"></div>
-          </div>
           <div
             class="stage-viewport"
             data-role="stage-viewport"
             aria-label="Critter viewer"
             tabindex="0"
           ></div>
+          <div class="stage-toolbar" data-component="stage-toolbar">
+            <div class="stage-tool-panel stage-tool-panel--rig" data-component="rig-controls"></div>
+          </div>
         </section>
       </div>
     `;
@@ -173,7 +181,7 @@ export class WeaponDisplayApp {
         return;
       }
       this.activeWeapon = weapon;
-      this.sceneManager.applyRarityGlow(weapon.rarity);
+      this.sceneManager.applyRarityGlow();
     });
 
     this.eventBus.on('critter:selected', (critterId) => {
@@ -183,6 +191,7 @@ export class WeaponDisplayApp {
       }
 
       this.activeCritter = critter;
+      this.emitCritterStats(critter);
       this.activeAnimationId = this.resolveAnimationId(critter);
       const activeAnimation = this.findAnimation(critter, this.activeAnimationId);
 
@@ -215,12 +224,25 @@ export class WeaponDisplayApp {
   }
 
   groupWeaponsByCategory() {
-    return this.weapons.reduce((acc, weapon) => {
+    const grouped = this.weapons.reduce((acc, weapon) => {
       const bucket = acc[weapon.category] || [];
       bucket.push(weapon);
       acc[weapon.category] = bucket;
       return acc;
     }, {});
+
+    Object.keys(grouped).forEach((category) => {
+      grouped[category].sort((a, b) => {
+        const rarityA = RARITY_ORDER[a.rarity] ?? Number.MAX_SAFE_INTEGER;
+        const rarityB = RARITY_ORDER[b.rarity] ?? Number.MAX_SAFE_INTEGER;
+        if (rarityA !== rarityB) {
+          return rarityA - rarityB;
+        }
+        return a.name.localeCompare(b.name);
+      });
+    });
+
+    return grouped;
   }
 
   findDefaultWeapon() {
@@ -262,6 +284,19 @@ export class WeaponDisplayApp {
       } else {
         this.sceneManager.stopAnimation();
       }
+    });
+  }
+
+  emitCritterStats(critter) {
+    if (!critter) {
+      this.eventBus.emit('viewport:critter-info', null);
+      return;
+    }
+
+    this.eventBus.emit('viewport:critter-info', {
+      id: critter.id,
+      name: critter.name,
+      stats: critter.stats ?? null,
     });
   }
 }

--- a/src/core/RendererFactory.js
+++ b/src/core/RendererFactory.js
@@ -2,11 +2,13 @@ import * as THREE from 'https://esm.sh/three@0.160.0';
 
 export const createRenderer = (container) => {
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-  renderer.setPixelRatio(window.devicePixelRatio || 1);
+  const pixelRatio = Math.min(window.devicePixelRatio || 1, 2.5);
+  renderer.setPixelRatio(pixelRatio);
   const { clientWidth, clientHeight } = container;
   renderer.setSize(clientWidth, clientHeight, false);
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.05;
   container.appendChild(renderer.domElement);
   return renderer;
 };

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -6,14 +6,6 @@ import { RigController } from './RigController.js';
 const ORBIT_CONTROLS_MODULE =
   'https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js';
 
-const RARITY_GLOWS = {
-  common: 0x7c6cff,
-  rare: 0x7df0ff,
-  epic: 0xff9af5,
-  legendary: 0xffe37d,
-  mythic: 0xffb7ff,
-};
-
 const CAMERA_DEFAULT_POSITION = new THREE.Vector3(0, 1.1, 3.3);
 const CAMERA_DEFAULT_TARGET = new THREE.Vector3(0, 0.65, 0);
 const CAMERA_TRANSITION_SPEED = 2.25;
@@ -330,17 +322,24 @@ export class SceneManager {
   }
 
   setupLights() {
-    const ambient = new THREE.AmbientLight(0xffe6ff, 0.4);
-    const rimLight = new THREE.DirectionalLight(0xa7c9ff, 1.15);
-    rimLight.position.set(-3, 4, 2);
-    const fillLight = new THREE.SpotLight(0xffc3f7, 1.25, 20, Math.PI / 4, 0.85, 2);
-    fillLight.position.set(2.6, 3.8, 1.4);
-    const bounceLight = new THREE.PointLight(0x8cf5ff, 0.6, 6, 2);
-    bounceLight.position.set(0, 1.2, 0.8);
+    const ambient = new THREE.AmbientLight(0xe9f7ff, 0.55);
+    const hemisphere = new THREE.HemisphereLight(0xbaf5e0, 0x0c1412, 0.6);
 
-    this.rarityLight = bounceLight;
+    const keyLight = new THREE.DirectionalLight(0xffffff, 1.35);
+    keyLight.position.set(4.5, 6, 5.2);
 
-    this.scene.add(ambient, rimLight, fillLight, bounceLight);
+    const rimLight = new THREE.DirectionalLight(0x78c7ff, 0.85);
+    rimLight.position.set(-4.5, 5, -2.5);
+
+    const fillLight = new THREE.PointLight(0xfff0d4, 0.95, 18, 2.2);
+    fillLight.position.set(0.9, 3.6, 2.8);
+
+    const accentLight = new THREE.PointLight(0x9fffe0, 1.05, 12, 2.4);
+    accentLight.position.set(0, 1.6, 1.2);
+    this.rarityLight = accentLight;
+    this.applyRarityGlow();
+
+    this.scene.add(ambient, hemisphere, keyLight, rimLight, fillLight, accentLight);
   }
 
   setupEnvironment() {}
@@ -386,7 +385,7 @@ export class SceneManager {
     this.currentModel = model;
     this.stageGroup.add(model);
 
-    this.applyRarityGlow(weapon.rarity);
+    this.applyRarityGlow();
     this.focusOnCurrentModel({ immediate: false });
     this.emitStageEvent('stage:model-ready', {
       type: 'weapon',
@@ -536,10 +535,10 @@ export class SceneManager {
     this.disposeRigController();
   }
 
-  applyRarityGlow(rarity = 'common') {
-    const color = RARITY_GLOWS[rarity] ?? RARITY_GLOWS.common;
+  applyRarityGlow() {
     if (this.rarityLight) {
-      this.rarityLight.color = new THREE.Color(color);
+      this.rarityLight.color = new THREE.Color(0x9fffe0);
+      this.rarityLight.intensity = 1.05;
     }
   }
 

--- a/src/data/critters.js
+++ b/src/data/critters.js
@@ -6,6 +6,12 @@ export const critters = [
     scale: 1.15,
     offset: { y: -0.6 },
     defaultAnimationId: 'frog_idle',
+    stats: {
+      health: 100,
+      speed: 100,
+      stamina: 100,
+      bonus: 'Double Jump',
+    },
     animations: [
       { id: 'frog_idle', label: 'Idle', path: 'assets/models/critters/animations/TH_Frog_Idle.glb' },
       {
@@ -81,6 +87,12 @@ export const critters = [
     scale: 1.25,
     offset: { y: -0.6 },
     defaultAnimationId: 'lizard_idle',
+    stats: {
+      health: 100,
+      speed: 100,
+      stamina: 100,
+      bonus: '+25% Sprint Boost While Above 50% Stamina',
+    },
     animations: [
       { id: 'lizard_idle', label: 'Idle', path: 'assets/models/critters/animations/TH_Lizard_Idle.glb' },
       {

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -8,6 +8,8 @@ export class ViewportOverlay {
     this.autoRotateButton = null;
     this.focusButton = null;
     this.resetButton = null;
+    this.statsElement = null;
+    this.statFields = {};
     this.autoRotateEnabled = false;
     this.state = 'idle';
     this.unsubscribe = [];
@@ -35,6 +37,29 @@ export class ViewportOverlay {
     this.root = document.createElement('div');
     this.root.className = 'viewport-ui';
     this.root.innerHTML = `
+      <div class="viewport-ui__top">
+        <div class="viewport-status" data-role="viewport-status">
+          <span class="viewport-status__text" data-role="viewport-status-text"></span>
+        </div>
+        <div class="viewport-stats" data-role="viewport-stats" hidden>
+          <span class="viewport-stats__name" data-stat="name"></span>
+          <dl class="viewport-stats__list">
+            <div class="viewport-stats__item">
+              <dt>Health</dt>
+              <dd data-stat="health">--</dd>
+            </div>
+            <div class="viewport-stats__item">
+              <dt>Speed</dt>
+              <dd data-stat="speed">--</dd>
+            </div>
+            <div class="viewport-stats__item">
+              <dt>Stamina</dt>
+              <dd data-stat="stamina">--</dd>
+            </div>
+          </dl>
+          <p class="viewport-stats__bonus" data-stat="bonus"></p>
+        </div>
+      </div>
       <div class="viewport-ui__bottom">
         <div class="viewport-controls-panel">
           <div class="viewport-controls" role="group" aria-label="Viewport controls">
@@ -56,9 +81,18 @@ export class ViewportOverlay {
     this.container.appendChild(this.root);
     this.statusElement = this.root.querySelector('[data-role="viewport-status"]');
     this.statusText = this.root.querySelector('[data-role="viewport-status-text"]');
+    this.statsElement = this.root.querySelector('[data-role="viewport-stats"]');
+    this.statFields = {
+      name: this.root.querySelector('[data-stat="name"]'),
+      health: this.root.querySelector('[data-stat="health"]'),
+      speed: this.root.querySelector('[data-stat="speed"]'),
+      stamina: this.root.querySelector('[data-stat="stamina"]'),
+      bonus: this.root.querySelector('[data-stat="bonus"]'),
+    };
     this.autoRotateButton = this.root.querySelector('[data-action="autorotate"]');
     this.focusButton = this.root.querySelector('[data-action="focus"]');
     this.resetButton = this.root.querySelector('[data-action="reset"]');
+    this.updateStats(null);
   }
 
   bindControls() {
@@ -118,6 +152,9 @@ export class ViewportOverlay {
           reset: true,
           autorotate: false,
         });
+        if (payload?.type === 'critter') {
+          this.updateStats(null);
+        }
       }),
       this.bus.on('stage:focus-achieved', () => {
         this.flashStatus();
@@ -128,6 +165,9 @@ export class ViewportOverlay {
       this.bus.on('stage:auto-rotate-changed', (payload) => {
         this.autoRotateEnabled = Boolean(payload?.enabled);
         this.updateAutoRotateButton();
+      }),
+      this.bus.on('viewport:critter-info', (payload) => {
+        this.updateStats(payload);
       })
     );
   }
@@ -191,6 +231,48 @@ export class ViewportOverlay {
     button.classList.toggle('is-disabled', !isEnabled);
   }
 
+  updateStats(payload) {
+    if (!this.statsElement || !this.statFields) {
+      return;
+    }
+
+    if (!payload || !payload.stats) {
+      this.statsElement.hidden = true;
+      if (this.statFields.name) {
+        this.statFields.name.textContent = payload?.name ?? '';
+      }
+      ['health', 'speed', 'stamina'].forEach((key) => {
+        if (this.statFields[key]) {
+          this.statFields[key].textContent = '--';
+        }
+      });
+      if (this.statFields.bonus) {
+        this.statFields.bonus.textContent = '';
+        this.statFields.bonus.classList.add('is-empty');
+      }
+      return;
+    }
+
+    const { name, stats } = payload;
+    this.statsElement.hidden = false;
+    if (this.statFields.name) {
+      this.statFields.name.textContent = name ?? '';
+    }
+
+    ['health', 'speed', 'stamina'].forEach((key) => {
+      if (this.statFields[key]) {
+        const value = stats[key];
+        this.statFields[key].textContent = typeof value === 'number' ? String(value) : value ?? '--';
+      }
+    });
+
+    if (this.statFields.bonus) {
+      const bonus = stats.bonus ? `Bonus: ${stats.bonus}` : '';
+      this.statFields.bonus.textContent = bonus;
+      this.statFields.bonus.classList.toggle('is-empty', !bonus);
+    }
+  }
+
   destroy() {
     this.unsubscribe.forEach((off) => off?.());
     this.unsubscribe = [];
@@ -206,6 +288,8 @@ export class ViewportOverlay {
       this.resetButton.replaceWith(this.resetButton.cloneNode(true));
       this.resetButton = null;
     }
+    this.statsElement = null;
+    this.statFields = {};
     if (this.root?.parentNode) {
       this.root.parentNode.removeChild(this.root);
     }

--- a/styles/main.css
+++ b/styles/main.css
@@ -697,9 +697,8 @@ dl dt {
   grid-column: 4;
   grid-row: 1 / span 2;
   position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 58%) minmax(220px, 300px);
-  grid-template-rows: minmax(0, 1fr);
+  display: flex;
+  flex-direction: column;
   background: linear-gradient(155deg, rgba(26, 60, 40, 0.96), rgba(17, 48, 59, 0.92));
   border: 1px solid rgba(107, 182, 207, 0.35);
   border-radius: calc(var(--border-radius-lg) + 4px);
@@ -730,15 +729,16 @@ dl dt {
 .stage-toolbar {
   position: relative;
   z-index: 1;
-  grid-column: 2;
-  grid-row: 1;
-  padding: 1.6rem 1.75rem 1.4rem;
+  padding: 1.4rem 1.75rem 1.6rem;
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
-  background: linear-gradient(180deg, rgba(10, 26, 19, 0.95), rgba(10, 26, 19, 0.4));
+  background: linear-gradient(180deg, rgba(10, 26, 19, 0.92), rgba(10, 26, 19, 0.75));
+  border-top: 1px solid rgba(210, 243, 220, 0.22);
+  box-shadow: 0 -10px 28px rgba(5, 15, 10, 0.4);
   backdrop-filter: blur(4px);
   overflow-y: auto;
+  max-height: clamp(220px, 28vh, 360px);
 }
 
 .stage-tool-panel {
@@ -752,6 +752,7 @@ dl dt {
   flex-direction: column;
   gap: 0.9rem;
   position: relative;
+  width: 100%;
 }
 
 .stage-tool-panel::before {
@@ -940,10 +941,8 @@ dl dt {
 
 .stage-viewport {
   position: relative;
-  grid-column: 1;
-  grid-row: 1;
+  flex: 1 1 auto;
   width: 100%;
-  height: 100%;
   min-height: 0;
 }
 
@@ -960,13 +959,20 @@ dl dt {
   inset: 0;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
   padding: 1.5rem 1.75rem;
   pointer-events: none;
   z-index: 2;
   color: var(--color-text-primary);
-  background: linear-gradient(180deg, rgba(8, 22, 16, 0.35), rgba(8, 22, 16, 0));
-  backdrop-filter: blur(2px);
+  background: linear-gradient(180deg, rgba(6, 18, 13, 0.55), rgba(6, 18, 13, 0));
+  gap: 1.2rem;
+}
+
+.viewport-ui__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  pointer-events: none;
 }
 
 .viewport-ui__bottom {
@@ -974,6 +980,113 @@ dl dt {
   pointer-events: none;
   justify-content: flex-end;
   align-items: flex-end;
+  margin-top: auto;
+}
+
+.viewport-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(210, 243, 220, 0.35);
+  background: rgba(10, 30, 22, 0.7);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+  min-width: 0;
+}
+
+.viewport-status.is-pulsing {
+  box-shadow: 0 0 0 6px rgba(159, 217, 127, 0.22);
+}
+
+.viewport-status[data-state='loading'] {
+  color: var(--color-water);
+  border-color: rgba(107, 182, 207, 0.55);
+}
+
+.viewport-status[data-state='empty'] {
+  color: rgba(247, 255, 244, 0.75);
+  border-color: rgba(247, 255, 244, 0.3);
+}
+
+.viewport-status__text {
+  white-space: nowrap;
+}
+
+.viewport-stats {
+  pointer-events: none;
+  min-width: 220px;
+  max-width: 280px;
+  padding: 1rem 1.1rem;
+  border-radius: 16px;
+  background: linear-gradient(175deg, rgba(14, 36, 26, 0.92), rgba(12, 30, 27, 0.82));
+  border: 1px solid rgba(210, 243, 220, 0.26);
+  box-shadow: 0 16px 38px rgba(8, 22, 16, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.viewport-stats[hidden] {
+  display: none;
+}
+
+.viewport-stats__name {
+  font-family: var(--font-display);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.82rem;
+  color: var(--color-highlight);
+}
+
+.viewport-stats__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.viewport-stats__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.55rem 0.6rem;
+  border-radius: 12px;
+  border: 1px solid rgba(210, 243, 220, 0.24);
+  background: rgba(9, 27, 19, 0.55);
+}
+
+.viewport-stats__item dt {
+  margin: 0;
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(247, 255, 244, 0.65);
+}
+
+.viewport-stats__item dd {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--color-text-primary);
+}
+
+.viewport-stats__bonus {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-water);
+}
+
+.viewport-stats__bonus.is-empty {
+  display: none;
 }
 
 .viewport-controls-panel {
@@ -1076,21 +1189,15 @@ dl dt {
   .stage {
     grid-column: 1 / -1;
     grid-row: 3;
-    height: 320px;
+    min-height: 320px;
     border-radius: var(--border-radius-lg);
-    display: flex;
-    flex-direction: column;
   }
 
   .stage-toolbar {
-    grid-column: auto;
-    grid-row: auto;
-    overflow-y: visible;
+    max-height: none;
   }
 
   .stage-viewport {
-    grid-column: auto;
-    grid-row: auto;
     flex: 1;
   }
 
@@ -1100,6 +1207,20 @@ dl dt {
 
   .viewport-controls {
     justify-content: flex-start;
+  }
+
+  .viewport-ui__top {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .viewport-stats {
+    width: 100%;
+    max-width: none;
+  }
+
+  .viewport-stats__list {
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
   }
 }
 
@@ -1156,9 +1277,11 @@ dl dt {
   .stage {
     grid-row: 5;
     grid-column: 1;
-    height: 320px;
-    display: flex;
-    flex-direction: column;
+    min-height: 320px;
+  }
+
+  .stage-toolbar {
+    max-height: none;
   }
 
   .viewport-ui {
@@ -1177,6 +1300,21 @@ dl dt {
   .viewport-controls {
     justify-content: flex-start;
   }
+
+  .viewport-ui__top {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .viewport-stats {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+  }
+
+  .viewport-stats__list {
+    grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  }
 }
 
 @media (max-width: 700px) {
@@ -1193,11 +1331,23 @@ dl dt {
   }
 
   .stage {
-    height: 260px;
+    min-height: 260px;
+  }
+
+  .stage-toolbar {
+    max-height: none;
   }
 
   .viewport-ui {
     padding: 1rem 1.1rem;
+  }
+
+  .viewport-ui__top {
+    gap: 0.75rem;
+  }
+
+  .viewport-stats__list {
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
   }
 
   .viewport-controls {


### PR DESCRIPTION
## Summary
- place the rig pose controls beneath the viewport and refresh the overlay with an in-viewport critter stat card
- add critter stat metadata, ensure weapons sort from common through mythic, and keep the accent lighting stable between selections
- tighten renderer pixel ratio and rebuild the scene light rig for a sharper, brighter presentation

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d0d41967688329aa6cfcea5ab84cec