### PR TITLE
Tighten equipment panel width and default critter view

### DIFF
--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -308,6 +308,37 @@ export class SceneManager {
     return true;
   }
 
+  updateDefaultViewFromCurrentModel() {
+    if (!this.currentModel) {
+      return false;
+    }
+
+    this.currentModel.updateWorldMatrix?.(true, true);
+    this.boundingBox.setFromObject(this.currentModel);
+    if (this.boundingBox.isEmpty()) {
+      return false;
+    }
+
+    this.boundingBox.getBoundingSphere(this.boundingSphere);
+    const { center, radius } = this.boundingSphere;
+
+    if (!Number.isFinite(radius) || radius <= 0) {
+      return false;
+    }
+
+    if (!Number.isFinite(center.x) || !Number.isFinite(center.y) || !Number.isFinite(center.z)) {
+      return false;
+    }
+
+    const distance = this.computeFrameDistance(radius);
+    const offset = FOCUS_OFFSET_DIRECTION.clone().multiplyScalar(distance);
+    const position = center.clone().add(offset);
+
+    this.defaultCameraTarget.copy(center);
+    this.defaultCameraPosition.copy(position);
+    return true;
+  }
+
   resetView(immediate = false) {
     this.startCameraTransition(this.defaultCameraPosition, this.defaultCameraTarget, { immediate });
     this.emitStageEvent('stage:view-reset');
@@ -386,6 +417,10 @@ export class SceneManager {
     this.stageGroup.add(model);
 
     this.applyRarityGlow();
+    if (!this.updateDefaultViewFromCurrentModel()) {
+      this.defaultCameraPosition.copy(CAMERA_DEFAULT_POSITION);
+      this.defaultCameraTarget.copy(CAMERA_DEFAULT_TARGET);
+    }
     this.focusOnCurrentModel({ immediate: false });
     this.emitStageEvent('stage:model-ready', {
       type: 'weapon',
@@ -444,7 +479,11 @@ export class SceneManager {
 
     this.mixer = new THREE.AnimationMixer(model);
     this.activeAction = null;
-    this.focusOnCurrentModel({ immediate: false });
+    if (!this.updateDefaultViewFromCurrentModel()) {
+      this.defaultCameraPosition.copy(CAMERA_DEFAULT_POSITION);
+      this.defaultCameraTarget.copy(CAMERA_DEFAULT_TARGET);
+    }
+    this.resetView(true);
     this.emitStageEvent('stage:model-ready', {
       type: 'critter',
       id: critter.id,
@@ -533,6 +572,8 @@ export class SceneManager {
     this.activeAction = null;
     this.pendingAnimationId = null;
     this.disposeRigController();
+    this.defaultCameraPosition.copy(CAMERA_DEFAULT_POSITION);
+    this.defaultCameraTarget.copy(CAMERA_DEFAULT_TARGET);
   }
 
   applyRarityGlow() {

--- a/styles/main.css
+++ b/styles/main.css
@@ -73,7 +73,7 @@ body::after {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 200px 300px minmax(360px, 520px) minmax(420px, 1fr);
+  grid-template-columns: 200px 300px minmax(216px, 312px) minmax(540px, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1.5rem;
   padding: 2.25rem 2.75rem;
@@ -1018,16 +1018,18 @@ dl dt {
 
 .viewport-stats {
   pointer-events: none;
-  min-width: 220px;
-  max-width: 280px;
-  padding: 1rem 1.1rem;
+  min-width: 0;
+  width: clamp(180px, 22vw, 240px);
+  margin-left: auto;
+  padding: 0.85rem 1rem;
   border-radius: 16px;
-  background: linear-gradient(175deg, rgba(14, 36, 26, 0.92), rgba(12, 30, 27, 0.82));
-  border: 1px solid rgba(210, 243, 220, 0.26);
-  box-shadow: 0 16px 38px rgba(8, 22, 16, 0.55);
+  background: linear-gradient(180deg, rgba(6, 18, 13, 0.6), rgba(6, 18, 13, 0.32));
+  border: 1px solid rgba(210, 243, 220, 0.2);
+  box-shadow: 0 12px 28px rgba(7, 20, 14, 0.4);
+  backdrop-filter: blur(8px);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .viewport-stats[hidden] {
@@ -1217,6 +1219,7 @@ dl dt {
   .viewport-stats {
     width: 100%;
     max-width: none;
+    margin-left: 0;
   }
 
   .viewport-stats__list {
@@ -1310,6 +1313,7 @@ dl dt {
     width: 100%;
     max-width: none;
     min-width: 0;
+    margin-left: 0;
   }
 
   .viewport-stats__list {


### PR DESCRIPTION
## Summary
- shrink the equipment detail panel and soften the stats overlay so the viewport has more visible space
- update the scene manager to derive default camera framing from the current model and reset critters to that view on load

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0d88f8488832999d4e5fbd52fed94