### PR TITLE
Improve critter viewport layout

### DIFF
--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -444,7 +444,7 @@ export class SceneManager {
 
     this.mixer = new THREE.AnimationMixer(model);
     this.activeAction = null;
-    this.focusOnCurrentModel({ immediate: false });
+    this.resetView(true);
     this.emitStageEvent('stage:model-ready', {
       type: 'critter',
       id: critter.id,

--- a/src/hud/components/ViewportOverlay.js
+++ b/src/hud/components/ViewportOverlay.js
@@ -41,6 +41,8 @@ export class ViewportOverlay {
         <div class="viewport-status" data-role="viewport-status">
           <span class="viewport-status__text" data-role="viewport-status-text"></span>
         </div>
+      </div>
+      <div class="viewport-ui__bottom">
         <div class="viewport-stats" data-role="viewport-stats" hidden>
           <span class="viewport-stats__name" data-stat="name"></span>
           <dl class="viewport-stats__list">
@@ -59,8 +61,6 @@ export class ViewportOverlay {
           </dl>
           <p class="viewport-stats__bonus" data-stat="bonus"></p>
         </div>
-      </div>
-      <div class="viewport-ui__bottom">
         <div class="viewport-controls-panel">
           <div class="viewport-controls" role="group" aria-label="Viewport controls">
             <button type="button" class="viewport-button" data-action="focus">Focus Model</button>

--- a/styles/main.css
+++ b/styles/main.css
@@ -73,7 +73,7 @@ body::after {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 200px 300px minmax(360px, 520px) minmax(420px, 1fr);
+  grid-template-columns: 200px 300px minmax(216px, 312px) minmax(520px, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1.5rem;
   padding: 2.25rem 2.75rem;
@@ -969,7 +969,7 @@ dl dt {
 
 .viewport-ui__top {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: flex-start;
   gap: 1.5rem;
   pointer-events: none;
@@ -978,8 +978,10 @@ dl dt {
 .viewport-ui__bottom {
   display: flex;
   pointer-events: none;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: flex-end;
+  gap: 1.2rem;
+  flex-wrap: wrap;
   margin-top: auto;
 }
 
@@ -1018,6 +1020,7 @@ dl dt {
 
 .viewport-stats {
   pointer-events: none;
+  flex: 0 1 280px;
   min-width: 220px;
   max-width: 280px;
   padding: 1rem 1.1rem;
@@ -1091,6 +1094,7 @@ dl dt {
 
 .viewport-controls-panel {
   pointer-events: auto;
+  flex: 1 1 260px;
   padding: 1rem 1.35rem;
   border-radius: 18px;
   border: 1px solid rgba(210, 243, 220, 0.28);
@@ -1291,9 +1295,11 @@ dl dt {
   .viewport-ui__bottom {
     flex-direction: column;
     align-items: stretch;
+    gap: 1rem;
   }
 
   .viewport-controls-panel {
+    flex: 1 1 100%;
     width: 100%;
   }
 
@@ -1307,6 +1313,7 @@ dl dt {
   }
 
   .viewport-stats {
+    flex: 1 1 100%;
     width: 100%;
     max-width: none;
     min-width: 0;


### PR DESCRIPTION
## Summary
- shrink the Equipment Info column to give the critter viewport more horizontal space
- move the critter stats panel into the lower toolbar so it no longer obscures the model
- reset the camera to the default view whenever a critter loads so the initial pose matches the reset state

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0d88f8488832999d4e5fbd52fed94