### PR TITLE
Improve critter viewport clarity, lighting, and info

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -66,7 +66,7 @@ export class WeaponDisplayApp {
 
     if (defaultWeapon) {
       this.activeWeapon = defaultWeapon;
-      this.sceneManager.applyRarityGlow(defaultWeapon.rarity);
+      this.sceneManager.applyRarityGlow();
     }
 
     this.critterSelector = new CritterSelector({
@@ -133,15 +133,15 @@ export class WeaponDisplayApp {
           <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
         </section>
         <section class="stage" data-component="stage">
-          <div class="stage-toolbar" data-component="stage-toolbar">
-            <div class="stage-tool-panel stage-tool-panel--rig" data-component="rig-controls"></div>
-          </div>
           <div
             class="stage-viewport"
             data-role="stage-viewport"
             aria-label="Critter viewer"
             tabindex="0"
           ></div>
+          <div class="stage-toolbar" data-component="stage-toolbar">
+            <div class="stage-tool-panel stage-tool-panel--rig" data-component="rig-controls"></div>
+          </div>
         </section>
       </div>
     `;
@@ -173,7 +173,7 @@ export class WeaponDisplayApp {
         return;
       }
       this.activeWeapon = weapon;
-      this.sceneManager.applyRarityGlow(weapon.rarity);
+      this.sceneManager.applyRarityGlow();
     });
 
     this.eventBus.on('critter:selected', (critterId) => {
@@ -215,12 +215,32 @@ export class WeaponDisplayApp {
   }
 
   groupWeaponsByCategory() {
-    return this.weapons.reduce((acc, weapon) => {
+    const grouped = this.weapons.reduce((acc, weapon) => {
       const bucket = acc[weapon.category] || [];
       bucket.push(weapon);
       acc[weapon.category] = bucket;
       return acc;
     }, {});
+
+    const rarityRank = {
+      common: 0,
+      rare: 1,
+      legendary: 2,
+      mythic: 3,
+    };
+
+    Object.values(grouped).forEach((list) => {
+      list.sort((a, b) => {
+        const rankA = rarityRank[a.rarity] ?? Number.MAX_SAFE_INTEGER;
+        const rankB = rarityRank[b.rarity] ?? Number.MAX_SAFE_INTEGER;
+        if (rankA !== rankB) {
+          return rankA - rankB;
+        }
+        return a.name.localeCompare(b.name);
+      });
+    });
+
+    return grouped;
   }
 
   findDefaultWeapon() {

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -6,13 +6,7 @@ import { RigController } from './RigController.js';
 const ORBIT_CONTROLS_MODULE =
   'https://esm.sh/three@0.160.0/examples/jsm/controls/OrbitControls.js';
 
-const RARITY_GLOWS = {
-  common: 0x7c6cff,
-  rare: 0x7df0ff,
-  epic: 0xff9af5,
-  legendary: 0xffe37d,
-  mythic: 0xffb7ff,
-};
+const BASE_RARITY_GLOW_COLOR = 0x9fd97f;
 
 const CAMERA_DEFAULT_POSITION = new THREE.Vector3(0, 1.1, 3.3);
 const CAMERA_DEFAULT_TARGET = new THREE.Vector3(0, 0.65, 0);
@@ -330,17 +324,22 @@ export class SceneManager {
   }
 
   setupLights() {
-    const ambient = new THREE.AmbientLight(0xffe6ff, 0.4);
-    const rimLight = new THREE.DirectionalLight(0xa7c9ff, 1.15);
-    rimLight.position.set(-3, 4, 2);
-    const fillLight = new THREE.SpotLight(0xffc3f7, 1.25, 20, Math.PI / 4, 0.85, 2);
-    fillLight.position.set(2.6, 3.8, 1.4);
-    const bounceLight = new THREE.PointLight(0x8cf5ff, 0.6, 6, 2);
-    bounceLight.position.set(0, 1.2, 0.8);
+    const ambient = new THREE.HemisphereLight(0xe8f7ff, 0x0b1a12, 0.65);
+    const keyLight = new THREE.DirectionalLight(0xffffff, 1.35);
+    keyLight.position.set(4.2, 5.1, 3.3);
+
+    const fillLight = new THREE.DirectionalLight(0xffe6c5, 0.9);
+    fillLight.position.set(-2.5, 3.2, -1.6);
+
+    const rimLight = new THREE.DirectionalLight(0x88d6ff, 0.85);
+    rimLight.position.set(-4.1, 2.6, 4.4);
+
+    const bounceLight = new THREE.PointLight(BASE_RARITY_GLOW_COLOR, 0.55, 10, 1.8);
+    bounceLight.position.set(0.2, 1.35, 0.6);
 
     this.rarityLight = bounceLight;
 
-    this.scene.add(ambient, rimLight, fillLight, bounceLight);
+    this.scene.add(ambient, keyLight, fillLight, rimLight, bounceLight);
   }
 
   setupEnvironment() {}
@@ -386,7 +385,7 @@ export class SceneManager {
     this.currentModel = model;
     this.stageGroup.add(model);
 
-    this.applyRarityGlow(weapon.rarity);
+    this.applyRarityGlow();
     this.focusOnCurrentModel({ immediate: false });
     this.emitStageEvent('stage:model-ready', {
       type: 'weapon',
@@ -404,6 +403,7 @@ export class SceneManager {
       type: 'critter',
       id: critter.id,
       name: critter.name,
+      stats: critter.stats ?? null,
     });
 
     let model = null;
@@ -422,6 +422,7 @@ export class SceneManager {
         type: 'critter',
         id: critter.id,
         name: critter.name,
+        stats: critter.stats ?? null,
       });
       this.stopAnimation();
       this.setAutoRotate(false);
@@ -450,6 +451,7 @@ export class SceneManager {
       type: 'critter',
       id: critter.id,
       name: critter.name,
+      stats: critter.stats ?? null,
     });
     this.pendingCritterId = null;
   }
@@ -536,10 +538,10 @@ export class SceneManager {
     this.disposeRigController();
   }
 
-  applyRarityGlow(rarity = 'common') {
-    const color = RARITY_GLOWS[rarity] ?? RARITY_GLOWS.common;
+  applyRarityGlow() {
     if (this.rarityLight) {
-      this.rarityLight.color = new THREE.Color(color);
+      this.rarityLight.color.setHex(BASE_RARITY_GLOW_COLOR);
+      this.rarityLight.intensity = 0.55;
     }
   }
 

--- a/src/data/critters.js
+++ b/src/data/critters.js
@@ -5,6 +5,12 @@ export const critters = [
     modelPath: 'assets/models/critters/models/SK_TH_Frog_Rigged_01.glb',
     scale: 1.15,
     offset: { y: -0.6 },
+    stats: {
+      health: 100,
+      speed: 100,
+      stamina: 100,
+      bonus: 'Double Jump',
+    },
     defaultAnimationId: 'frog_idle',
     animations: [
       { id: 'frog_idle', label: 'Idle', path: 'assets/models/critters/animations/TH_Frog_Idle.glb' },
@@ -80,6 +86,12 @@ export const critters = [
     modelPath: 'assets/models/critters/models/SK_TH_Lizard_Rigged_01.glb',
     scale: 1.25,
     offset: { y: -0.6 },
+    stats: {
+      health: 100,
+      speed: 100,
+      stamina: 100,
+      bonus: '+25% Sprint Boost While Above 50% Stamina',
+    },
     defaultAnimationId: 'lizard_idle',
     animations: [
       { id: 'lizard_idle', label: 'Idle', path: 'assets/models/critters/animations/TH_Lizard_Idle.glb' },

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -5,6 +5,10 @@ export class ViewportOverlay {
     this.root = null;
     this.statusElement = null;
     this.statusText = null;
+    this.statsElement = null;
+    this.statsNameElement = null;
+    this.statsBonusElement = null;
+    this.statsValues = {};
     this.autoRotateButton = null;
     this.focusButton = null;
     this.resetButton = null;
@@ -35,6 +39,32 @@ export class ViewportOverlay {
     this.root = document.createElement('div');
     this.root.className = 'viewport-ui';
     this.root.innerHTML = `
+      <div class="viewport-ui__top">
+        <div class="viewport-status" data-role="viewport-status" role="status" aria-live="polite">
+          <span class="viewport-status__text" data-role="viewport-status-text"></span>
+        </div>
+        <div class="critter-stats" data-role="critter-stats" hidden>
+          <div class="critter-stats__header">
+            <span class="critter-stats__title">Vitals</span>
+            <h3 class="critter-stats__name" data-role="critter-name"></h3>
+          </div>
+          <dl class="critter-stats__grid">
+            <div class="critter-stats__row">
+              <dt>Health</dt>
+              <dd data-stat="health"></dd>
+            </div>
+            <div class="critter-stats__row">
+              <dt>Speed</dt>
+              <dd data-stat="speed"></dd>
+            </div>
+            <div class="critter-stats__row">
+              <dt>Stamina</dt>
+              <dd data-stat="stamina"></dd>
+            </div>
+          </dl>
+          <p class="critter-stats__bonus" data-role="critter-bonus"></p>
+        </div>
+      </div>
       <div class="viewport-ui__bottom">
         <div class="viewport-controls-panel">
           <div class="viewport-controls" role="group" aria-label="Viewport controls">
@@ -56,9 +86,19 @@ export class ViewportOverlay {
     this.container.appendChild(this.root);
     this.statusElement = this.root.querySelector('[data-role="viewport-status"]');
     this.statusText = this.root.querySelector('[data-role="viewport-status-text"]');
+    this.statsElement = this.root.querySelector('[data-role="critter-stats"]');
+    this.statsNameElement = this.root.querySelector('[data-role="critter-name"]');
+    this.statsBonusElement = this.root.querySelector('[data-role="critter-bonus"]');
+    this.statsValues = {};
+    this.root.querySelectorAll('[data-stat]').forEach((node) => {
+      if (node.dataset.stat) {
+        this.statsValues[node.dataset.stat] = node;
+      }
+    });
     this.autoRotateButton = this.root.querySelector('[data-action="autorotate"]');
     this.focusButton = this.root.querySelector('[data-action="focus"]');
     this.resetButton = this.root.querySelector('[data-action="reset"]');
+    this.updateCritterStats(null);
   }
 
   bindControls() {
@@ -97,6 +137,11 @@ export class ViewportOverlay {
         const name = payload?.name ?? 'Model';
         this.setStatus('loading', `Loading ${name}...`);
         this.setLoading(true);
+        if (payload?.type === 'critter') {
+          this.updateCritterStats(payload, { state: 'loading' });
+        } else {
+          this.updateCritterStats(null);
+        }
       }),
       this.bus.on('stage:model-ready', (payload) => {
         const name = payload?.name ?? 'Model';
@@ -108,6 +153,11 @@ export class ViewportOverlay {
           autorotate: true,
         });
         this.flashStatus();
+        if (payload?.type === 'critter') {
+          this.updateCritterStats(payload, { state: 'ready' });
+        } else {
+          this.updateCritterStats(null);
+        }
       }),
       this.bus.on('stage:model-missing', (payload) => {
         const name = payload?.name ?? 'model';
@@ -118,6 +168,7 @@ export class ViewportOverlay {
           reset: true,
           autorotate: false,
         });
+        this.updateCritterStats(null);
       }),
       this.bus.on('stage:focus-achieved', () => {
         this.flashStatus();
@@ -136,6 +187,7 @@ export class ViewportOverlay {
     this.state = state;
     if (this.statusElement) {
       this.statusElement.dataset.state = state;
+      this.statusElement.classList.remove('is-pulsing');
     }
     if (this.statusText) {
       this.statusText.textContent = message;
@@ -183,6 +235,45 @@ export class ViewportOverlay {
     this.updateButtonState(this.autoRotateButton, autorotate);
   }
 
+  updateCritterStats(detail, { state } = {}) {
+    if (!this.statsElement) {
+      return;
+    }
+
+    const stats = detail?.stats;
+    if (!stats) {
+      this.statsElement.hidden = true;
+      this.statsElement.dataset.state = 'empty';
+      return;
+    }
+
+    this.statsElement.hidden = false;
+    this.statsElement.dataset.state = state || 'ready';
+
+    if (this.statsNameElement) {
+      this.statsNameElement.textContent = detail?.name || 'Critter';
+    }
+
+    ['health', 'speed', 'stamina'].forEach((key) => {
+      const node = this.statsValues[key];
+      if (!node) {
+        return;
+      }
+      const value = stats[key];
+      node.textContent = typeof value === 'number' ? `${value}` : value ?? '—';
+    });
+
+    if (this.statsBonusElement) {
+      if (stats.bonus) {
+        this.statsBonusElement.textContent = stats.bonus;
+        this.statsBonusElement.hidden = false;
+      } else {
+        this.statsBonusElement.textContent = '';
+        this.statsBonusElement.hidden = true;
+      }
+    }
+  }
+
   updateButtonState(button, isEnabled) {
     if (!button || typeof isEnabled === 'undefined') {
       return;
@@ -213,5 +304,9 @@ export class ViewportOverlay {
       clearTimeout(this.pulseTimeout);
       this.pulseTimeout = null;
     }
+    this.statsElement = null;
+    this.statsNameElement = null;
+    this.statsBonusElement = null;
+    this.statsValues = {};
   }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -698,8 +698,8 @@ dl dt {
   grid-row: 1 / span 2;
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 58%) minmax(220px, 300px);
-  grid-template-rows: minmax(0, 1fr);
+  grid-template-columns: 1fr;
+  grid-template-rows: minmax(0, 1fr) auto;
   background: linear-gradient(155deg, rgba(26, 60, 40, 0.96), rgba(17, 48, 59, 0.92));
   border: 1px solid rgba(107, 182, 207, 0.35);
   border-radius: calc(var(--border-radius-lg) + 4px);
@@ -730,15 +730,16 @@ dl dt {
 .stage-toolbar {
   position: relative;
   z-index: 1;
-  grid-column: 2;
-  grid-row: 1;
-  padding: 1.6rem 1.75rem 1.4rem;
+  grid-column: 1;
+  grid-row: 2;
+  padding: 1.4rem 1.75rem 1.6rem;
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
   background: linear-gradient(180deg, rgba(10, 26, 19, 0.95), rgba(10, 26, 19, 0.4));
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(6px);
   overflow-y: auto;
+  border-top: 1px solid rgba(107, 182, 207, 0.2);
 }
 
 .stage-tool-panel {
@@ -960,13 +961,146 @@ dl dt {
   inset: 0;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
-  padding: 1.5rem 1.75rem;
+  justify-content: space-between;
+  padding: 1.75rem;
   pointer-events: none;
   z-index: 2;
   color: var(--color-text-primary);
-  background: linear-gradient(180deg, rgba(8, 22, 16, 0.35), rgba(8, 22, 16, 0));
-  backdrop-filter: blur(2px);
+  background: linear-gradient(180deg, rgba(8, 22, 16, 0.38), rgba(8, 22, 16, 0));
+}
+
+.viewport-ui__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.viewport-status {
+  pointer-events: none;
+  min-width: 180px;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(210, 243, 220, 0.32);
+  background: rgba(12, 30, 21, 0.75);
+  box-shadow: 0 14px 26px rgba(7, 20, 14, 0.35);
+  font-family: var(--font-display);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.viewport-status[data-state='loading'] {
+  background: rgba(107, 182, 207, 0.32);
+  border-color: rgba(107, 182, 207, 0.48);
+}
+
+.viewport-status[data-state='ready'] {
+  background: rgba(159, 217, 127, 0.28);
+  border-color: rgba(159, 217, 127, 0.45);
+}
+
+.viewport-status[data-state='empty'] {
+  background: rgba(197, 141, 82, 0.32);
+  border-color: rgba(197, 141, 82, 0.5);
+}
+
+.viewport-status__text {
+  display: block;
+}
+
+.viewport-status.is-pulsing {
+  animation: viewport-status-pulse 0.9s ease;
+}
+
+@keyframes viewport-status-pulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 14px 26px rgba(7, 20, 14, 0.35);
+  }
+  50% {
+    transform: scale(1.02);
+    box-shadow: 0 18px 34px rgba(7, 20, 14, 0.45);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 14px 26px rgba(7, 20, 14, 0.35);
+  }
+}
+
+.critter-stats {
+  pointer-events: none;
+  margin-left: auto;
+  padding: 1.1rem 1.35rem;
+  border-radius: 18px;
+  border: 1px solid rgba(210, 243, 220, 0.28);
+  background: linear-gradient(165deg, rgba(16, 37, 27, 0.9), rgba(17, 44, 52, 0.75));
+  box-shadow: 0 20px 32px rgba(7, 20, 14, 0.45);
+  min-width: 220px;
+  transition: opacity 0.3s ease;
+}
+
+.critter-stats[data-state='loading'] {
+  opacity: 0.65;
+}
+
+.critter-stats__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.critter-stats__title {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-highlight);
+}
+
+.critter-stats__name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-family: var(--font-display);
+  letter-spacing: 0.12em;
+  color: var(--color-text-primary);
+}
+
+.critter-stats__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.45rem 1rem;
+  margin: 0 0 0.75rem;
+}
+
+.critter-stats__row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.critter-stats__row dt {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(243, 248, 240, 0.72);
+}
+
+.critter-stats__row dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.critter-stats__bonus {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-water);
 }
 
 .viewport-ui__bottom {
@@ -981,8 +1115,9 @@ dl dt {
   padding: 1rem 1.35rem;
   border-radius: 18px;
   border: 1px solid rgba(210, 243, 220, 0.28);
-  background: linear-gradient(165deg, rgba(16, 37, 27, 0.85), rgba(17, 44, 52, 0.78));
+  background: linear-gradient(165deg, rgba(16, 37, 27, 0.82), rgba(17, 44, 52, 0.7));
   box-shadow: 0 18px 32px rgba(7, 20, 14, 0.45);
+  backdrop-filter: blur(8px);
 }
 
 .viewport-controls {


### PR DESCRIPTION
## Summary
- relocate the pose controls under the viewport and refresh the overlay to show critter stats in-scene
- add frog and lizard stat blocks and emit them with stage events so the overlay stays in sync
- rebuild the lighting rig and keep the rarity glow color stable for consistent illumination, while sorting weapon cards by rarity

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d0d41967688329aa6cfcea5ab84cec