### PR TITLE
Enhance critter viewport presentation and lighting

### DIFF
--- a/src/app/WeaponDisplayApp.js
+++ b/src/app/WeaponDisplayApp.js
@@ -7,6 +7,12 @@ import { CritterSelector } from '../hud/components/CritterSelector.js';
 import { ViewportOverlay } from '../hud/components/ViewportOverlay.js';
 import { RigControlPanel } from '../hud/components/RigControlPanel.js';
 
+const RARITY_ORDER = ['common', 'rare', 'legendary', 'mythic'];
+const RARITY_WEIGHT = RARITY_ORDER.reduce((acc, rarity, index) => {
+  acc[rarity] = index;
+  return acc;
+}, {});
+
 export class WeaponDisplayApp {
   constructor(rootElement) {
     this.root = rootElement;
@@ -97,6 +103,7 @@ export class WeaponDisplayApp {
     }
 
     this.critterSelector.render(defaultCritter?.id);
+    this.eventBus.emit('viewport:critter-details', { critter: defaultCritter || null });
   }
 
   buildLayout() {
@@ -133,15 +140,15 @@ export class WeaponDisplayApp {
           <div class="panel-footer" data-role="detail-footer">Awaiting selection</div>
         </section>
         <section class="stage" data-component="stage">
-          <div class="stage-toolbar" data-component="stage-toolbar">
-            <div class="stage-tool-panel stage-tool-panel--rig" data-component="rig-controls"></div>
-          </div>
           <div
             class="stage-viewport"
             data-role="stage-viewport"
             aria-label="Critter viewer"
             tabindex="0"
           ></div>
+          <div class="stage-toolbar" data-component="stage-toolbar">
+            <div class="stage-tool-panel stage-tool-panel--rig" data-component="rig-controls"></div>
+          </div>
         </section>
       </div>
     `;
@@ -179,10 +186,14 @@ export class WeaponDisplayApp {
     this.eventBus.on('critter:selected', (critterId) => {
       const critter = this.critterMap.get(critterId);
       if (!critter || this.activeCritter?.id === critterId) {
+        if (!critter) {
+          this.eventBus.emit('viewport:critter-details', { critter: null });
+        }
         return;
       }
 
       this.activeCritter = critter;
+      this.eventBus.emit('viewport:critter-details', { critter });
       this.activeAnimationId = this.resolveAnimationId(critter);
       const activeAnimation = this.findAnimation(critter, this.activeAnimationId);
 
@@ -215,12 +226,25 @@ export class WeaponDisplayApp {
   }
 
   groupWeaponsByCategory() {
-    return this.weapons.reduce((acc, weapon) => {
+    const grouped = this.weapons.reduce((acc, weapon) => {
       const bucket = acc[weapon.category] || [];
       bucket.push(weapon);
       acc[weapon.category] = bucket;
       return acc;
     }, {});
+
+    Object.values(grouped).forEach((weapons) => {
+      weapons.sort((a, b) => {
+        const rankA = RARITY_WEIGHT[a.rarity] ?? RARITY_ORDER.length;
+        const rankB = RARITY_WEIGHT[b.rarity] ?? RARITY_ORDER.length;
+        if (rankA !== rankB) {
+          return rankA - rankB;
+        }
+        return a.name.localeCompare(b.name);
+      });
+    });
+
+    return grouped;
   }
 
   findDefaultWeapon() {

--- a/src/core/RendererFactory.js
+++ b/src/core/RendererFactory.js
@@ -7,6 +7,10 @@ export const createRenderer = (container) => {
   renderer.setSize(clientWidth, clientHeight, false);
   renderer.outputColorSpace = THREE.SRGBColorSpace;
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.1;
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  renderer.physicallyCorrectLights = true;
   container.appendChild(renderer.domElement);
   return renderer;
 };

--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -14,6 +14,9 @@ const RARITY_GLOWS = {
   mythic: 0xffb7ff,
 };
 
+const DEFAULT_STAGE_LIGHT_COLOR = 0xaad7ff;
+const DEFAULT_STAGE_LIGHT_INTENSITY = 1.15;
+
 const CAMERA_DEFAULT_POSITION = new THREE.Vector3(0, 1.1, 3.3);
 const CAMERA_DEFAULT_TARGET = new THREE.Vector3(0, 0.65, 0);
 const CAMERA_TRANSITION_SPEED = 2.25;
@@ -331,19 +334,39 @@ export class SceneManager {
 
   setupLights() {
     const ambient = new THREE.AmbientLight(0xffe6ff, 0.4);
-    const rimLight = new THREE.DirectionalLight(0xa7c9ff, 1.15);
-    rimLight.position.set(-3, 4, 2);
-    const fillLight = new THREE.SpotLight(0xffc3f7, 1.25, 20, Math.PI / 4, 0.85, 2);
-    fillLight.position.set(2.6, 3.8, 1.4);
-    const bounceLight = new THREE.PointLight(0x8cf5ff, 0.6, 6, 2);
-    bounceLight.position.set(0, 1.2, 0.8);
+    const rimLight = new THREE.DirectionalLight(0xa7c9ff, 1.1);
+    rimLight.position.set(-3.5, 4.4, 2.8);
+    const fillLight = new THREE.SpotLight(0xc4e5ff, 1.2, 24, Math.PI / 4.2, 0.8, 2.1);
+    fillLight.position.set(3, 4.2, 1.6);
+    const bounceLight = new THREE.PointLight(DEFAULT_STAGE_LIGHT_COLOR, DEFAULT_STAGE_LIGHT_INTENSITY, 12, 2.2);
+    bounceLight.position.set(0.4, 1.4, 1.1);
 
     this.rarityLight = bounceLight;
 
-    this.scene.add(ambient, rimLight, fillLight, bounceLight);
+    const hemisphere = new THREE.HemisphereLight(0xcfe8ff, 0x0c1a12, 0.45);
+    const keyLight = new THREE.DirectionalLight(0xfff6dc, 1.55);
+    keyLight.position.set(4.5, 6, 3.5);
+    const backLight = new THREE.DirectionalLight(0x9fd97f, 0.85);
+    backLight.position.set(-3.5, 5.5, -2.5);
+
+    hemisphere.name = 'hemi-light';
+    keyLight.name = 'key-light';
+    backLight.name = 'back-light';
+
+    this.scene.add(ambient, hemisphere, keyLight, backLight, fillLight, bounceLight, rimLight);
+    this.applyDefaultStageLighting();
   }
 
   setupEnvironment() {}
+
+  applyDefaultStageLighting() {
+    if (!this.rarityLight) {
+      return;
+    }
+
+    this.rarityLight.color = new THREE.Color(DEFAULT_STAGE_LIGHT_COLOR);
+    this.rarityLight.intensity = DEFAULT_STAGE_LIGHT_INTENSITY;
+  }
 
   async loadWeapon(weapon) {
     if (!weapon) return;
@@ -441,6 +464,8 @@ export class SceneManager {
     this.currentCritterId = critter.id;
     this.stageGroup.add(model);
 
+    this.applyDefaultStageLighting();
+
     this.setupRigController(model);
 
     this.mixer = new THREE.AnimationMixer(model);
@@ -534,13 +559,22 @@ export class SceneManager {
     this.activeAction = null;
     this.pendingAnimationId = null;
     this.disposeRigController();
+    this.applyDefaultStageLighting();
   }
 
   applyRarityGlow(rarity = 'common') {
     const color = RARITY_GLOWS[rarity] ?? RARITY_GLOWS.common;
-    if (this.rarityLight) {
-      this.rarityLight.color = new THREE.Color(color);
+    if (!this.rarityLight) {
+      return;
     }
+
+    if (this.currentCritterId) {
+      this.applyDefaultStageLighting();
+      return;
+    }
+
+    this.rarityLight.color = new THREE.Color(color);
+    this.rarityLight.intensity = DEFAULT_STAGE_LIGHT_INTENSITY;
   }
 
   createPlaceholderModel() {
@@ -553,6 +587,8 @@ export class SceneManager {
   handleResize() {
     if (!this.renderer || !this.camera) return;
     const { clientWidth, clientHeight } = this.container;
+    const pixelRatio = window.devicePixelRatio || 1;
+    this.renderer.setPixelRatio(pixelRatio);
     this.renderer.setSize(clientWidth, clientHeight, false);
     this.camera.aspect = clientWidth / Math.max(clientHeight, 1);
     this.camera.updateProjectionMatrix();

--- a/src/data/critters.js
+++ b/src/data/critters.js
@@ -6,6 +6,12 @@ export const critters = [
     scale: 1.15,
     offset: { y: -0.6 },
     defaultAnimationId: 'frog_idle',
+    stats: {
+      health: 100,
+      speed: 100,
+      stamina: 100,
+      bonus: 'Double Jump',
+    },
     animations: [
       { id: 'frog_idle', label: 'Idle', path: 'assets/models/critters/animations/TH_Frog_Idle.glb' },
       {
@@ -81,6 +87,12 @@ export const critters = [
     scale: 1.25,
     offset: { y: -0.6 },
     defaultAnimationId: 'lizard_idle',
+    stats: {
+      health: 100,
+      speed: 100,
+      stamina: 100,
+      bonus: '+25% Sprint Boost While Above 50% Stamina',
+    },
     animations: [
       { id: 'lizard_idle', label: 'Idle', path: 'assets/models/critters/animations/TH_Lizard_Idle.glb' },
       {

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -13,6 +13,14 @@ export class ViewportOverlay {
     this.unsubscribe = [];
     this.pulseTimeout = null;
     this.isLoading = false;
+    this.critterCardElement = null;
+    this.critterNameElement = null;
+    this.critterStatElements = {
+      health: null,
+      speed: null,
+      stamina: null,
+      bonus: null,
+    };
   }
 
   init() {
@@ -35,6 +43,35 @@ export class ViewportOverlay {
     this.root = document.createElement('div');
     this.root.className = 'viewport-ui';
     this.root.innerHTML = `
+      <div class="viewport-ui__top">
+        <div class="viewport-status" data-role="viewport-status" data-state="idle">
+          <span class="viewport-status__label">Preview</span>
+          <span class="viewport-status__text" data-role="viewport-status-text"></span>
+        </div>
+        <aside class="viewport-critter" data-role="critter-card" hidden>
+          <div class="viewport-critter__header">
+            <span class="viewport-critter__name" data-role="critter-name"></span>
+          </div>
+          <dl class="viewport-critter__stats">
+            <div class="viewport-critter__stat">
+              <dt>Health</dt>
+              <dd data-role="critter-stat-health"></dd>
+            </div>
+            <div class="viewport-critter__stat">
+              <dt>Speed</dt>
+              <dd data-role="critter-stat-speed"></dd>
+            </div>
+            <div class="viewport-critter__stat">
+              <dt>Stamina</dt>
+              <dd data-role="critter-stat-stamina"></dd>
+            </div>
+            <div class="viewport-critter__stat viewport-critter__stat--wide">
+              <dt>Bonus</dt>
+              <dd data-role="critter-stat-bonus"></dd>
+            </div>
+          </dl>
+        </aside>
+      </div>
       <div class="viewport-ui__bottom">
         <div class="viewport-controls-panel">
           <div class="viewport-controls" role="group" aria-label="Viewport controls">
@@ -59,6 +96,14 @@ export class ViewportOverlay {
     this.autoRotateButton = this.root.querySelector('[data-action="autorotate"]');
     this.focusButton = this.root.querySelector('[data-action="focus"]');
     this.resetButton = this.root.querySelector('[data-action="reset"]');
+    this.critterCardElement = this.root.querySelector('[data-role="critter-card"]');
+    this.critterNameElement = this.root.querySelector('[data-role="critter-name"]');
+    this.critterStatElements = {
+      health: this.root.querySelector('[data-role="critter-stat-health"]'),
+      speed: this.root.querySelector('[data-role="critter-stat-speed"]'),
+      stamina: this.root.querySelector('[data-role="critter-stat-stamina"]'),
+      bonus: this.root.querySelector('[data-role="critter-stat-bonus"]'),
+    };
   }
 
   bindControls() {
@@ -118,6 +163,9 @@ export class ViewportOverlay {
           reset: true,
           autorotate: false,
         });
+        if (payload?.type === 'critter') {
+          this.updateCritterDetails(null);
+        }
       }),
       this.bus.on('stage:focus-achieved', () => {
         this.flashStatus();
@@ -128,6 +176,17 @@ export class ViewportOverlay {
       this.bus.on('stage:auto-rotate-changed', (payload) => {
         this.autoRotateEnabled = Boolean(payload?.enabled);
         this.updateAutoRotateButton();
+      }),
+      this.bus.on('viewport:critter-details', (payload) => {
+        const critter = payload?.critter ?? null;
+        this.updateCritterDetails(critter);
+        if (!this.isLoading) {
+          if (critter) {
+            this.setStatus('ready', critter.name);
+          } else {
+            this.setStatus('idle', 'Select a critter to preview.');
+          }
+        }
       })
     );
   }
@@ -181,6 +240,44 @@ export class ViewportOverlay {
     this.updateButtonState(this.focusButton, focus);
     this.updateButtonState(this.resetButton, reset);
     this.updateButtonState(this.autoRotateButton, autorotate);
+  }
+
+  updateCritterDetails(critter) {
+    if (!this.critterCardElement) {
+      return;
+    }
+
+    if (!critter) {
+      this.critterCardElement.hidden = true;
+      Object.values(this.critterStatElements).forEach((element) => {
+        if (element) {
+          element.textContent = '';
+        }
+      });
+      if (this.critterNameElement) {
+        this.critterNameElement.textContent = '';
+      }
+      return;
+    }
+
+    this.critterCardElement.hidden = false;
+    if (this.critterNameElement) {
+      this.critterNameElement.textContent = critter.name;
+    }
+
+    const stats = critter.stats ?? {};
+    if (this.critterStatElements.health) {
+      this.critterStatElements.health.textContent = stats.health ?? '—';
+    }
+    if (this.critterStatElements.speed) {
+      this.critterStatElements.speed.textContent = stats.speed ?? '—';
+    }
+    if (this.critterStatElements.stamina) {
+      this.critterStatElements.stamina.textContent = stats.stamina ?? '—';
+    }
+    if (this.critterStatElements.bonus) {
+      this.critterStatElements.bonus.textContent = stats.bonus ?? '—';
+    }
   }
 
   updateButtonState(button, isEnabled) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -698,8 +698,8 @@ dl dt {
   grid-row: 1 / span 2;
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 58%) minmax(220px, 300px);
-  grid-template-rows: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr) auto;
   background: linear-gradient(155deg, rgba(26, 60, 40, 0.96), rgba(17, 48, 59, 0.92));
   border: 1px solid rgba(107, 182, 207, 0.35);
   border-radius: calc(var(--border-radius-lg) + 4px);
@@ -730,15 +730,16 @@ dl dt {
 .stage-toolbar {
   position: relative;
   z-index: 1;
-  grid-column: 2;
-  grid-row: 1;
-  padding: 1.6rem 1.75rem 1.4rem;
+  grid-column: 1;
+  grid-row: 2;
+  padding: 1.4rem 1.75rem 1.6rem;
   display: flex;
   flex-direction: column;
   gap: 1.1rem;
-  background: linear-gradient(180deg, rgba(10, 26, 19, 0.95), rgba(10, 26, 19, 0.4));
-  backdrop-filter: blur(4px);
+  background: linear-gradient(180deg, rgba(10, 26, 19, 0.95), rgba(10, 26, 19, 0.6));
+  backdrop-filter: blur(6px);
   overflow-y: auto;
+  border-top: 1px solid rgba(107, 182, 207, 0.25);
 }
 
 .stage-tool-panel {
@@ -960,13 +961,22 @@ dl dt {
   inset: 0;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
-  padding: 1.5rem 1.75rem;
+  justify-content: space-between;
+  padding: 1.5rem 1.75rem 1.35rem;
   pointer-events: none;
   z-index: 2;
   color: var(--color-text-primary);
-  background: linear-gradient(180deg, rgba(8, 22, 16, 0.35), rgba(8, 22, 16, 0));
-  backdrop-filter: blur(2px);
+  background: linear-gradient(180deg, rgba(8, 22, 16, 0.42), rgba(8, 22, 16, 0));
+  gap: 1.25rem;
+}
+
+.viewport-ui__top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.15rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  pointer-events: none;
 }
 
 .viewport-ui__bottom {
@@ -976,6 +986,119 @@ dl dt {
   align-items: flex-end;
 }
 
+.viewport-status {
+  pointer-events: none;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.65rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(210, 243, 220, 0.38);
+  background: linear-gradient(160deg, rgba(12, 32, 23, 0.85), rgba(12, 32, 23, 0.55));
+  min-width: 200px;
+}
+
+.viewport-status[data-state='loading'] {
+  border-color: rgba(107, 182, 207, 0.65);
+}
+
+.viewport-status[data-state='empty'] {
+  border-color: rgba(197, 141, 82, 0.55);
+}
+
+.viewport-status__label {
+  font-size: 0.65rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(247, 255, 244, 0.6);
+}
+
+.viewport-status__text {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  letter-spacing: 0.1em;
+}
+
+.viewport-status.is-pulsing {
+  animation: viewport-status-pulse 0.9s ease;
+}
+
+@keyframes viewport-status-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(159, 217, 127, 0.45);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(159, 217, 127, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(159, 217, 127, 0);
+  }
+}
+
+.viewport-critter {
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  padding: 0.95rem 1.25rem;
+  border-radius: 18px;
+  border: 1px solid rgba(210, 243, 220, 0.32);
+  background: linear-gradient(160deg, rgba(11, 30, 21, 0.85), rgba(16, 37, 27, 0.65));
+  max-width: clamp(240px, 32vw, 320px);
+  box-shadow: 0 18px 28px rgba(7, 20, 14, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+.viewport-critter[hidden] {
+  display: none;
+}
+
+.viewport-critter__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.viewport-critter__name {
+  font-family: var(--font-display);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 1rem;
+  color: var(--color-highlight);
+}
+
+.viewport-critter__stats {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.viewport-critter__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.viewport-critter__stat--wide {
+  grid-column: 1 / -1;
+}
+
+.viewport-critter__stat dt {
+  margin: 0;
+  font-size: 0.62rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(247, 255, 244, 0.55);
+}
+
+.viewport-critter__stat dd {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
 .viewport-controls-panel {
   pointer-events: auto;
   padding: 1rem 1.35rem;
@@ -983,6 +1106,10 @@ dl dt {
   border: 1px solid rgba(210, 243, 220, 0.28);
   background: linear-gradient(165deg, rgba(16, 37, 27, 0.85), rgba(17, 44, 52, 0.78));
   box-shadow: 0 18px 32px rgba(7, 20, 14, 0.45);
+}
+
+.viewport-controls-panel {
+  backdrop-filter: blur(6px);
 }
 
 .viewport-controls {
@@ -1076,22 +1203,23 @@ dl dt {
   .stage {
     grid-column: 1 / -1;
     grid-row: 3;
-    height: 320px;
+    min-height: 360px;
+    height: auto;
     border-radius: var(--border-radius-lg);
-    display: flex;
-    flex-direction: column;
+    grid-template-rows: minmax(240px, 1fr) auto;
   }
 
   .stage-toolbar {
-    grid-column: auto;
-    grid-row: auto;
+    grid-column: 1;
+    grid-row: 2;
     overflow-y: visible;
+    padding: 1.25rem 1.5rem 1.4rem;
   }
 
   .stage-viewport {
-    grid-column: auto;
-    grid-row: auto;
-    flex: 1;
+    grid-column: 1;
+    grid-row: 1;
+    min-height: 240px;
   }
 
   .viewport-ui {
@@ -1156,13 +1284,25 @@ dl dt {
   .stage {
     grid-row: 5;
     grid-column: 1;
-    height: 320px;
-    display: flex;
-    flex-direction: column;
+    min-height: 340px;
+    grid-template-rows: minmax(220px, 1fr) auto;
   }
 
   .viewport-ui {
     padding: 1.1rem 1.3rem;
+  }
+
+  .viewport-ui__top {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .viewport-critter {
+    max-width: none;
+  }
+
+  .viewport-critter__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .viewport-ui__bottom {
@@ -1193,11 +1333,17 @@ dl dt {
   }
 
   .stage {
-    height: 260px;
+    height: auto;
+    min-height: 300px;
+    grid-template-rows: minmax(200px, 1fr) auto;
   }
 
   .viewport-ui {
-    padding: 1rem 1.1rem;
+    padding: 0.95rem 1.1rem;
+  }
+
+  .viewport-critter__stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .viewport-controls {


### PR DESCRIPTION
## Summary
- repositioned the stage so pose controls sit beneath the viewport and removed the blanket blur to sharpen the critter view
- added in-viewport critter stat cards and wiring so the overlay stays in sync with the active selection
- tuned renderer and lighting to keep illumination consistent between selections and sorted gear by the requested rarity order

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0d41967688329aa6cfcea5ab84cec