### PR TITLE
Adjust critter viewport layout and default view

### DIFF
--- a/src/core/SceneManager.js
+++ b/src/core/SceneManager.js
@@ -276,34 +276,51 @@ export class SceneManager {
     return distance * FOCUS_PADDING;
   }
 
-  focusOnCurrentModel({ immediate = false } = {}) {
+  computeCurrentModelView() {
     if (!this.currentModel) {
-      return false;
+      return null;
     }
 
     this.currentModel.updateWorldMatrix?.(true, true);
     this.boundingBox.setFromObject(this.currentModel);
     if (this.boundingBox.isEmpty()) {
-      return false;
+      return null;
     }
 
     this.boundingBox.getBoundingSphere(this.boundingSphere);
     if (!Number.isFinite(this.boundingSphere.radius) || this.boundingSphere.radius <= 0) {
-      return false;
+      return null;
     }
 
     const center = this.boundingSphere.center.clone();
-    if (!Number.isFinite(center.x) || !Number.isFinite(center.y) || !Number.isFinite(center.z)) {
-      return false;
+    const components = [center.x, center.y, center.z];
+    if (!components.every((value) => Number.isFinite(value))) {
+      return null;
     }
+
     const distance = this.computeFrameDistance(this.boundingSphere.radius);
     const offset = FOCUS_OFFSET_DIRECTION.clone().multiplyScalar(distance);
     const position = center.clone().add(offset);
 
-    this.startCameraTransition(position, center, { immediate });
+    return {
+      position,
+      target: center,
+    };
+  }
+
+  focusOnCurrentModel({ immediate = false } = {}) {
+    const view = this.computeCurrentModelView();
+    if (!view) {
+      return false;
+    }
+
+    this.defaultCameraPosition.copy(view.position);
+    this.defaultCameraTarget.copy(view.target);
+
+    this.startCameraTransition(view.position, view.target, { immediate });
     this.emitStageEvent('stage:focus-achieved', {
-      position: position.toArray(),
-      target: center.toArray(),
+      position: view.position.toArray(),
+      target: view.target.toArray(),
     });
     return true;
   }
@@ -440,11 +457,20 @@ export class SceneManager {
     this.currentCritterId = critter.id;
     this.stageGroup.add(model);
 
+    const critterView = this.computeCurrentModelView();
+    if (critterView) {
+      this.defaultCameraPosition.copy(critterView.position);
+      this.defaultCameraTarget.copy(critterView.target);
+    } else {
+      this.defaultCameraPosition.copy(CAMERA_DEFAULT_POSITION);
+      this.defaultCameraTarget.copy(CAMERA_DEFAULT_TARGET);
+    }
+    this.resetView(true);
+
     this.setupRigController(model);
 
     this.mixer = new THREE.AnimationMixer(model);
     this.activeAction = null;
-    this.focusOnCurrentModel({ immediate: false });
     this.emitStageEvent('stage:model-ready', {
       type: 'critter',
       id: critter.id,

--- a/styles/main.css
+++ b/styles/main.css
@@ -73,7 +73,7 @@ body::after {
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-columns: 200px 300px minmax(360px, 520px) minmax(420px, 1fr);
+  grid-template-columns: 200px 300px minmax(216px, 312px) minmax(520px, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   gap: 1.5rem;
   padding: 2.25rem 2.75rem;
@@ -969,10 +969,12 @@ dl dt {
 
 .viewport-ui__top {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-start;
-  gap: 1.5rem;
+  gap: 0.9rem;
   pointer-events: none;
+  align-self: flex-start;
+  width: min(100%, 280px);
 }
 
 .viewport-ui__bottom {
@@ -1018,13 +1020,15 @@ dl dt {
 
 .viewport-stats {
   pointer-events: none;
-  min-width: 220px;
-  max-width: 280px;
+  width: 100%;
+  max-width: 320px;
+  min-width: 0;
   padding: 1rem 1.1rem;
   border-radius: 16px;
-  background: linear-gradient(175deg, rgba(14, 36, 26, 0.92), rgba(12, 30, 27, 0.82));
+  background: linear-gradient(175deg, rgba(14, 36, 26, 0.78), rgba(12, 30, 27, 0.6));
   border: 1px solid rgba(210, 243, 220, 0.26);
-  box-shadow: 0 16px 38px rgba(8, 22, 16, 0.55);
+  box-shadow: 0 12px 28px rgba(8, 22, 16, 0.45);
+  backdrop-filter: blur(6px);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -1167,7 +1171,7 @@ dl dt {
   }
 
   .app-shell {
-    grid-template-columns: 160px 300px minmax(340px, 1fr);
+    grid-template-columns: 160px 300px minmax(204px, 1fr);
     grid-template-rows: auto minmax(0, 1fr) minmax(280px, auto);
     padding: 2rem;
   }
@@ -1212,6 +1216,7 @@ dl dt {
   .viewport-ui__top {
     flex-direction: column;
     align-items: flex-start;
+    width: 100%;
   }
 
   .viewport-stats {
@@ -1304,6 +1309,7 @@ dl dt {
   .viewport-ui__top {
     flex-direction: column;
     gap: 1rem;
+    width: 100%;
   }
 
   .viewport-stats {
@@ -1344,6 +1350,7 @@ dl dt {
 
   .viewport-ui__top {
     gap: 0.75rem;
+    width: 100%;
   }
 
   .viewport-stats__list {


### PR DESCRIPTION
## Summary
- shrink the equipment detail column and restyle the viewport stats stack so the critter viewport has more visible space
- compute a critter-specific default camera view and apply a reset when loading so critters start in the reset orientation

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d0d88f8488832999d4e5fbd52fed94